### PR TITLE
Check for cached metadata version before comparing it

### DIFF
--- a/lib/licensed/command/cache.rb
+++ b/lib/licensed/command/cache.rb
@@ -40,8 +40,9 @@ module Licensed
                 # or default to a blank license
                 license = Licensed::License.read(filename) || Licensed::License.new
 
-                # Version did not change, no need to re-cache
-                if !force && version == license["version"]
+                # cached version string exists and did not change, no need to re-cache
+                has_version = !license["version"].nil? && !license["version"].empty?
+                if !force && has_version && version == license["version"]
                   @config.ui.info "    Using #{name} (#{version})"
                   next
                 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -36,13 +36,15 @@ class TestSource
 
   def dependencies
     @dependencies_hook.call if @dependencies_hook.respond_to?(:call)
-    @dependencies ||= [
-      Licensed::Dependency.new(Dir.pwd, {
-        "type"     => TestSource.type,
-        "name"     => "dependency",
-        "version"  => "1.0"
-      })
-    ]
+    @dependencies ||= [TestSource.create_dependency]
+  end
+
+  def self.create_dependency
+    Licensed::Dependency.new(Dir.pwd, {
+      "type"     => TestSource.type,
+      "name"     => "dependency",
+      "version"  => "1.0"
+    })
   end
 end
 


### PR DESCRIPTION
Fixes an issue where a new dependency's license metadata was not being cached when version metadata for the dependency was not available.

This bug occurs as a result of https://github.com/github/licensed/pull/21.  Previous to that change, licensed only considered reusing cached license data when the cached data existed.  A file existence check was removed to optimize for using cached data for more than version checks.

`github/linguist` hit an edge case where their license information, which doesn't contain version metadata, began to view non-existent metadata as the same version as new metadata and skipped caching the new content.

This PR adds a check that the cached data contains non-nil version metadata before checking if the version metadata is current.  Since we can't verify version information that doesn't exist, nil or empty version metadata will force rechecking and caching license content.

/cc @lildude FYI and review as the reporter of the bug