### PR TITLE
Expand paths from repository root

### DIFF
--- a/docs/sources/go.md
+++ b/docs/sources/go.md
@@ -1,7 +1,8 @@
 # Go
 
-The go source uses `go` CLI commands to enumerate dependencies and properties.  It is expected that `go` projects have been built, and that `GO_PATH` and `GO_ROOT` are properly set before running `licensed`.
+The go source uses `go` CLI commands to enumerate dependencies and properties.  It is expected that `go` projects have been built, and that `go` environment variables are properly set before running `licensed`.
 
+#### Source paths
 Source paths for go projects should point to a location that contains an entrypoint to the executable or library.
 
 An example usage might see a configuration like:
@@ -10,3 +11,15 @@ source_path: go/path/src/github.com/BurntSushi/toml/cmd/tomlv
 ```
 
 Note that this configuration points directly to the tomlv command source, which contains `func main`.
+
+#### GOPATH
+A valid `GOPATH` is required to successfully find `go` dependencies.  If `GOPATH` is not available in the calling environment, or if a different `GOPATH` is needed than what is set in the calling environment, a value can be set in the `licensed` configuration file.
+
+```yaml
+go:
+  GOPATH: ~/go
+```
+
+The setting supports absolute, relative and expandable (e.g. "~") paths.  Relative paths are considered relative to the repository root.
+
+Non-empty `GOPATH` configuration settings will override the `GOPATH` environment variable while enumerating `go` dependencies.  The `GOPATH` environment variable is restored once dependencies have been enumerated.

--- a/lib/licensed/source/cabal.rb
+++ b/lib/licensed/source/cabal.rb
@@ -135,7 +135,7 @@ module Licensed
         Array(@config["cabal"]["ghc_package_db"]).map do |path|
           next "--#{path}" if %w(global user).include?(path)
           path = realized_ghc_package_path(path)
-          path = File.expand_path(path, @config.pwd)
+          path = File.expand_path(path, Licensed::Git.repository_root)
 
           next unless File.exist?(path)
           "--package-db=#{path}"

--- a/lib/licensed/source/go.rb
+++ b/lib/licensed/source/go.rb
@@ -133,7 +133,7 @@ module Licensed
         @gopath = if path.nil? || path.empty?
                     ENV["GOPATH"]
                   else
-                    File.expand_path(path, @config.pwd)
+                    File.expand_path(path, Licensed::Git.repository_root)
                   end
       end
 

--- a/test/source/cabal_test.rb
+++ b/test/source/cabal_test.rb
@@ -69,5 +69,37 @@ if Licensed::Shell.tool_available?("ghc")
         end
       end
     end
+
+    describe "package_db_args" do
+      it "recognizes global as a special arg" do
+        config["cabal"] = { "ghc_package_db" => ["global"] }
+        assert_equal ["--global"], source.package_db_args
+      end
+
+      it "recognizes user as a special arg" do
+        config["cabal"] = { "ghc_package_db" => ["user"] }
+        assert_equal ["--user"], source.package_db_args
+      end
+
+      it "allows paths relative to the repository root" do
+        config["cabal"] = { "ghc_package_db" => ["test/fixtures/haskell"] }
+        assert_equal ["--package-db=#{fixtures}"], source.package_db_args
+      end
+
+      it "allows expandable paths" do
+        config["cabal"] = { "ghc_package_db" => ["~"] }
+        assert_equal ["--package-db=#{File.expand_path("~")}"], source.package_db_args
+      end
+
+      it "allows absolute paths" do
+        config["cabal"] = { "ghc_package_db" => [fixtures] }
+        assert_equal ["--package-db=#{fixtures}"], source.package_db_args
+      end
+
+      it "does not allow paths that don't exist" do
+        config["cabal"] = { "ghc_package_db" => ["bad/path"] }
+        assert_equal [], source.package_db_args
+      end
+    end
   end
 end

--- a/test/source/cabal_test.rb
+++ b/test/source/cabal_test.rb
@@ -30,7 +30,7 @@ if Licensed::Shell.tool_available?("ghc")
     end
 
     describe "dependencies" do
-      let(:local_db) { "dist-newstyle/packagedb/ghc-<ghc_version>" }
+      let(:local_db) { File.join(fixtures, "dist-newstyle/packagedb/ghc-<ghc_version>") }
       let(:user_db) { "~/.cabal/store/ghc-<ghc_version>/package.db" }
 
       describe "without configured package dbs" do

--- a/test/source/go_test.rb
+++ b/test/source/go_test.rb
@@ -38,7 +38,7 @@ if Licensed::Shell.tool_available?("go")
         assert_equal gopath, source.gopath
       end
 
-      it "works with a configuration path relative to the source path" do
+      it "works with a configuration path relative to repository root" do
         config["go"]["GOPATH"] = "test/fixtures/go"
         assert_equal gopath, source.gopath
       end


### PR DESCRIPTION
Merged https://github.com/github/licensed/pull/17 a few minutes prematurely 😢 

After using the ☝️ changes in https://github.com/github/licensed/pull/13, I realized that expanding GOPATH relative to the source path didn't make sense because Go source is expected to be in the GOPATH workspace.  Thus every relative GOPATH in the configuration file would look something like "../../..." 🤦‍♂️ .

I looked for other cases of path expansion and found that the same issue occurred in the cabal source.  The cabal documentation also specified that path expansion should occur from the repository root so that has been an issue for a little while.

This PR fixes the path expansion issues and updates and adds tests to verify that path expansion works as expected for the go and cabal sources.  I also added documentation for the GOPATH configuration setting.