### PR TITLE
Update .rubocop.yml to exclude external content

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,8 @@
 inherit_gem:
   rubocop-github:
     - config/default.yml
+
+AllCops:
+  Exclude:
+    - test/fixtures/**/*
+    - vendor/gems/**/*


### PR DESCRIPTION
Small update, this change ignores test fixtures and local vendor gems from rubocop checks.  No need to check external code.