### PR TITLE
Enable Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,9 @@ matrix:
     - language: ruby
       rvm: 2.4.0
       script: bundle exec rake rubocop build
+
+    # go tests
+    - language: go
+      go: 1.7.x
+      before_script: ./script/source-setup/go
+      script: ./script/test go

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,24 +6,28 @@ matrix:
     - language: ruby
       rvm: 2.4.0
       script: bundle exec rake rubocop build
+      env: NAME="Lint and Build"
 
     # go tests
     - language: go
       go: 1.7.x
       before_script: ./script/source-setup/go
       script: ./script/test go
+      env: NAME="go"
 
     # cabal tests
     - language: haskell
       ghc: "8.2"
       before_script: ./script/source-setup/cabal
       script: ./script/test cabal
+      env: NAME="cabal"
 
     # npm tests
     - language: node_js
       node_js: "8"
       before_script: ./script/source-setup/npm
       script: ./script/test npm
+      env: NAME="npm"
 
     # bower tests
     - language: node_js
@@ -32,17 +36,20 @@ matrix:
         - npm install -g bower
         - ./script/source-setup/bower
       script: ./script/test bower
+      env: NAME="bower"
 
     # bundler tests
     - language: ruby
       rvm: 2.4.0
       before_script: ./script/source-setup/bundler
       script: ./script/test bundler
+      env: NAME="bundler"
 
     # manifest tests
     - language: ruby
       rvm: 2.4.0
       script: ./script/test manifest
+      env: NAME="manifest"
 
 notifications:
   disable: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,9 @@ matrix:
       ghc: "8.2"
       before_script: ./script/source-setup/cabal
       script: ./script/test cabal
+
+    # npm tests
+    - language: node_js
+      node_js: "8"
+      before_script: ./script/source-setup/npm
+      script: ./script/test npm

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
-language: ruby
-rvm:
-  - 2.2.3
-before_install: gem install bundler -v 1.10.6
+install: ./script/bootstrap
+
+matrix:
+  include:
+    # lint and build
+    - language: ruby
+      rvm: 2.4.0
+      script: bundle exec rake rubocop build

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,9 @@ matrix:
       go: 1.7.x
       before_script: ./script/source-setup/go
       script: ./script/test go
+
+    # cabal tests
+    - language: haskell
+      ghc: "8.2"
+      before_script: ./script/source-setup/cabal
+      script: ./script/test cabal

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,3 +38,6 @@ matrix:
       rvm: 2.4.0
       before_script: ./script/source-setup/bundler
       script: ./script/test bundler
+
+notifications:
+  disable: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,3 +32,9 @@ matrix:
         - npm install -g bower
         - ./script/source-setup/bower
       script: ./script/test bower
+
+    # bundler tests
+    - language: ruby
+      rvm: 2.4.0
+      before_script: ./script/source-setup/bundler
+      script: ./script/test bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,5 +39,10 @@ matrix:
       before_script: ./script/source-setup/bundler
       script: ./script/test bundler
 
+    # manifest tests
+    - language: ruby
+      rvm: 2.4.0
+      script: ./script/test manifest
+
 notifications:
   disable: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,11 @@ matrix:
       node_js: "8"
       before_script: ./script/source-setup/npm
       script: ./script/test npm
+
+    # bower tests
+    - language: node_js
+      node_js: "8"
+      before_script:
+        - npm install -g bower
+        - ./script/source-setup/bower
+      script: ./script/test bower

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,10 +31,10 @@ Here are a few things you can do that will increase the likelihood of your pull 
 
 Pull requests that include a new dependency source must also
 
