### PR TITLE
Check for required tools when determining if source is enabled

### DIFF
--- a/lib/licensed/source/bundler.rb
+++ b/lib/licensed/source/bundler.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
-if Licensed::Shell.tool_available?("bundle")
+begin
   require "bundler"
+rescue LoadError
 end
 
 module Licensed
@@ -17,7 +18,7 @@ module Licensed
       end
 
       def enabled?
-        Licensed::Shell.tool_available?("bundle") && lockfile_path && lockfile_path.exist?
+        defined?(::Bundler) && lockfile_path && lockfile_path.exist?
       end
 
       def dependencies

--- a/lib/licensed/source/bundler.rb
+++ b/lib/licensed/source/bundler.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
-require "bundler"
+if Licensed::Shell.tool_available?("bundle")
+  require "bundler"
+end
 
 module Licensed
   module Source
@@ -15,7 +17,7 @@ module Licensed
       end
 
       def enabled?
-        lockfile_path && lockfile_path.exist?
+        Licensed::Shell.tool_available?("bundle") && lockfile_path && lockfile_path.exist?
       end
 
       def dependencies

--- a/lib/licensed/source/go.rb
+++ b/lib/licensed/source/go.rb
@@ -14,7 +14,7 @@ module Licensed
       end
 
       def enabled?
-        go_source?
+        Licensed::Shell.tool_available?("go") && go_source?
       end
 
       def dependencies

--- a/lib/licensed/source/npm.rb
+++ b/lib/licensed/source/npm.rb
@@ -13,7 +13,7 @@ module Licensed
       end
 
       def enabled?
-        File.exist?(@config.pwd.join("package.json"))
+        Licensed::Shell.tool_available?("npm") && File.exist?(@config.pwd.join("package.json"))
       end
 
       def dependencies


### PR DESCRIPTION
I'm seeing some failures using `licensed` in scenarios where one or more of the tools are not installed.  This PR adds calls to verify that the appropriate tools are installed in the local environment when checking if a source is enabled. In particular:

The go source calls `go doc` as part of it's check for whether the source is enabled.  If go isn't installed this throws an error.

The rubygem source starts with `require "bundler"`.  If bundler isn't installed, 💥 .

For completeness I also added a check for `npm` being available in that source, though I hadn't seen any failures.

The bower source doesn't actually call into bower and the cabal source already checks for ghc being available.