### PR TITLE
Fix test failures when a tool is not available locally

### DIFF
--- a/lib/licensed/source/pip.rb
+++ b/lib/licensed/source/pip.rb
@@ -14,7 +14,8 @@ module Licensed
       end
 
       def enabled?
-        Licensed::Shell.tool_available?(virtual_env_pip) && File.exist?(@config.pwd.join("requirements.txt"))
+        return unless virtual_env_pip && Licensed::Shell.tool_available?(virtual_env_pip)
+        File.exist?(@config.pwd.join("requirements.txt"))
       end
 
       def dependencies
@@ -54,6 +55,7 @@ module Licensed
       end
 
       def virtual_env_pip
+        return unless virtual_env_dir
         File.join(virtual_env_dir, "bin", "pip")
       end
 

--- a/lib/licensed/source/pip.rb
+++ b/lib/licensed/source/pip.rb
@@ -14,7 +14,7 @@ module Licensed
       end
 
       def enabled?
-        File.exist?(@config.pwd.join("requirements.txt"))
+        Licensed::Shell.tool_available?(virtual_env_pip) && File.exist?(@config.pwd.join("requirements.txt"))
       end
 
       def dependencies
@@ -50,13 +50,19 @@ module Licensed
       end
 
       def pip_command(*args)
-        venv_dir = @config.dig("python", "virtual_env_dir")
-        if venv_dir.nil?
-          raise "Virtual env directory not set."
+        Licensed::Shell.execute(virtual_env_pip, "--disable-pip-version-check", "show", *args)
+      end
+
+      def virtual_env_pip
+        File.join(virtual_env_dir, "bin", "pip")
+      end
+
+      def virtual_env_dir
+        return @virtual_env_dir if defined?(@virtual_env_dir)
+        @virtual_env_dir = begin
+          venv_dir = @config.dig("python", "virtual_env_dir")
+          File.expand_path(venv_dir, Licensed::Git.repository_root) if venv_dir
         end
-        venv_dir = File.expand_path(venv_dir, Licensed::Git.repository_root)
-        pip = File.join(venv_dir, "bin", "pip")
-        Licensed::Shell.execute(pip, "--disable-pip-version-check", "show", *args)
       end
     end
   end

--- a/test/command/cache_test.rb
+++ b/test/command/cache_test.rb
@@ -30,6 +30,10 @@ describe Licensed::Command::Cache do
       let(:source) { Licensed::Source.const_get(source_type).new(config) }
 
       it "extracts license info" do
+        Dir.chdir config.source_path do
+          skip "#{source_type} not available" unless source.enabled?
+        end
+
         generator.run
 
         path = config.cache_path.join("#{source.class.type}/#{expected_dependency}.txt")

--- a/test/command/list_test.rb
+++ b/test/command/list_test.rb
@@ -23,6 +23,10 @@ describe Licensed::Command::List do
       let(:source) { Licensed::Source.const_get(source_type).new(config) }
 
       it "lists dependencies" do
+        Dir.chdir config.source_path do
+          skip "#{source_type} not available" unless source.enabled?
+        end
+
         out, = capture_io { command.run }
         assert_match(/Found #{expected_dependency}/, out)
         assert_match(/#{source.class.type} dependencies:/, out)

--- a/test/source/pip_test.rb
+++ b/test/source/pip_test.rb
@@ -11,7 +11,7 @@ if Licensed::Shell.tool_available?("pip")
     describe "enabled?" do
       it "is true if pip source is available" do
         Dir.chdir(fixtures) do
-        assert source.enabled?
+          assert source.enabled?
         end
       end
 
@@ -19,17 +19,6 @@ if Licensed::Shell.tool_available?("pip")
         Dir.mktmpdir do |dir|
           Dir.chdir(dir) do
             refute source.enabled?
-          end
-        end
-      end
-    end
-
-    describe "config file params check" do
-      it "fails if virtual_env_dir is not set" do
-        config.delete("python")
-        assert_raises RuntimeError  do
-          Dir.chdir(fixtures) do
-            source.pip_command
           end
         end
       end


### PR DESCRIPTION
When `script/test` is run without any arguments, `cache_test.rb` and `list_test.rb` each run their respective command for a single test case over all sources.

As part of the release process, I ran `script/test` and found that I was having test failures due to not having a python development environment available with `pip` and `venv`.  The source-specific test files are gated to check that their respective tools are available before the tests are run, however the cache and list tests are somewhat generic, making it hard to check for specific dependencies.

Luckily, the sources already do this with the `#enabled?` method.

This PR changes the `pip` source to check that the expected pip executable exists as part of `#enabled?`.

The relevant test cases have also been updated to check that sources are enabled before trying to use them, and skip the test case if the source is not enabled.