-- Include [documentation](docs/sources) for the new source and update the [documented source list](README.md#Sources).
+- Include [documentation](docs/sources) for the new source and update the [documented source list](README.md#sources).
 - Add a [setup script](script/source-setup) if needed.
 - Include [tests](test/source) and [test fixtures](test/fixtures) needed to verify the source in CI.
-- Add a CI job to [.travis.yml][.travis.yml].
+- Add a CI job to [.travis.yml](.travis.yml).
 
 ## Releasing
 If you are the current maintainer of this gem:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,15 @@ Here are a few things you can do that will increase the likelihood of your pull 
 - Keep your change as focused as possible. If there are multiple changes you would like to make that are not dependent upon each other, consider submitting them as separate pull requests.
 - Write a [good commit message](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
 
+#### Adding a new Dependency Source
+
+Pull requests that include a new dependency source must also
+
+- Include [documentation](docs/sources) for the new source and update the [documented source list](README.md#Sources).
+- Add a [setup script](script/source-setup) if needed.
+- Include [tests](test/source) and [test fixtures](test/fixtures) needed to verify the source in CI.
+- Add a CI job to [.travis.yml][.travis.yml].
+
 ## Releasing
 If you are the current maintainer of this gem:
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Licensed is **not** a complete open source license compliance solution. Please u
 
 ## Current Status
 
+[![Build Status](https://travis-ci.org/github/licensed.svg?branch=master)](https://travis-ci.org/github/licensed)
+
 Licensed is in active development and currently used at GitHub.  See the [open issues](https://github.com/github/licensed/issues) for a list of potential work.
 
 ## Installation

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require "bundler/gem_tasks"
 require "rake/testtask"
+require "rubocop/rake_task"
 
 desc "Run source setup scripts"
 task :setup do
@@ -51,6 +52,12 @@ Rake::TestTask.new(:test) do |t|
   t.libs << "test"
   t.libs << "lib"
   t.test_files = FileList["test/**/*_test.rb"]
+end
+
+# add rubocop task
+# -S adds styleguide urls to offense messages
+RuboCop::RakeTask.new do |t|
+  t.options.push "-S"
 end
 
 task default: :test

--- a/Rakefile
+++ b/Rakefile
@@ -24,7 +24,8 @@ task :setup do
   end
 end
 
-sources = Dir["lib/licensed/source/*.rb"].map { |f| File.basename(f, ".*") }
+sources_search = File.expand_path("lib/licensed/source/*.rb", __dir__)
+sources = Dir[sources_search].map { |f| File.basename(f, ".*") }
 
 namespace :test do
   sources.each do |source|

--- a/Rakefile
+++ b/Rakefile
@@ -43,7 +43,7 @@ namespace :test do
 
       # use negative lookahead to exclude all source tests except
       # the tests for `source`
-      t.test_files = FileList["test/**/*_test.rb"].exclude(/test\/source\/(!?#{source}).*?_test.rb/)
+      t.test_files = FileList["test/**/*_test.rb"].exclude(/test\/source\/(?!#{source}).*?_test.rb/)
     end
   end
 end

--- a/lib/licensed/dependency.rb
+++ b/lib/licensed/dependency.rb
@@ -74,7 +74,8 @@ module Licensed
     # Returns a Licensee::LicenseFile with the content of the license in the
     # dependency's repository to account for LICENSE files not being distributed
     def remote_license_file
-      @remote_license_file ||= Licensed.from_github(self["homepage"])
+      return @remote_license_file if defined?(@remote_license_file)
+      @remote_license_file = Licensed.from_github(self["homepage"])
     end
 
     # Regardless of the license detected, try to pull the license content

--- a/lib/licensed/source/bundler.rb
+++ b/lib/licensed/source/bundler.rb
@@ -4,6 +4,7 @@ require "bundler"
 module Licensed
   module Source
     class Bundler
+      BUNDLER_ENV_KEYS = %w(BUNDLE_GEMFILE).freeze
       def initialize(config)
         @config = config
       end
@@ -56,6 +57,10 @@ module Licensed
       def with_local_configuration
         # with a clean, original environment
         ::Bundler.with_original_env do
+          # bundler restores all ENV at the end of the `with_original_env`
+          # block.  we shouldn't need to restore these values manually
+          BUNDLER_ENV_KEYS.each { |k| ENV.delete(k) }
+
           # reset all bundler configuration
           ::Bundler.reset!
           # and re-configure with settings for current directory

--- a/script/source-setup/bundler
+++ b/script/source-setup/bundler
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-if [ -z "$(which bundler)" ]; then
+if [ -z "$(which bundle)" ]; then
   echo "A local bundler instalation is required for bundler development." >&2
   exit 127
 fi

--- a/script/test
+++ b/script/test
@@ -2,4 +2,8 @@
 
 set -e
 
-bundle exec rake test
+if [ $# -gt 0 ]; then
+  bundle exec rake "${@/#/test:}"
+else
+  bundle exec rake test
+fi

--- a/script/test
+++ b/script/test
@@ -2,8 +2,15 @@
 
 set -e
 
-if [ $# -gt 0 ]; then
-  bundle exec rake "${@/#/test:}"
+if [ "$#" -gt "0" ] ; then
+  if [ -f "$1" ]; then
+    # argument was a file, run it's tests only
+    bundle exec rake test TEST="$1"
+  else
+    # argument was not a file, execute it as a test suite identifier
+    bundle exec rake test:"$1"
+  fi
 else
+  # no arguments, run all tests
   bundle exec rake test
 fi

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -11,20 +11,20 @@ describe "licensed" do
 
   describe "cache" do
     it "exits 0" do
-      _, status = Open3.capture2 "bundle exec exe/licensed cache -c #{config_path}"
+      _, status = Open3.capture2 "bundle exec exe/licensed cache -c #{config_path} --offline"
       assert status.success?
     end
 
     it "exits 1 when a config file isn't found" do
-      _, _, status = Open3.capture3 "bundle exec exe/licensed cache"
+      _, _, status = Open3.capture3 "bundle exec exe/licensed cache --offline"
       refute status.success?
     end
 
     it "accepts a path to a config file" do
-      out, status = Open3.capture2 "bundle exec exe/licensed cache -c #{config_path}"
+      out, status = Open3.capture2 "bundle exec exe/licensed cache -c #{config_path} --offline"
       refute out =~ /Usage/i
 
-      out, status = Open3.capture2 "bundle exec exe/licensed cache --config #{config_path}"
+      out, status = Open3.capture2 "bundle exec exe/licensed cache --config #{config_path} --offline"
       refute out =~ /Usage/i
     end
   end


### PR DESCRIPTION
Resolves https://github.com/github/licensed/issues/5

This turns on Travis CI and runs a job for each dependency source.  Each job runs

1.  Tests specific to that source
2. Tests for the non-source licensed components

This strategy errs on the side of caution to make sure that dependency sources don't modify and break source-agnostic code.  Structuring the tests this way also makes development easier on a single source - running `bundle exec rake test:[source]` will run a full test pass on `licensed` for the source.

This PR also makes the following changes that were needed to get CI working

1. test suites can be run from either rake tasks or `script/test`

```
# the following are equivalent
bundle exec rake test:go
./script/test go
```

2. fixed a few issues that were causing problems in CI
   1. https://github.com/github/licensed/commit/c366e24f51be2448c0ecee3db211ba5017b40abf forces CLI tests to run offline and avoid timeouts from querying GitHub in CI.
   2. https://github.com/github/licensed/commit/d858334833745786bd64623fe858fa0463573245 fixes a problem where a nil result from querying GitHub was not cached properly.  This was an initial fix attempt for ☝️ 
   3. https://github.com/github/licensed/commit/83f572f0f56c701c5f3a22f32f70432c8b6ba72f clears `BUNDLE_GEMFILE` from ENV in the `bundler` source.  The variable is set during CI and was causing the wrong Gemfile to be used when enumerating dependencies
