### PR TITLE
Fix cabal source to look for all cabal file targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ test/fixtures/go/src/*
 test/fixtures/go/pkg
 !test/fixtures/go/src/test
 test/fixtures/cabal/*
-!test/fixtures/cabal/app.cabal
+!test/fixtures/cabal/app*
 
 vendor/licenses
 .licenses

--- a/docs/sources/cabal.md
+++ b/docs/sources/cabal.md
@@ -2,7 +2,25 @@
 
 The cabal source uses the `ghc-pkg` command to enumerate dependencies and provide metadata.  It is un-opinionated on GHC packagedb locations and requires some configuration to ensure that all packages are properly found.
 
-The cabal source will detect dependencies when a `.cabal` file is found at an apps `source_path`.
+The cabal source will detect dependencies when a `.cabal` file is found at an apps `source_path`.  By default, the cabal source will enumerate dependencies for all executable and library targets in a cabal file.
+
+### Specifying which cabal file targets should enumerate dependencies
+The cabal source can be configured to override which cabal file targets contain dependencies that need to be documented.
+
+The default configuration is equivalent to:
+```yml
+cabal:
+  cabal_file_targets:
+    - executable
+    - library
+```
+
+However if you only wanted to enumerate dependencies for a `my_cabal_exe` executable target, you could specify:
+```yml
+cabal:
+  cabal_file_targets:
+    - executable my_cabal_exe
+```
 
 ### Specifying GHC packagedb locations through environment
 You can configure the `cabal` source to use specific packagedb locations by setting the `GHC_PACKAGE_PATH` environment variable before running `licensed`.

--- a/lib/licensed/source/cabal.rb
+++ b/lib/licensed/source/cabal.rb
@@ -16,7 +16,7 @@ module Licensed
       end
 
       def enabled?
-        cabal_packages.any? && ghc?
+        cabal_file_dependencies.any? && ghc?
       end
 
       def dependencies
@@ -66,7 +66,7 @@ module Licensed
 
       # Returns a `Set` of the package ids for all cabal dependencies
       def package_ids
-        recursive_dependencies(cabal_packages)
+        recursive_dependencies(cabal_file_dependencies)
       end
 
       # Recursively finds the dependencies for each cabal package.
@@ -150,13 +150,14 @@ module Licensed
         path.gsub("<ghc_version>", ghc_version)
       end
 
-      def cabal_packages
+      # Returns a set containing the top-level dependencies found in cabal files
+      def cabal_file_dependencies
         cabal_files.each_with_object(Set.new) do |cabal_file, packages|
           content = File.read(cabal_file)
           next if content.nil? || content.empty?
 
-          # add any dependencies for explicitly matched content from
-          # the cabal file.  by default this will find executable's dependencies
+          # add any dependencies for matched targets from the cabal file.
+          # by default this will find executable and library dependencies
           content.scan(cabal_file_regex).each do |match|
             # match[1] is a string of "," separated dependencies
             dependencies = match[1].split(",").map(&:strip)

--- a/lib/licensed/source/cabal.rb
+++ b/lib/licensed/source/cabal.rb
@@ -4,6 +4,9 @@ require "English"
 module Licensed
   module Source
     class Cabal
+      DEPENDENCY_REGEX = /\s*.+?\s*/.freeze
+      DEFAULT_TARGETS = %w{executable library}.freeze
+
       def self.type
         "cabal"
       end
@@ -63,8 +66,7 @@ module Licensed
 
       # Returns a `Set` of the package ids for all cabal dependencies
       def package_ids
-        deps = cabal_packages.flat_map { |n| package_dependencies(n, false) }
-        recursive_dependencies(deps)
+        recursive_dependencies(cabal_packages)
       end
 
       # Recursively finds the dependencies for each cabal package.
@@ -148,12 +150,55 @@ module Licensed
         path.gsub("<ghc_version>", ghc_version)
       end
 
-      # Return an array of the top-level cabal packages for the current app
       def cabal_packages
