### PR TITLE
Fix licenses typo

### DIFF
--- a/lib/licensed/command/cache.rb
+++ b/lib/licensed/command/cache.rb
@@ -11,7 +11,7 @@ module Licensed
       def run(force: false)
         summary = @config.apps.flat_map do |app|
           app_name = app["name"]
-          @config.ui.info "Caching licenes for #{app_name}:"
+          @config.ui.info "Caching licenses for #{app_name}:"
 
           # load the app environment
           Dir.chdir app.source_path do


### PR DESCRIPTION
Quick fix PR for a typo I noticed whilst testing https://github.com/github/licensed/pull/41:

```console
$ script/licensed --module /Users/lildude/github/linguist/vendor/grammars/m3
  > Caching licenes for linguist:  <---- HERE
[...]
```