### PR TITLE
Warn exclusively on missing license text, ignore notices

### DIFF
--- a/lib/licensed/command/status.rb
+++ b/lib/licensed/command/status.rb
@@ -36,7 +36,7 @@ module Licensed
                 if license["version"] != dependency["version"]
                   warnings << "cached license data out of date"
                 end
-                warnings << "missing license text" if license.text.strip.empty?
+                warnings << "missing license text" if license.license_text.empty?
                 unless allowed_or_reviewed?(app, license)
                   warnings << "license needs reviewed: #{license["license"]}."
                 end

--- a/lib/licensed/license.rb
+++ b/lib/licensed/license.rb
@@ -44,9 +44,8 @@ module Licensed
       File.write(filename, YAML.dump(@metadata) + "---\n#{text}")
     end
 
-    # Returns the raw content for Licensee::ContentHelper#content_normalized.
-    # The content is the license text only without any notices
-    def content
+    # Returns the license text without any notices
+    def license_text
       return unless text
 
       # if the text contains the separator, the first string in the array
@@ -54,9 +53,9 @@ module Licensed
       # if the text didn't contain the separator, the text itself is the entirety
       # of the license text
       split = text.split(TEXT_SEPARATOR)
-      split.length > 1 ? split.first.strip : text
+      split.length > 1 ? split.first.strip : text.strip
     end
-
+    alias_method :content, :license_text # use license_text for content matching
 
     # Returns whether the current license should be updated to `other`
     # based on whether the normalized license content matches

--- a/test/command/status_test.rb
+++ b/test/command/status_test.rb
@@ -62,6 +62,26 @@ describe Licensed::Command::Status do
     assert_match(/missing license text/, out)
   end
 
+  it "warns if license is empty with notices" do
+    filename = config.cache_path.join("test/dependency.txt")
+    license = Licensed::License.read(filename)
+    license.text = "#{Licensed::License::TEXT_SEPARATOR}notice"
+    license.save(filename)
+
+    out, _ = capture_io { verifier.run }
+    assert_match(/missing license text/, out)
+  end
+
+  it "does not warn if license is not empty" do
+    filename = config.cache_path.join("test/dependency.txt")
+    license = Licensed::License.read(filename)
+    license.text = "license"
+    license.save(filename)
+
+    out, _ = capture_io { verifier.run }
+    refute_match(/missing license text/, out)
+  end
+
   it "warns if versions do not match" do
     verifier.app_dependencies(config.apps.first).first["version"] = "nope"
     out, _ = capture_io { verifier.run }

--- a/test/license_test.rb
+++ b/test/license_test.rb
@@ -25,6 +25,11 @@ describe Licensed::License do
   end
 
   describe "content" do
+    it "returns nil if text hasn't been set" do
+      license = Licensed::License.new
+      assert_nil license.license_text
+    end
+
     it "returns full text if the text separator is not found" do
       license = Licensed::License.new({}, "license")
       assert_equal "license", license.content
@@ -33,6 +38,23 @@ describe Licensed::License do
     it "returns the license text if the text separator is found" do
       license = Licensed::License.new({}, "license#{Licensed::License::TEXT_SEPARATOR}notice")
       assert_equal "license", license.content
+    end
+  end
+
+  describe "license_text" do
+    it "returns nil if text hasn't been set" do
+      license = Licensed::License.new
+      assert_nil license.license_text
+    end
+
+    it "returns full text if the text separator is not found" do
+      license = Licensed::License.new({}, "license")
+      assert_equal "license", license.license_text
+    end
+
+    it "returns the license text if the text separator is found" do
+      license = Licensed::License.new({}, "license#{Licensed::License::TEXT_SEPARATOR}notice")
+      assert_equal "license", license.license_text
     end
   end
 


### PR DESCRIPTION
Fixes https://github.com/github/licensed/issues/20

Following https://github.com/github/licensed/pull/21 where license text was separated from notices, we can now evaluate the license text separately from any notices and warn when missing.

This defines `License#license_text` which reads from `License#text` nearly identically to `License#content` from https://github.com/github/licensed/pull/21 with an extra `String#strip`.  `License#content` has been aliased to point at `License#license_text`.

`license_text` is already defined on `Dependency` where it now overrides the base `Licensed` implementation.