### PR TITLE
Avoid license key change when dependency license text hasn't changed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /pkg/
 /spec/reports/
 /tmp/
+.byebug_history
 
 # test fixtures
 test/fixtures/bundler/.bundle/

--- a/lib/licensed/command/cache.rb
+++ b/lib/licensed/command/cache.rb
@@ -34,19 +34,22 @@ module Licensed
                 names << name
                 filename = cache_path.join("#{name}.txt")
 
-                if File.exist?(filename)
-                  license = Licensed::License.read(filename)
+                # try to load existing license from disk
+                # or default to a blank license
+                license = Licensed::License.read(filename) || Licensed::License.new
 
-                  # Version did not change, no need to re-cache
-                  if !force && version == license["version"]
-                    @config.ui.info "    Using #{name} (#{version})"
-                    next
-                  end
+                # Version did not change, no need to re-cache
+                if !force && version == license["version"]
+                  @config.ui.info "    Using #{name} (#{version})"
+                  next
                 end
 
                 @config.ui.info "    Caching #{name} (#{version})"
 
                 dependency.detect_license!
+                # use the cached license value if the license text wasn't updated
+                dependency["license"] = license["license"] if dependency.license_text_match?(license)
+
                 dependency.save(filename)
               end
 

--- a/lib/licensed/dependency.rb
+++ b/lib/licensed/dependency.rb
@@ -32,7 +32,7 @@ module Licensed
     # `dependency["license"]` and legal text is set to `dependency.text`
     def detect_license!
       self["license"] = license_key
-      self.text = ([license_text] + self.notices).compact.join("\n" + "-" * 80 + "\n")
+      self.text = [license_text, *notices].join("\n" + TEXT_SEPARATOR + "\n").strip
     end
 
     # Extract legal notices from the dependency source

--- a/lib/licensed/dependency.rb
+++ b/lib/licensed/dependency.rb
@@ -41,7 +41,7 @@ module Licensed
            .sort # sorted by the path
            .map { |f| File.read(f) } # read the file contents
            .map(&:strip) # strip whitespace
-           .select { |t| t.length > 0 } # files with content only 
+           .select { |t| t.length > 0 } # files with content only
     end
 
     # Returns an array of file paths used to locate legal notices

--- a/lib/licensed/dependency.rb
+++ b/lib/licensed/dependency.rb
@@ -37,7 +37,11 @@ module Licensed
 
     # Extract legal notices from the dependency source
     def notices
-      local_files.uniq.map { |f| File.read(f) }
+      local_files.uniq # unique local file paths
+           .sort # sorted by the path
+           .map { |f| File.read(f) } # read the file contents
+           .map(&:strip) # strip whitespace
+           .select { |t| t.length > 0 } # files with content only 
     end
 
     # Returns an array of file paths used to locate legal notices

--- a/lib/licensed/license.rb
+++ b/lib/licensed/license.rb
@@ -18,6 +18,7 @@ module Licensed
     #
     # Returns a Licensed::License
     def self.read(filename)
+      return unless File.exist?(filename)
       match = File.read(filename).scrub.match(YAML_FRONTMATTER_PATTERN)
       new(YAML.load(match[1]), match[2])
     end

--- a/lib/licensed/license.rb
+++ b/lib/licensed/license.rb
@@ -6,7 +6,6 @@ require "forwardable"
 module Licensed
   class License
     YAML_FRONTMATTER_PATTERN = /\A---\s*\n(.*?\n?)^---\s*$\n?(.*)\z/m
-    LEGAL_FILES = /\A(COPYING|NOTICE|LEGAL)(?:\..*)?\z/i
 
     # Read an existing license file
     #

--- a/licensed.gemspec
+++ b/licensed.gemspec
@@ -33,4 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "webmock", "~> 1.21"
   spec.add_development_dependency "rubocop", "~> 0.49"
   spec.add_development_dependency "rubocop-github", "~> 0.6"
+  spec.add_development_dependency "byebug"
 end

--- a/test/command/cache_test.rb
+++ b/test/command/cache_test.rb
@@ -56,6 +56,22 @@ describe Licensed::Command::Cache do
     refute config.cache_path.join("test/dependency.txt").exist?
   end
 
