### PR TITLE
[Go Source]: Set GOPATH via configuration file

### DIFF
--- a/lib/licensed/source/go.rb
+++ b/lib/licensed/source/go.rb
@@ -125,7 +125,14 @@ module Licensed
       end
 
       def gopath
-        @gopath ||= File.expand_path(@config.dig("go", "GOPATH") || ENV["GOPATH"], @config.pwd)
+        return @gopath if defined?(@gopath)
+
+        path = @config.dig("go", "GOPATH")
+        @gopath = if path.nil? || path.empty?
+                    ENV["GOPATH"]
+                  else
+                    File.expand_path(path, @config.pwd)
+                  end
       end
 
       private

--- a/lib/licensed/source/go.rb
+++ b/lib/licensed/source/go.rb
@@ -116,7 +116,7 @@ module Licensed
 
       # Returns whether go source is found
       def go_source?
-        @go_source ||= Licensed::Shell.success?("go", "doc")
+        @go_source ||= with_configured_gopath { Licensed::Shell.success?("go", "doc") }
       end
 
       # Returns a list of go standard packages

--- a/lib/licensed/source/go.rb
+++ b/lib/licensed/source/go.rb
@@ -124,6 +124,8 @@ module Licensed
         @std_packages ||= Licensed::Shell.execute("go", "list", "std").lines.map(&:strip)
       end
 
+      # Returns a GOPATH value from either a configuration value or ENV["GOPATH"],
+      # with the configuration value preferred over the ENV var
       def gopath
         return @gopath if defined?(@gopath)
 
@@ -137,6 +139,8 @@ module Licensed
 
       private
 
+      # Execute a block with ENV["GOPATH"] set to the value of #gopath.
+      # Any pre-existing ENV["GOPATH"] value is restored after the block ends.
       def with_configured_gopath(&block)
         begin
           original_gopath = ENV["GOPATH"]

--- a/lib/licensed/source/go.rb
+++ b/lib/licensed/source/go.rb
@@ -124,6 +124,10 @@ module Licensed
         @std_packages ||= Licensed::Shell.execute("go", "list", "std").lines.map(&:strip)
       end
 
+      def gopath
+        @gopath ||= File.expand_path(@config.dig("go", "GOPATH") || ENV["GOPATH"], @config.pwd)
+      end
+
       private
 
       def with_configured_gopath(&block)
@@ -135,10 +139,6 @@ module Licensed
         ensure
           ENV["GOPATH"] = original_gopath
         end
-      end
-
-      def gopath
-        @gopath ||= @config.dig("go", "GOPATH") || ENV["GOPATH"]
       end
     end
   end

--- a/test/source/go_test.rb
+++ b/test/source/go_test.rb
@@ -4,9 +4,9 @@ require "tmpdir"
 
 if Licensed::Shell.tool_available?("go")
   describe Licensed::Source::Go do
-    let(:go_path) { File.expand_path("../../fixtures/go", __FILE__) }
-    let(:fixtures) { File.join(go_path, "src/test") }
-    let(:config) { Licensed::Configuration.new("go" => { "GOPATH" => go_path }) }
+    let(:gopath) { File.expand_path("../../fixtures/go", __FILE__) }
+    let(:fixtures) { File.join(gopath, "src/test") }
+    let(:config) { Licensed::Configuration.new("go" => { "GOPATH" => gopath }) }
     let(:source) { Licensed::Source::Go.new(config) }
 
     describe "enabled?" do
@@ -35,12 +35,12 @@ if Licensed::Shell.tool_available?("go")
 
     describe "gopath" do
       it "works with an absolute configuration path" do
-        assert_equal go_path, source.gopath
+        assert_equal gopath, source.gopath
       end
 
       it "works with a configuration path relative to the source path" do
         config["go"]["GOPATH"] = "test/fixtures/go"
-        assert_equal go_path, source.gopath
+        assert_equal gopath, source.gopath
       end
 
       it "works with an expandable configuration path" do
@@ -50,18 +50,18 @@ if Licensed::Shell.tool_available?("go")
 
       it "uses ENV['GOPATH'] if not set in configuration" do
         begin
-          original_go_path = ENV["GOPATH"]
-          ENV["GOPATH"] = go_path
+          original_gopath = ENV["GOPATH"]
+          ENV["GOPATH"] = gopath
           config.delete("go")
 
-          assert_equal go_path, source.gopath
+          assert_equal gopath, source.gopath
 
           # sanity test that finding dependencies using ENV works
           Dir.chdir fixtures do
             assert source.dependencies.detect { |d| d["name"] == "github.com/hashicorp/golang-lru" }
           end
         ensure
-          ENV["GOPATH"] = original_go_path
+          ENV["GOPATH"] = original_gopath
         end
       end
     end
@@ -95,12 +95,12 @@ if Licensed::Shell.tool_available?("go")
       describe "with unavailable packages" do
         # use a custom go path that doesn't contain go libraries installed from
         # setup scripts
-        let(:go_path) { Dir.mktmpdir }
+        let(:gopath) { Dir.mktmpdir }
 
         before do
           # fixtures now points at the tmp location, copy go source to tmp
           # fixtures location
-          FileUtils.mkdir_p File.join(go_path, "src")
+          FileUtils.mkdir_p File.join(gopath, "src")
           FileUtils.cp_r File.expand_path("../../fixtures/go/src/test", __FILE__), fixtures
 
           # the tests are expected to print errors from `go list` which
@@ -112,7 +112,7 @@ if Licensed::Shell.tool_available?("go")
 
         after do
           $stderr.reopen(@previous_stderr)
-          FileUtils.rm_rf go_path
+          FileUtils.rm_rf gopath
         end
 
         it "do not raise an error if ignored" do
@@ -145,7 +145,7 @@ if Licensed::Shell.tool_available?("go")
           Dir.chdir fixtures do
             dep = source.dependencies.detect { |d| d["name"] == "github.com/hashicorp/golang-lru" }
             assert dep
-            assert_equal go_path, dep.search_root
+            assert_equal gopath, dep.search_root
           end
         end
       end


### PR DESCRIPTION
Resolves https://github.com/github/licensed/issues/14, found when testing https://github.com/github/licensed/pull/13.

This PR adds a configuration setting for `GOPATH` that overrides ENV["GOPATH"] if available and nonempty.
```yaml
go:
  GOPATH: .gopath
```

The override occurs when:
- checking if there is go source at the source path
- enumerating dependencies

Adding the configuration value makes the `go` dependency source less reliant on the calling environment.  This enables better testability and usage of the source when updating the calling environment is difficult.