### PR TITLE
[Bundler] Don't use Bundler.default_*file to find gem file and lock file

### DIFF
--- a/lib/licensed/source/bundler.rb
+++ b/lib/licensed/source/bundler.rb
@@ -61,9 +61,8 @@ module Licensed
       def with_local_configuration
         # with a clean, original environment
         ::Bundler.with_original_env do
-          # bundler restores all ENV at the end of the `with_original_env`
-          # block.  we shouldn't need to restore these values manually
-          BUNDLER_ENV_KEYS.each { |k| ENV.delete(k) }
+          # force bundler to use the local gem file
+          ENV["BUNDLE_GEMFILE"] = gemfile_path.to_s
 
           # reset all bundler configuration
           ::Bundler.reset!

--- a/lib/licensed/source/bundler.rb
+++ b/lib/licensed/source/bundler.rb
@@ -5,12 +5,14 @@ module Licensed
   module Source
     class Bundler
       BUNDLER_ENV_KEYS = %w(BUNDLE_GEMFILE).freeze
+      GEMFILES = %w{Gemfile gems.rb}.freeze
+
       def initialize(config)
         @config = config
       end
 
       def enabled?
-        @config.enabled?(type) && File.exist?(lockfile_path)
+        @config.enabled?(type) && lockfile_path && lockfile_path.exist?
       end
 
       def type
@@ -41,14 +43,16 @@ module Licensed
         definition.groups - [:test, :development]
       end
 
-      # Returns the expected path to the Bundler Gemfile
+      # Returns the path to the Bundler Gemfile
       def gemfile_path
-        @config.pwd.join ::Bundler.default_gemfile.basename.to_s
+        @gemfile_path ||= GEMFILES.map { |g| @config.pwd.join g }
+                                  .find { |f| f.exist? }
       end
 
-      # Returns the expected path to the Bundler Gemfile.lock
+      # Returns the path to the Bundler Gemfile.lock
       def lockfile_path
-        @config.pwd.join ::Bundler.default_lockfile.basename.to_s
+        return unless gemfile_path
+        @lockfile_path ||= gemfile_path.dirname.join("#{gemfile_path.basename}.lock")
       end
 
       private

--- a/lib/licensed/source/bundler.rb
+++ b/lib/licensed/source/bundler.rb
@@ -4,7 +4,6 @@ require "bundler"
 module Licensed
   module Source
     class Bundler
-      BUNDLER_ENV_KEYS = %w(BUNDLE_GEMFILE).freeze
       GEMFILES = %w{Gemfile gems.rb}.freeze
 
       def initialize(config)

--- a/lib/licensed/source/bundler.rb
+++ b/lib/licensed/source/bundler.rb
@@ -58,6 +58,8 @@ module Licensed
 
       # helper to clear all bundler environment around a yielded block
       def with_local_configuration
+        original_bundle_gemfile = ENV["BUNDLE_GEMFILE"]
+
         # with a clean, original environment
         ::Bundler.with_original_env do
           # force bundler to use the local gem file
@@ -71,6 +73,7 @@ module Licensed
           yield
         end
       ensure
+        ENV["BUNDLE_GEMFILE"] = original_bundle_gemfile
         # restore bundler configuration
         ::Bundler.reset!
         ::Bundler.configure

--- a/test/source/bundler_test.rb
+++ b/test/source/bundler_test.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 require "test_helper"
 require "tmpdir"
-require "byebug"
 
 if Licensed::Shell.tool_available?("bundle")
   describe Licensed::Source::Bundler do


### PR DESCRIPTION
Fixes https://github.com/github/licensed/issues/23
Fixes https://github.com/github/licensed/issues/24

Fixing a couple issues where `::Bundler.default_*file` does not behave ideally for usage in licensed
1. They raise errors if a gem file can't be found
   - e.g. if the licensed gem is installed globally and not run from bundler, and a gem file isn't in the configured app source path
2. They prefer `ENV["BUNDLE_GEMFILE"]` over searching for a gem file in the local file hierarchy
   - can lead to a mismatch if the name of the gem file in `ENV["BUNDLE_GEMFILE"]` doesn't match the name of the file in the configured app source path (gems.rb vs Gemfile)
3.  licensed has a very specific usage that looks for the gem file at the app source path and does not need any of the extra search logic in [`Bundler::SharedHelpers::find_gemfile`](https://github.com/bundler/bundler/blob/257fb54da0003c3a67f6e7b3b5a242a4ba9c45cb/lib/bundler/shared_helpers.rb#L240-L246)

The downside is that now the source has to either keep track of the possible gem file names itself or call the private [`Bundler::SharedHelpers::gemfile_names`](https://github.com/bundler/bundler/blob/257fb54da0003c3a67f6e7b3b5a242a4ba9c45cb/lib/bundler/shared_helpers.rb#L248-L250).  This PR opts to keep track of the file names locally so that licensed doesn't take a dependency on a private method that could change without notice.