### PR TITLE
Source bundler dependencies without using ::Bundler::Definition#specs

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -47,7 +47,8 @@ namespace :test do
 
       # use negative lookahead to exclude all source tests except
       # the tests for `source`
-      t.test_files = FileList["test/**/*_test.rb"].exclude(/test\/source\/(?!#{source}).*?_test.rb/)
+      t.test_files = FileList["test/**/*_test.rb"].exclude(/test\/source\/(?!#{source}).*?_test.rb/,
+                                                           "test/fixtures/**/*_test.rb")
     end
   end
 end
@@ -55,7 +56,7 @@ end
 Rake::TestTask.new(:test) do |t|
   t.libs << "test"
   t.libs << "lib"
-  t.test_files = FileList["test/**/*_test.rb"]
+  t.test_files = FileList["test/**/*_test.rb"].exclude("test/fixtures/**/*_test.rb")
 end
 
 # add rubocop task

--- a/docs/sources/bundler.md
+++ b/docs/sources/bundler.md
@@ -2,6 +2,29 @@
 
 The bundler source will detect dependencies `Gemfile` and `Gemfile.lock` files are found at an apps `source_path`.  The source uses the `Bundler` API to enumerate dependencies from `Gemfile` and `Gemfile.lock`.
 
-The bundler source will exclude gems in the `:development` and `:test` groups.  Be aware that if you have a local
-bundler configuration (e.g. `.bundle`), that configuration will be respected as well.  For example, if you have a local
-configuration set for `without: [':server']`, the bundler source will exclude all gems in the `:server` group.
+### Excluding gem groups
+
+The bundler source determines which gem groups to include or exclude with the following logic, in order of precedence.
+1. Include all groups specified in the Gemfile
+2. Exclude all groups from the `without` bundler configuration (e.g. `.bundle/config`)
+3. Include all groups from the `with` bundler configuration (e.g. `.bundle/config`)
+4. Exclude all groups from the `without` licensed configuration (`:development` and `:test` if not otherwise specified)
+
+`licensed` can be configured to override the default "without" development and test groups in the configuration file.
+
+Strings and string arrays are both :+1:
+
+```yml
+rubygems:
+  without: development
+```
+
+or
+
+```yml
+rubygems:
+  without:
+    - build
+    - development
+    - test
+```

--- a/lib/licensed/shell.rb
+++ b/lib/licensed/shell.rb
@@ -6,8 +6,8 @@ module Licensed
     # Executes a command, returning its standard output on success. On failure,
     # it raises an exception that contains the error output, unless
     # `allow_failure` is true, in which case it returns an empty string.
-    def self.execute(cmd, *args, allow_failure: false)
-      stdout, stderr, status = Open3.capture3(cmd, *args)
+    def self.execute(cmd, *args, allow_failure: false, env: {})
+      stdout, stderr, status = Open3.capture3(env, cmd, *args)
 
       if status.success?
         stdout.strip

--- a/lib/licensed/source/bundler.rb
+++ b/lib/licensed/source/bundler.rb
@@ -19,7 +19,7 @@ module Licensed
       end
 
       def enabled?
-        defined?(::Bundler) && Licensed::Shell.tool_available?("bundle") && lockfile_path && lockfile_path.exist?
+        defined?(::Bundler) && lockfile_path && lockfile_path.exist?
       end
 
       def dependencies
@@ -135,6 +135,12 @@ module Licensed
       def bundler_spec
         # cache this so we run CLI commands as few times as possible
         return @bundler_spec if defined?(@bundler_spec)
+
+        # finding the bundler gem is dependent on having `gem` available
+        unless Licensed::Shell.tool_available?("gem")
+          @bundler_spec = nil
+          return
+        end
 
         # Bundler is always used from the default gem install location.
         # we can use `gem specification bundler` with a clean ENV to

--- a/lib/licensed/source/bundler.rb
+++ b/lib/licensed/source/bundler.rb
@@ -19,7 +19,7 @@ module Licensed
       end
 
       def enabled?
-        defined?(::Bundler) && lockfile_path && lockfile_path.exist?
+        defined?(::Bundler) && Licensed::Shell.tool_available?("bundle") && lockfile_path && lockfile_path.exist?
       end
 
       def dependencies
@@ -123,10 +123,6 @@ module Licensed
       def bundler_spec
         # cache this so we run CLI commands as few times as possible
         return @bundler_spec if defined?(@bundler_spec)
-
-        unless Licensed::Shell.tool_available?("bundle")
-          return @bundler_spec = nil
-        end
 
         # set GEM_PATH to nil in the execution environment to pick up host
         # information.  this is a specific hack for running from a

--- a/lib/licensed/source/bundler.rb
+++ b/lib/licensed/source/bundler.rb
@@ -8,6 +8,7 @@ module Licensed
   module Source
     class Bundler
       GEMFILES = %w{Gemfile gems.rb}.freeze
+      DEFAULT_WITHOUT_GROUPS = %i{development test}
 
       def self.type
         "rubygem"
@@ -23,8 +24,8 @@ module Licensed
 
       def dependencies
         @dependencies ||= with_local_configuration do
-          definition.specs_for(groups).map do |spec|
-            Dependency.new(spec.gem_dir, {
+          specs.map do |spec|
+            Licensed::Dependency.new(spec.gem_dir, {
               "type"     => Bundler.type,
               "name"     => spec.name,
               "version"  => spec.version.to_s,
@@ -35,14 +36,123 @@ module Licensed
         end
       end
 
+      # Returns an array of Gem::Specifications for all gem dependencies
+      def specs
+        # get the specifications for all dependencies in a Gemfile
+        root_dependencies = definition.dependencies.select { |d| include?(d) }
+        root_specs = specs_for_dependencies(root_dependencies).compact
+
+        # recursively find the remaining specifications
+        all_specs = recursive_specs(root_specs)
+
+        # delete any specifications loaded from a gemspec
+        all_specs.delete_if { |s| s.source.is_a?(::Bundler::Source::Gemspec) }
+      end
+
+      # Recursively finds the dependencies for Gem specifications.
+      # Returns a `Set` containing the package names for all dependencies
+      def recursive_specs(specs, results = Set.new)
+        return [] if specs.nil? || specs.empty?
+
+        new_specs = Set.new(specs) - results.to_a
+        return [] if new_specs.empty?
+
+        results.merge new_specs
+
+        dependency_specs = new_specs.flat_map { |s| specs_for_dependencies(s.dependencies) }
+                                    .compact
+        return results if dependency_specs.empty?
+
+        results.merge recursive_specs(dependency_specs, results)
+      end
+
+      # Returns the specs for dependencies that pass the checks in `include?`
+      # Raises an error if the specification isn't found
+      def specs_for_dependencies(dependencies)
+        included_dependencies = dependencies.select { |d| include?(d) }
+        included_dependencies.map do |dep|
+          gem_spec(dep) || raise("Unable to find a specification for #{dep.name} (#{dep.requirement}) in any sources")
+        end
+      end
+
+      # Returns a Gem::Specification for the provided gem argument.  If a
+      # Gem::Specification isn't found, an error will be raised.
+      def gem_spec(dependency)
+        return unless dependency
+
+        # bundler specifications aren't put in ::Bundler.specs_path, even if the
+        # gem is a runtime dependency.  it needs to be handled specially
+        return bundler_spec if dependency.name == "bundler"
+
+        # find a specifiction from the resolved ::Bundler::Definition specs
+        spec = definition.resolve.find { |s| s.satisfies?(dependency) }
+        return spec unless spec.is_a?(::Bundler::LazySpecification)
+
+        # if the specification is coming from a gemspec source,
+        # we can get a non-lazy specification straight from the source
+        if spec.source.is_a?(::Bundler::Source::Gemspec)
+          return spec.source.specs.first
+        end
+
+        # look for a specification at the bundler specs path
+        spec_path = ::Bundler.specs_path.join("#{spec.full_name}.gemspec")
+        return unless File.exist?(spec_path.to_s)
+        Gem::Specification.load(spec_path.to_s)
+      end
+
+      # Returns whether a dependency should be included in the final
+      def include?(dependency)
+        # ::Bundler::Dependency has an extra `should_include?`
+        return false unless dependency.should_include? if dependency.respond_to?(:should_include?)
+
+        # Don't return gems listed as `:development` in the gemfile
+        return false if dependency.type == :development
+
+        # Gem::Dependency don't have groups - in our usage these objects always
+        # come as child-dependencies and are never directly from a Gemfile.
+        # We assume that all Gem::Dependencies are ok at this point
+        return true if dependency.groups.nil?
+
+        # check if the dependency is in any groups we're interested in
+        (dependency.groups & groups).any?
+      end
+
+      # Returns a gemspec for bundler, found and loaded by running `bundle show bundle`
+      # This is a hack to work around bundler not placing it's own spec at
+      # `::Bundler.specs_path` when it's an explicit dependency
+      def bundler_spec
+        # cache this so we run CLI commands as few times as possible
+        @bundler_spec ||= begin
+          # set GEM_PATH to nil in the execution environment to pick up host
+          # information.  this is a specific hack for running from a
+          # ruby-packer built executable
+          path = Licensed::Shell.execute("bundle", "show", "bundler", env: { "GEM_PATH" => nil })
+          # get the gemspec path for the given bundler gem path
+          path = File.expand_path("../../specifications/#{File.basename(path)}.gemspec", path)
+          Gem::Specification.load(path)
+        end
+      end
+
       # Build the bundler definition
       def definition
         @definition ||= ::Bundler::Definition.build(gemfile_path, lockfile_path, nil)
       end
 
-      # Returns the bundle definition groups, excluding test and development
+      # Returns the bundle definition groups, removing "without" groups,
+      # and including "with" groups
       def groups
-        definition.groups - [:test, :development]
+        definition.groups - Array(::Bundler.settings[:without]) + Array(::Bundler.settings[:with]) - exclude_groups
+      end
+
+      # Returns any groups to exclude specified from both licensed configuration
+      # and bundler configuration.
+      # Defaults to [:development, :test] + ::Bundler.settings[:without]
+      def exclude_groups
+        @exclude_groups ||= begin
+          exclude = Array(@config.dig("rubygems", "without"))
+          exclude.push(*DEFAULT_WITHOUT_GROUPS) if exclude.empty?
+          exclude.uniq.map(&:to_sym)
+        end
       end
 
       # Returns the path to the Bundler Gemfile
@@ -61,20 +171,15 @@ module Licensed
 
       # helper to clear all bundler environment around a yielded block
       def with_local_configuration
-        original_bundle_gemfile = ENV["BUNDLE_GEMFILE"]
+        # force bundler to use the local gem file
+        original_bundle_gemfile, ENV["BUNDLE_GEMFILE"] = ENV["BUNDLE_GEMFILE"], gemfile_path.to_s
 
-        # with a clean, original environment
-        ::Bundler.with_original_env do
-          # force bundler to use the local gem file
-          ENV["BUNDLE_GEMFILE"] = gemfile_path.to_s
+        # reset all bundler configuration
+        ::Bundler.reset!
+        # and re-configure with settings for current directory
+        ::Bundler.configure
 
-          # reset all bundler configuration
-          ::Bundler.reset!
-          # and re-configure with settings for current directory
-          ::Bundler.configure
-
-          yield
-        end
+        yield
       ensure
         ENV["BUNDLE_GEMFILE"] = original_bundle_gemfile
         # restore bundler configuration

--- a/lib/licensed/source/bundler.rb
+++ b/lib/licensed/source/bundler.rb
@@ -122,15 +122,20 @@ module Licensed
       # `::Bundler.specs_path` when it's an explicit dependency
       def bundler_spec
         # cache this so we run CLI commands as few times as possible
-        @bundler_spec ||= begin
-          # set GEM_PATH to nil in the execution environment to pick up host
-          # information.  this is a specific hack for running from a
-          # ruby-packer built executable
-          path = Licensed::Shell.execute("bundle", "show", "bundler", env: { "GEM_PATH" => nil })
-          # get the gemspec path for the given bundler gem path
-          path = File.expand_path("../../specifications/#{File.basename(path)}.gemspec", path)
-          Gem::Specification.load(path)
+        return @bundler_spec if defined?(@bundler_spec)
+
+        unless Licensed::Shell.tool_available?("bundle")
+          return @bundler_spec = nil
         end
+
+        # set GEM_PATH to nil in the execution environment to pick up host
+        # information.  this is a specific hack for running from a
+        # ruby-packer built executable
+        path = Licensed::Shell.execute("bundle", "show", "bundler", env: { "GEM_PATH" => nil })
+        # get the gemspec path for the given bundler gem path
+        path = File.expand_path("../../specifications/#{File.basename(path)}.gemspec", path)
+
+        @bundler_spec = Gem::Specification.load(path)
       end
 
       # Build the bundler definition

--- a/licensed.gemspec
+++ b/licensed.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "webmock", "~> 1.21"
   spec.add_development_dependency "rubocop", "~> 0.49"
   spec.add_development_dependency "rubocop-github", "~> 0.6"
-  spec.add_dependency "byebug"
+  spec.add_development_dependency "byebug"
 end

--- a/licensed.gemspec
+++ b/licensed.gemspec
@@ -26,13 +26,13 @@ Gem::Specification.new do |spec|
   spec.add_dependency "octokit", "~>4.0"
   spec.add_dependency "pathname-common_prefix", "~>0.0.1"
   spec.add_dependency "tomlrb", "~>1.2"
+  spec.add_dependency "bundler", "~> 1.10"
 
-  spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.8"
   spec.add_development_dependency "vcr", "~> 2.9"
   spec.add_development_dependency "webmock", "~> 1.21"
   spec.add_development_dependency "rubocop", "~> 0.49"
   spec.add_development_dependency "rubocop-github", "~> 0.6"
-  spec.add_development_dependency "byebug"
+  spec.add_dependency "byebug"
 end

--- a/script/source-setup/bundler
+++ b/script/source-setup/bundler
@@ -17,4 +17,4 @@ if [ "$1" == "-f" ]; then
   find . -not -regex "\.*" -and -not -name "Gemfile" -print0 | xargs -0 rm -rf
 fi
 
-bundle install --path vendor/gems
+bundle install --path vendor/gems --without ignore

--- a/test/fixtures/bundler/Gemfile
+++ b/test/fixtures/bundler/Gemfile
@@ -2,3 +2,23 @@
 source "https://rubygems.org"
 
 gem "semantic", "1.6.0"
+
+group :ignore do
+  gem "json", "2.1.0"
+end
+
+group :bundler do
+  gem "bundler", "1.16.1"
+end
+
+group :exclude do
+  gem "i18n", "1.0.1"
+end
+
+group :development do
+ gem "tzinfo", "1.2.5"
+end
+
+group :test do
+ gem "minitest", "5.11.3"
+end

--- a/test/fixtures/bundler/Gemfile
+++ b/test/fixtures/bundler/Gemfile
@@ -8,7 +8,7 @@ group :ignore do
 end
 
 group :bundler do
-  gem "bundler", "1.16.1"
+  gem "bundler"
 end
 
 group :exclude do

--- a/test/source/bundler_test.rb
+++ b/test/source/bundler_test.rb
@@ -119,9 +119,7 @@ if Licensed::Shell.tool_available?("bundle")
       describe "when bundler is a listed dependency" do
         it "includes bundler as a dependency when included in dependencies" do
           Dir.chdir(fixtures) do
-            dep = source.dependencies.find { |d| d["name"] == "bundler" }
-            assert dep
-            assert_equal "1.16.1", dep["version"]
+            assert source.dependencies.find { |d| d["name"] == "bundler" }
           end
         end
 

--- a/test/source/bundler_test.rb
+++ b/test/source/bundler_test.rb
@@ -116,11 +116,23 @@ if Licensed::Shell.tool_available?("bundle")
         end
       end
 
-      it "includes bundler as a dependency when included in dependencies" do
-        Dir.chdir(fixtures) do
-          dep = source.dependencies.find { |d| d["name"] == "bundler" }
-          assert dep
-          assert_equal "1.16.1", dep["version"]
+      describe "when bundler is a listed dependency" do
+        it "includes bundler as a dependency when included in dependencies" do
+          Dir.chdir(fixtures) do
+            dep = source.dependencies.find { |d| d["name"] == "bundler" }
+            assert dep
+            assert_equal "1.16.1", dep["version"]
+          end
+        end
+
+        it "raises an error if bundle isn't available" do
+          Licensed::Shell.stub(:tool_available?, false) do
+            Dir.chdir(fixtures) do
+              assert_raises do
+                source.dependencies
+              end
+            end
+          end
         end
       end
 

--- a/test/source/bundler_test.rb
+++ b/test/source/bundler_test.rb
@@ -28,14 +28,6 @@ if Licensed::Shell.tool_available?("bundle")
           refute source.enabled?
         end
       end
-
-      it "is false if bundle is not available" do
-        Licensed::Shell.stub(:tool_available?, false) do
-          Dir.chdir(fixtures) do
-            refute source.enabled?
-          end
-        end
-      end
     end
 
     describe "gemfile_path" do

--- a/test/source/bundler_test.rb
+++ b/test/source/bundler_test.rb
@@ -28,6 +28,14 @@ if Licensed::Shell.tool_available?("bundle")
           refute source.enabled?
         end
       end
+
+      it "is false if bundle is not available" do
+        Licensed::Shell.stub(:tool_available?, false) do
+          Dir.chdir(fixtures) do
+            refute source.enabled?
+          end
+        end
+      end
     end
 
     describe "gemfile_path" do
@@ -117,19 +125,9 @@ if Licensed::Shell.tool_available?("bundle")
       end
 
       describe "when bundler is a listed dependency" do
-        it "includes bundler as a dependency when included in dependencies" do
+        it "includes bundler as a dependency" do
           Dir.chdir(fixtures) do
             assert source.dependencies.find { |d| d["name"] == "bundler" }
-          end
-        end
-
-        it "raises an error if bundle isn't available" do
-          Licensed::Shell.stub(:tool_available?, false) do
-            Dir.chdir(fixtures) do
-              assert_raises do
-                source.dependencies
-              end
-            end
           end
         end
       end


### PR DESCRIPTION
Fixes https://github.com/github/licensed/issues/53

This PR updates the bundler source to support finding dependencies in the Bundler source without using Bundler's internal specification `materialize` logic.  It largely aims for unchanged function, though there are two changes called out below.

#### Why
In aiming to be able to distribute a packaged executable of `ruby+licensed`, there were issues with the bundler source.  The executable uses a squashed file system containing ruby, licensed and bundler.  When licensed evaluates a source using the bundler object model, it's using the bundler gem available inside the squashed file system rather than the bundler gem on the host.

When using the bundler gem from the squashed file system, it uses gem information also from inside the squashed file system because it doesn't know about the host file system.  There is a fundamental mismatch which makes sense given that we're running bundler from a separate file system and expecting it to find information from the host automagically.

#### How
Custom logic is added to the bundler source to enumerate specifications that is overall simpler and more straightforward to read through and debug despite having more custom logic in the source.

licensed requires that `bundle install` was already successfully run for dependencies to be enumerated.  As a result, we know that all (*) specifications can be found at `::Bundle.specs_path`.  Both `Gem::Specification` and `::Bundler::Specification` support `#full_name` so we can find the specification using `::Bundle.specs_path.join("#{spec.full_name}.gemspec")`.

**(*)** - There are two exceptions
1. The bundler gemspec itself.  Even when bundler is an explicit Gemfile dependency, it still does not put it's own gemspec under `::Bundler.specs_path`.  More on this in a bit
2. Gemfile dependencies from local gemspecs.  In this scenario we actually don't need to do much.  The realized specification can be obtained from the un-realized specification through `spec.source.specs.first`, where `source` represents the gemspec itself.

It's worth calling out that obtaining the bundler `Gem::Specification` is special cased.  To support the self-contained executable scenario from https://github.com/github/licensed/issues/50, licensed can't use the currently loaded `::Bundler` gem API because it references the gem from the self-contained executable.  It has no knowledge of the host machines Bundler state or installed location.  Instead licensed runs bundler as a separate process on the host machine to find the bundler gem path which is then used to find the specification.

#### Functional changes
1. Bundler is no longer included as a dependency unless it's explicitly called out in the Gemfile.  If the gem hasn't been specified in the Gemfile it's considered a development dependency and filtered.
   - /cc @mlinksva Is this 👍 considering it's likely that bundler is generally assumed to be on the machine and doesn't need to be listed in the Gemfile even when it's a runtime dependency.

2. Configuration overrides for groups to exclude from dependencies is allowed.  Previous functionality is maintained with the default values `:development` and `:test`.