### PR TITLE
Raise more informative message after shelling out fails

### DIFF
--- a/lib/licensed/git.rb
+++ b/lib/licensed/git.rb
@@ -23,7 +23,7 @@ module Licensed
         file = File.directory?(descriptor) ? "." : File.basename(descriptor)
 
         Dir.chdir dir do
-          Licensed::Shell.execute("git", "rev-list", "-1", "HEAD", "--", file)
+          Licensed::Shell.execute("git", "rev-list", "-1", "HEAD", "--", file, allow_failure: true)
         end
       end
 

--- a/lib/licensed/shell.rb
+++ b/lib/licensed/shell.rb
@@ -3,12 +3,19 @@ require "open3"
 
 module Licensed
   module Shell
-    # Executes a command, returning it's STDOUT on success.  Returns an empty
-    # string on failure
-    def self.execute(cmd, *args)
-      output, _, status = Open3.capture3(cmd, *args)
-      return "" unless status.success?
-      output.strip
+    # Executes a command, returning its standard output on success. On failure,
+    # it raises an exception that contains the error output, unless
+    # `allow_failure` is true, in which case it returns an empty string.
+    def self.execute(cmd, *args, allow_failure: false)
+      stdout, stderr, status = Open3.capture3(cmd, *args)
+
+      if status.success?
+        stdout.strip
+      elsif allow_failure
+        ""
+      else
+        raise Error.new([cmd, *args], status.exitstatus, stderr)
+      end
     end
 
     # Executes a command and returns a boolean value indicating if the command
@@ -23,6 +30,32 @@ module Licensed
     def self.tool_available?(tool)
       output, err, status = Open3.capture3("which", tool)
       status.success? && !output.strip.empty? && err.strip.empty?
+    end
+
+    class Error < RuntimeError
+      def initialize(cmd, status, stderr)
+        super()
+        @cmd = cmd
+        @exitstatus = status
+        @output = stderr
+      end
+
+      def message
+        output = @output.to_s.strip
+        extra = output.empty?? "" : "\n#{output.gsub(/^/, "    ")}"
+        "command exited with status #{@exitstatus}\n  #{escape_cmd}#{extra}"
+      end
+
+      def escape_cmd
+        @cmd.map do |arg|
+          if arg =~ /[\s'"]/
+            escaped = arg.gsub(/([\\"])/, '\\\\\1')
+            %("#{escaped}")
+          else
+            arg
+          end
+        end.join(" ")
+      end
     end
   end
 end

--- a/lib/licensed/source/cabal.rb
+++ b/lib/licensed/source/cabal.rb
@@ -125,7 +125,7 @@ module Licensed
       # Runs a `ghc-pkg field` command for a given set of fields and arguments
       # Automatically includes ghc package DB locations in the command
       def ghc_pkg_field_command(id, fields, *args)
-        Licensed::Shell.execute("ghc-pkg", "field", id, fields.join(","), *args, *package_db_args)
+        Licensed::Shell.execute("ghc-pkg", "field", id, fields.join(","), *args, *package_db_args, allow_failure: true)
       end
 
       # Returns an array of ghc package DB locations as specified in the app

--- a/lib/licensed/source/go.rb
+++ b/lib/licensed/source/go.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require "json"
 require "English"
+require "pathname"
 
 module Licensed
   module Source
@@ -113,7 +114,7 @@ module Licensed
       # package - Go package import path
       def package_info_command(package)
         package ||= ""
-        Licensed::Shell.execute("go", "list", "-json", package)
+        Licensed::Shell.execute("go", "list", "-json", package, allow_failure: true)
       end
 
       # Returns the info for the package under test
@@ -140,7 +141,12 @@ module Licensed
         @gopath = if path.nil? || path.empty?
                     ENV["GOPATH"]
                   else
-                    File.expand_path(path, Licensed::Git.repository_root)
+                    root = begin
+                             Licensed::Git.repository_root
+                           rescue Licensed::Shell::Error
+                             Pathname.pwd
+                           end
+                    File.expand_path(path, root)
                   end
       end
 


### PR DESCRIPTION
Before:

```sh
$ licensed status -c path/to/config.yml
MYPROJECT/vendor/gems/2.4.2/ruby/2.4.0/gems/json-2.1.0/lib/json/common.rb:156:in `parse': 765: unexpected token at '' (JSON::ParserError)
        from MYPROJECT/vendor/gems/2.4.2/ruby/2.4.0/gems/json-2.1.0/lib/json/common.rb:156:in `parse'
        from MYPROJECT/vendor/gems/2.4.2/ruby/2.4.0/gems/licensed-1.0.1/lib/licensed/source/npm.rb:28:in `dependencies'
```

The trouble is that `npm list` resulted in an error, but we can't see the command executed nor its error output. Instead there is a misleading JSON parse error because it tried to parse an empty string.

After:

```sh
$ licensed status -c path/to/config.yml
/Users/mislav/github/licensed/lib/licensed/shell.rb:93:in `raise_on_failure!': command exited with status 1 (Licensed::Shell::Error)
  npm list --parseable --production --long
    npm ERR! missing: d3-format@1.2.0, required by @github/d3@4.10.2
    npm ERR! missing: d3-geo@1.6.4, required by @github/d3@4.10.2
    npm ERR! missing: d3-zoom@1.5.0, required by @github/d3@4.10.2
        from /Users/mislav/github/licensed/lib/licensed/source/npm.rb:28:in `dependencies'
        from /Users/mislav/github/licensed/lib/licensed/command/status.rb:18:in `each'
```

This extends the `Licensed::Shell` implementation so it raises a helpful message when shelling out fails.

As a bonus, it also switches to a streaming implementation for commands that process output per line.