-        cabal_files.map do |f|
-          name_match = File.read(f).match(/^name:\s*(.*)$/)
-          name_match[1] if name_match
-        end.compact
+        cabal_files.each_with_object(Set.new) do |cabal_file, packages|
+          content = File.read(cabal_file)
+          next if content.nil? || content.empty?
+
+          # add any dependencies for explicitly matched content from
+          # the cabal file.  by default this will find executable's dependencies
+          content.scan(cabal_file_regex).each do |match|
+            # match[1] is a string of "," separated dependencies
+            dependencies = match[1].split(",").map(&:strip)
+            dependencies.each do |dep|
+              # the dependency might have a version specifier.
+              # remove it so we can get the full id specifier for each package
+              id = cabal_package_id(dep.split(/\s/)[0])
+              packages.add(id) if id
+            end
+          end
+        end
+      end
+
+      # Returns an installed package id for the package.
+      def cabal_package_id(package_name)
+        field = ghc_pkg_field_command(package_name, ["id"])
+        id = field.split(":", 2)[1]
+        id.strip if id
+      end
+
+      # Find `build-depends` lists from specified targets in a cabal file
+      def cabal_file_regex
+        # this will match 0 or more occurences of
+        # match[0] - specifier, e.g. executable, library, etc
+        # match[1] - full list of matched dependencies
+        # match[2] - first matched dependency (required)
+        # match[3] - remainder of matched dependencies (not required)
+        @cabal_file_regex ||= /
+          # match a specifier, e.g. library or executable
+          ^(#{cabal_file_targets.join("|")})
+            .*? # stuff
+
+            # match a list of 1 or more dependencies
+            build-depends:(#{DEPENDENCY_REGEX}(,#{DEPENDENCY_REGEX})*)\n
+        /xmi
+      end
+
+      # Returns the targets to search for `build-depends` in a cabal file
+      def cabal_file_targets
+        targets = Array(@config.dig("cabal", "cabal_file_targets"))
+        targets.push(*DEFAULT_TARGETS) if targets.empty?
+        targets
       end
 
       # Returns an array of the local directory cabal package files

--- a/script/source-setup/cabal
+++ b/script/source-setup/cabal
@@ -11,7 +11,7 @@ BASE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd $BASE_PATH/test/fixtures/cabal
 
 if [ "$1" == "-f" ]; then
-  find . -not -regex "\.*" -and -not -name "app\.cabal" -print0 | xargs -0 rm -rf
+  find . -not -regex "\.*" -and -not -path "*app*" -print0 | xargs -0 rm -rf
 fi
 
 cabal new-build

--- a/test/fixtures/cabal/app.cabal
+++ b/test/fixtures/cabal/app.cabal
@@ -11,3 +11,9 @@ library
   hs-source-dirs:      .
   build-depends:       zlib == 0.6.2
   default-language:    Haskell2010
+
+executable app
+  hs-source-dirs:      app
+  main-is:             Main.hs
+  build-depends:       base, Glob == 0.9.2
+  default-language:    Haskell2010

--- a/test/fixtures/cabal/app/Main.hs
+++ b/test/fixtures/cabal/app/Main.hs
@@ -1,0 +1,1 @@
+main = putStrLn "Hello world"

--- a/test/source/cabal_test.rb
+++ b/test/source/cabal_test.rb
@@ -59,6 +59,24 @@ if Licensed::Shell.tool_available?("ghc")
           assert dep["summary"]
         end
       end
+
+      it "finds dependencies for executables" do
+        config["cabal"] = { "ghc_package_db" => ["global", user_db, local_db] }
+        Dir.chdir(fixtures) do
+          dep = source.dependencies.detect { |d| d["name"] == "Glob" }
+          assert dep
+          assert_equal "cabal", dep["type"]
+          assert_equal "0.9.2", dep["version"]
+          assert dep["summary"]
+        end
+      end
+
+      it "does not include the target project" do
+        config["cabal"] = { "ghc_package_db" => ["global", user_db, local_db] }
+        Dir.chdir(fixtures) do
+          refute source.dependencies.detect { |d| d["name"] == "app" }
+        end
+      end
     end
 
     describe "package_db_args" do


### PR DESCRIPTION
The cabal source had a bug where it was only enumerating dependencies for a library built from a cabal file.  In the event that a cabal file contained one or more executables, their dependencies would not be enumerated.

This updates the cabal source to broadly enumerate dependencies for targets in `*.cabal` files.  By default all `library` and `executable` targets are evaluated but this can be overridden via the configuration file as outlined in the documentation updates.  This can be used to either scope down the dependencies (for example, if a library is built but not publicly shipped) or expand them (for example, to enumerate dependencies of test targets).

The underlying mechanics uses a regex to parse each specified targets' `build-depends` list.  We get the full id of each dependent package which is then recursively evaluated for all dependencies.