### PR TITLE
use local Gemfile to find bundler dependencies

### DIFF
--- a/test/source/bundler_test.rb
+++ b/test/source/bundler_test.rb
@@ -3,27 +3,6 @@ require "test_helper"
 require "tmpdir"
 
 if Licensed::Shell.tool_available?("bundle")
-  module Bundler
-    class << self
-      # helper to clear all bundler environment around a yielded block
-      def with_local_configuration
-        # with the clean, original environment
-        with_original_env do
-          # reset all bundler configuration
-          reset!
-          # and re-configure with settings for current directory
-          configure
-
-          yield
-        end
-      ensure
-        # restore bundler configuration
-        reset!
-        configure
-      end
-    end
-  end
-
   describe Licensed::Source::Bundler do
     let(:fixtures) { File.expand_path("../../fixtures/bundler", __FILE__) }
     let(:config) { Licensed::Configuration.new }
@@ -74,11 +53,9 @@ if Licensed::Shell.tool_available?("bundle")
     describe "dependencies" do
       it "finds dependencies from Gemfile" do
         Dir.chdir(fixtures) do
-          ::Bundler.with_local_configuration do
-            dep = source.dependencies.find { |d| d["name"] == "semantic" }
-            assert dep
-            assert_equal "1.6.0", dep["version"]
-          end
+          dep = source.dependencies.find { |d| d["name"] == "semantic" }
+          assert dep
+          assert_equal "1.6.0", dep["version"]
         end
       end
     end


### PR DESCRIPTION
Fixes https://github.com/github/licensed/issues/15.

Moving a bundler environment fix from being a test helper into the source to make the fix broadly available.  The underlying issue is that `bundler exec` stores state that is picked up during the `bundler` source dependency evaluation.  This causes the Gemfile used for `bundle exec` to be evaluated rather than the Gemfile that might exist at the source path set from configuration.

Noticed this was a broader issue that required moving the environment fix when adding tests for https://github.com/github/licensed/pull/13