+  it "uses cached license if license text does not change" do
+    generator.run
+
+    path = config.cache_path.join("test/dependency.txt")
+    license = Licensed::License.read(path)
+    license["license"] = "test"
+    license["version"] = "0.0"
+    license.save(path)
+
+    generator.run
+
+    license = Licensed::License.read(path)
+    assert_equal "test", license["license"]
+    refute_equal "0.0", license["version"]
+  end
+
   it "does not include ignored dependencies in dependency counts" do
     config.ui.level = "info"
     out, _ = capture_io { generator.run }

--- a/test/dependency_test.rb
+++ b/test/dependency_test.rb
@@ -109,6 +109,18 @@ describe Licensed::Dependency do
       end
     end
 
+    it "always contains a license text section if there are legal notices" do
+      mkproject do |dependency|
+        File.write "AUTHORS", "authors"
+
+        dependency.detect_license!
+
+        # the text should always start with license text (even if empty),
+        # followed by a separator if there are any legal notices
+        assert_match(/\A#{Licensed::License::TEXT_SEPARATOR}\n/, dependency.text)
+      end
+    end
+
     it "sets license to other if undetected" do
       mkproject do |dependency|
         File.write "LICENSE", "some unknown license"

--- a/test/dependency_test.rb
+++ b/test/dependency_test.rb
@@ -109,6 +109,22 @@ describe Licensed::Dependency do
       end
     end
 
+    it "does not extract empty legal notices" do
+      mkproject do |dependency|
+        File.write "AUTHORS", ""
+        File.write "COPYING", "copying"
+        File.write "NOTICE", ""
+        File.write "LEGAL", "legal"
+
+        dependency.detect_license!
+
+        refute_match(/authors/, dependency.text)
+        assert_match(/copying/, dependency.text)
+        refute_match(/notice/, dependency.text)
+        assert_match(/legal/, dependency.text)
+      end
+    end
+
     it "always contains a license text section if there are legal notices" do
       mkproject do |dependency|
         File.write "AUTHORS", "authors"

--- a/test/license_test.rb
+++ b/test/license_test.rb
@@ -23,4 +23,31 @@ describe Licensed::License do
       Licensed::License.read(@filename)
     end
   end
+
+  describe "content" do
+    it "returns full text if the text separator is not found" do
+      license = Licensed::License.new({}, "license")
+      assert_equal "license", license.content
+    end
+
+    it "returns the license text if the text separator is found" do
+      license = Licensed::License.new({}, "license#{Licensed::License::TEXT_SEPARATOR}notice")
+      assert_equal "license", license.content
+    end
+  end
+
+  describe "license_text_match?" do
+    it "returns false for a non-License argument" do
+      license = Licensed::License.new
+      refute license.license_text_match? nil
+      refute license.license_text_match? ""
+    end
+
+    it "returns true if the normalized content is the same" do
+      license = Licensed::License.new({}, "test content")
+      other = Licensed::License.new({}, "* test content")
+
+      assert license.license_text_match?(other)
+    end
+  end
 end


### PR DESCRIPTION
Resolves https://github.com/github/licensed/issues/2.

This PR affects the `cache` command, attempting to reuse the `license` metadata value when possible to cut down on noise.

`licensed cache` now compares the license available in a dependency's cached file to the content found from `dependency.detect_license!`.  When no changes are found, `licensed cache` will reuse the cached license value.  `License#license_text_match?` uses `Licensee::ContentHelper` to compare normalized license content instead of the raw data.

A side effect of this PR is a slight behavior change that should be entirely backwards compatible - a licensed text section will always be written to the cached file.  We used to strip out `nil` license text and legal notices which means that [`licensed` couldn't know if the first (or only) text in a cached file is the license text or a legal notice](https://github.com/github/licensed/issues/20).

Ensuring that `Dependency#detect_license!` always includes section for license text in `self.text` means that we can reliably use that section to compare cached license text against the license text found from `Dependency#detect_license!`.

This makes the assumption that it is 👍 to only compare license text to determine that the license key can be reused.  If `Dependency#notices` should also be compared, then https://github.com/github/licensed/tree/less-license-chattiness should be considered instead of this PR.

/cc @lildude FYI as `github/linguist` was asking for this.  Please let me know if you'd like me to ping someone else for `linguist`s attention 🙇 