### PR TITLE
Remove check for [ignored] property for dep source

### DIFF
--- a/docs/sources/dep.md
+++ b/docs/sources/dep.md
@@ -3,11 +3,8 @@ This source is intended to be used when all of a projects dependencies have been
 
 # Go Dep
 
-The dep source will detect dependencies when the source is enabled and both `Gopkg.toml` and `Gopkg.lock` are found at an apps `source_path`.  It
+The dep source will detect dependencies when the source is enabled and `Gopkg.lock` is found at an apps `source_path`.  It
 parses the `Gopkg.lock` file to find packages that have been vendored into the project directory.
-
-This source will self-disable if the `ignored` property in `Gopkg.toml` has any values.  While strongly discouraged, the source can be forced to run
-via configuration.
 
 ```yml
 dep:

--- a/lib/licensed/source/dep.rb
+++ b/lib/licensed/source/dep.rb
@@ -60,19 +60,11 @@ module Licensed
       end
 
       def go_dep_available?
-        return false unless gopkg_lock_path.exist? && gopkg_toml_path.exist?
-        return true if @config.dig("dep", "allow_ignored") == true
-
-        gopkg_toml = Tomlrb.load_file(gopkg_toml_path, symbolize_keys: true)
-        gopkg_toml[:ignored].nil? || gopkg_toml[:ignored].empty?
+        gopkg_lock_path.exist?
       end
 
       def gopkg_lock_path
         @config.pwd.join("Gopkg.lock")
-      end
-
-      def gopkg_toml_path
-        @config.pwd.join("Gopkg.toml")
       end
 
       # Returns a list of go standard packages

--- a/test/source/dep_test.rb
+++ b/test/source/dep_test.rb
@@ -21,16 +21,6 @@ describe Licensed::Source::Dep do
         end
       end
     end
-
-    it "is false if Gopkg.toml contains ignored packages and allow_ignored is not true" do
-      Dir.chdir(fixtures) do
-        config["dep"]["allow_ignored"] = false
-        refute source.enabled?
-
-        config["dep"].delete("allow_ignored")
-        refute source.enabled?
-      end
-    end
   end
 
   describe "packages" do


### PR DESCRIPTION
Spent some time this weekend working on a Golang project that used `dep`, and I realized that the ignored property in `Gopkg.toml` didn't work  the way I thought it did.  Updating the source to remove that check.

The idea behind `dep` is that all dependencies should be in the file, except potentially the go standard library.  As a result, I'm taking `Gopkg.lock` as the source of truth for the v1 release.  If a project relies on `go` packages in the local environment that are not listed in `Gopkg.lock` then the project must still use the `go` source over the `dep` source.