### PR TITLE
Workflow and scripting to build and package distributable exes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,8 +40,8 @@ Pull requests that include a new dependency source must also
 If you are the current maintainer of this gem:
 
 1. Create a branch for the release: git checkout -b cut-release-vxx.xx.xx
-2. Make sure your local dependencies are up to date: script/bootstrap
-3. Ensure that tests are green: bundle exec rake test
+2. Make sure your local dependencies are up to date: `script/bootstrap`
+3. Ensure that tests are green: `bundle exec rake test`
 4. Bump gem version in lib/licensed/version.rb.
 5. Update [`CHANGELOG.md`](CHANGELOG.md)
 6. Make a PR to github/licensed.
@@ -51,8 +51,11 @@ If you are the current maintainer of this gem:
    2. Install the new gem locally
    3. Test behavior locally, branch deploy, whatever needs to happen
 9. Merge github/licensed PR
-10. Tag and push: git tag vx.xx.xx; git push --tags
-11. Push to rubygems.org -- gem push licensed-x.xx.xx.gem
+10. Tag and push: `git tag x.xx.xx; git push --tags`
+11. Push to rubygems.org -- `gem push licensed-x.xx.xx.gem`
+12. Build packages for new tag: `VERSION=x.xx.xx bundle exec rake package`
+13. Create release for new tag at github/licensed.
+14. Add built packages to new release
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ if Licensed::Shell.tool_available?('bundle')
 end
 ```
 
+## Packaging
+
+Licensed can be built into an exe and packaged for distribution to systems that don't have ruby already available.  See the [packaging documentation](./docs/packaging.md) for details.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/github/licensed. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org/) code of conduct.  See [CONTRIBUTING](CONTRIBUTING.md) for more details.

--- a/Rakefile
+++ b/Rakefile
@@ -59,7 +59,7 @@ Rake::TestTask.new(:test) do |t|
 end
 
 packages_search = File.expand_path("script/packages/*", __dir__)
-platforms = Dir[packages_search].map { |f| File.basename(f, ".*")}
+platforms = Dir[packages_search].map { |f| File.basename(f, ".*") }
 
 namespace :package do
   platforms.each do |platform|

--- a/Rakefile
+++ b/Rakefile
@@ -52,29 +52,36 @@ namespace :test do
   end
 end
 
-task :package, [:target] do |task, args|
-  target = args[:target]
-  target = "*" if target.nil? || target.empty?
-  Dir["script/packages/#{target}"].each do |script|
-    puts "Building #{script}"
-
-    if Bundler.with_original_env { system(script) }
-      # green
-      puts "\033[32mCompleted #{script}.\e[0m"
-    else
-      # red
-      puts "\033[31mEncountered an error running #{script}.\e[0m"
-    end
-
-    puts
-  end
-end
-
 Rake::TestTask.new(:test) do |t|
   t.libs << "test"
   t.libs << "lib"
   t.test_files = FileList["test/**/*_test.rb"]
 end
+
+packages_search = File.expand_path("script/packages/*", __dir__)
+platforms = Dir[packages_search].map { |f| File.basename(f, ".*")}
+
+namespace :package do
+  platforms.each do |platform|
+    desc "Package licensed for #{platform}"
+    task platform.to_sym do
+      puts "Packaging licensed for #{platform}"
+
+      if Bundler.with_original_env { system("script/packages/#{platform}") }
+        # green
+        puts "\033[32mCompleted packaging for #{platform}.\e[0m"
+      else
+        # red
+        puts "\033[31mEncountered an error packaging for #{platform}.\e[0m"
+      end
+
+      puts
+    end
+  end
+end
+
+desc "Package licensed for all platforms"
+task package: platforms.map { |platform| "package:#{platform}" }
 
 # add rubocop task
 # -S adds styleguide urls to offense messages

--- a/Rakefile
+++ b/Rakefile
@@ -52,6 +52,24 @@ namespace :test do
   end
 end
 
+task :package, [:target] do |task, args|
+  target = args[:target]
+  target = "*" if target.nil? || target.empty?
+  Dir["script/packages/#{target}"].each do |script|
+    puts "Building #{script}"
+
+    if Bundler.with_original_env { system(script) }
+      # green
+      puts "\033[32mCompleted #{script}.\e[0m"
+    else
+      # red
+      puts "\033[31mEncountered an error running #{script}.\e[0m"
+    end
+
+    puts
+  end
+end
+
 Rake::TestTask.new(:test) do |t|
   t.libs << "test"
   t.libs << "lib"

--- a/docker/Dockerfile.build-linux
+++ b/docker/Dockerfile.build-linux
@@ -1,0 +1,10 @@
+FROM ruby:2.4-slim-stretch
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends cmake make gcc pkg-config squashfs-tools git curl bison \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -L http://enclose.io/rubyc/rubyc-linux-x64.gz | gunzip > /usr/local/bin/rubyc \
+    && chmod +x /usr/local/bin/rubyc
+
+ENV CPPFLAGS="-P"
+ENV RUBYC="/usr/local/bin/rubyc"

--- a/docker/Dockerfile.build-linux
+++ b/docker/Dockerfile.build-linux
@@ -2,8 +2,9 @@ FROM ruby:2.4-slim-stretch
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends cmake make gcc pkg-config squashfs-tools git curl bison \
-    && rm -rf /var/lib/apt/lists/* \
-    && curl -L http://enclose.io/rubyc/rubyc-linux-x64.gz | gunzip > /usr/local/bin/rubyc \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -L http://enclose.io/rubyc/rubyc-linux-x64.gz | gunzip > /usr/local/bin/rubyc \
     && chmod +x /usr/local/bin/rubyc
 
 ENV CPPFLAGS="-P"

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -1,0 +1,40 @@
+# Packaging licensed for distribution
+
+Licensed is built into executables and packaged for distribution using [ruby-packer][ruby-packer].
+
+Executable packages are currently supported for:
+1. Linux
+2. MacOS / Darwin
+
+The packaged executables contain a self-expanding file system containing ruby, licensed and all of it's runtime dependencies.  Licensed is run inside the contained file system, allowing usage in scenarios where ruby is not available on the host system.
+
+### Building packages
+
+Packages are built as `licensed-$VERSION-$PLATFORM-x64.tar.gz` tarballs that contain a single `./licensed` executable.  After building a package through the available scripting, it will be available in the `pkg` directory.
+
+#### Building all packages
+```bash
+# build all packages
+$ script/package
+```
+or
+```bash
+# build all packages
+$ bundle exec rake package
+```
+
+#### Building packages for a single platform
+```bash
+# build package for linux
+$ script/package linux
+```
+or
+```bash
+# build package for linux
+$ bundle exec rake package[linux]
+
+# if using the zsh shell then you'll need to escape the brackets
+$ bundle exec rake package\[linux\]
+```
+
+[ruby-packer]: https://github.com/pmq20/ruby-packer

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -36,10 +36,7 @@ $ script/package linux
 or
 ```bash
 # build package for linux
-$ bundle exec rake package[linux]
-
-# if using the zsh shell then you'll need to escape the brackets
-$ bundle exec rake package\[linux\]
+$ bundle exec rake package:linux
 ```
 
 #### Building packages for a specific version

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -12,6 +12,11 @@ The packaged executables contain a self-expanding file system containing ruby, l
 
 Packages are built as `licensed-$VERSION-$PLATFORM-x64.tar.gz` tarballs that contain a single `./licensed` executable.  After building a package through the available scripting, it will be available in the `pkg` directory.
 
+By default an exe is built for the current licensed git `HEAD`.  The
+`$VERSION` in the package name will be set to the current branch name if
+available, otherwise the current SHA.  To use a specific licensed version,
+set a `VERSION` environment variable when calling the packaging scripts.  `VERSION` can be set to any value that works with `git checkout`.
+
 #### Building all packages
 ```bash
 # build all packages
@@ -35,6 +40,17 @@ $ bundle exec rake package[linux]
 
 # if using the zsh shell then you'll need to escape the brackets
 $ bundle exec rake package\[linux\]
+```
+
+#### Building packages for a specific version
+```bash
+# VERSION can be set to anything that works with git checkout - tag, branch, SHA1
+$ VERSION="1.1.0" script/package
+```
+or
+```bash
+# VERSION can be set to anything that works with git checkout - tag, branch, SHA1
+$ VERSION="1.1.0" bundle exec rake package
 ```
 
 [ruby-packer]: https://github.com/pmq20/ruby-packer

--- a/script/build-rubyc-exe
+++ b/script/build-rubyc-exe
@@ -24,7 +24,7 @@ usage(){
   grep "^#/" <"$0" | cut -c3-
 }
 
-BASE_DIR="$(cd "$(dirname $0)/../.." && pwd)"
+BASE_DIR="$(cd "$(dirname $0)/.." && pwd)"
 if [ ! -f "$RUBYC" ]; then
   echo "Please specify a rubyc compiler" >&2
   usage

--- a/script/build-rubyc-exe
+++ b/script/build-rubyc-exe
@@ -18,13 +18,15 @@
 #/     $ build-rubyc-exe RUBYC="./rubyc-darwin" VERSION="1.1.0"
 #/
 
-set -e
+set -euo pipefail
 
 usage(){
   grep "^#/" <"$0" | cut -c3-
 }
 
 BASE_DIR="$(cd "$(dirname $0)/.." && pwd)"
+VERSION=${VERSION:=""}
+RUBYC=${RUBYC:=""}
 if [ ! -f "$RUBYC" ]; then
   echo "Please specify a rubyc compiler" >&2
   usage

--- a/script/build-rubyc-exe
+++ b/script/build-rubyc-exe
@@ -44,12 +44,15 @@ else
   VERSION="$(git rev-parse --abbrev-ref HEAD)"
 fi
 
+PACKAGE_DEST="$BASE_DIR/pkg"
+mkdir -p "$PACKAGE_DEST"
+
 PLATFORM="$(uname -s | tr '[:upper:]' '[:lower:]')"
-TARGET="licensed-$VERSION-$PLATFORM-x64"
+TARGET="licensed-$VERSION-$PLATFORM-x64.tar.gz"
 
 "$RUBYC" --clean-tmpdir -o "$BUILD_DEST/licensed" "$BASE_DIR/exe/licensed"
 
 chmod +x $BUILD_DEST/licensed
-tar -C "$BUILD_DEST" -czf "$BASE_DIR/pkg/$TARGET.tar.gz" "./licensed"
+tar -C "$BUILD_DEST" -czf "$PACKAGE_DEST/$TARGET" "./licensed"
 
-echo "licensed built to $BASE_DIR/pkg/$TARGET.tar.gz"
+echo "licensed built to $PACKAGE_DEST/$TARGET"

--- a/script/build-rubyc-exe
+++ b/script/build-rubyc-exe
@@ -1,0 +1,53 @@
+#!/bin/bash
+#/ Usage: script/build-rubyc-exe <RUBYC> [VERSION]
+#/
+#/ WARNING: You should not need to call this directly. Please create packages using
+#/ `script/package [platform]` or `bundle exec rake package[platform]`
+#/
+#/ Builds a distributable package for licensed for a given RUBYC compiler and licensed VERSION.
+#/ Packages are of the form licensed-$VERSION-$PLATFORM-x64.tar.gz and contain a `./licensed` executable
+#/ Built Packages are placed in the <root>/pkg directory.
+#/
+#/ OPTIONS:
+#/   <RUBYC>           The path to a rubyc compiler that should be used to compile the target executable
+#/   [VERSION]         (optional, default to current git branch or SHA1) version of licensed to build exe at
+#/
+#/ EXAMPLES:
+#/
+#/   Builds a package for version 1.1.0 using a local rubyc compiler
+#/     $ build-rubyc-exe RUBYC="./rubyc-darwin" VERSION="1.1.0"
+#/
+
+set -e
+
+usage(){
+  grep "^#/" <"$0" | cut -c3-
+}
+
+BASE_DIR="$(cd "$(dirname $0)/../.." && pwd)"
+if [ ! -f "$RUBYC" ]; then
+  echo "Please specify a rubyc compiler" >&2
+  usage
+  exit 127
+fi
+
+BUILD_DEST="$(mktemp -d)"
+trap "rm -rf $BUILD_DEST" EXIT
+
+if [ -n "$VERSION" ]; then
+  git checkout "$VERSION"
+  CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+  trap "rm -rf $BUILD_DEST; git checkout $CURRENT_BRANCH" EXIT
+else
+  VERSION="$(git rev-parse --abbrev-ref HEAD)"
+fi
+
+PLATFORM="$(uname -s | tr '[:upper:]' '[:lower:]')"
+TARGET="licensed-$VERSION-$PLATFORM-x64"
+
+"$RUBYC" --clean-tmpdir -o "$BUILD_DEST/licensed" "$BASE_DIR/exe/licensed"
+
+chmod +x $BUILD_DEST/licensed
+tar -C "$BUILD_DEST" -czf "$BASE_DIR/pkg/$TARGET.tar.gz" "./licensed"
+
+echo "licensed built to $BASE_DIR/pkg/$TARGET.tar.gz"

--- a/script/package
+++ b/script/package
@@ -12,4 +12,9 @@
 
 set -e
 
-bundle exec rake package["$1"]
+PLATFORM=""
+if [ -n "$1" ]; then
+  PLATFORM=":$1"
+fi
+
+bundle exec rake "package$PLATFORM"

--- a/script/package
+++ b/script/package
@@ -1,0 +1,15 @@
+#!/bin/bash
+#/ Usage: script/package [PLATFORM] [VERSION]
+#/
+#/ Builds distributable packages for licensed.
+#/ Packages are of the form licensed-$VERSION-$PLATFORM-x64.tar.gz and contain a `./licensed` executable
+#/ Built packages are placed in the <root>/pkg directory.
+#/
+#/ OPTIONS:
+#/   [PLATFORM]        (optional, default to all platforms) platform to build exe for
+#/   [VERSION]         (optional, default to current git branch or SHA1) version of licensed to build exe at
+#/
+
+set -e
+
+bundle exec rake package["$1"]

--- a/script/packages/linux
+++ b/script/packages/linux
@@ -1,0 +1,50 @@
+#!/bin/bash
+#/ Usage: script/packages/linux [VERSION]
+#/
+#/ WARNING: You should not need to call this directly. Please create packages using
+#/ `script/package [platform]` or `bundle exec rake package[platform]`
+#/
+#/ Builds a linux distributable package for licensed for a given and licensed VERSION.
+#/ Packages are of the form licensed-$VERSION-linux-x64.tar.gz and contain a `./licensed` executable
+#/ Built packages are placed in the <root>/pkg directory.
+#/
+#/ If calling from a non-linux OS, docker is used to build a linux binary
+#/
+#/ OPTIONS:
+#/   [VERSION]         (optional, default to current git branch or SHA1) version of licensed to build exe at
+#/
+
+set -e
+
+BASE_DIR="$(cd "$(dirname $0)/../.." && pwd)"
+
+build_linux_docker() {
+  IMAGE="licensed/build-linux"
+  docker build -t "$IMAGE" - < "$BASE_DIR/docker/Dockerfile.build-linux"
+  docker run --rm \
+    -e VERSION="$VERSION" \
+    -v "$BASE_DIR":/var/licensed \
+    -w /var/licensed \
+    "$IMAGE" \
+    "script/build-rubyc-exe"
+}
+
+build_linux_local() {
+  sudo apt-get update && \
+       apt-get install -y --no-install-recommends cmake make gcc pkg-config squashfs-tools curl bison git
+
+  if [ ! -f "$BASE_DIR/bin/rubyc-linux" ]; then
+    mkdir -p "$BASE_DIR/bin"
+    curl -L http://enclose.io/rubyc/rubyc-linux-x64.gz | gunzip > "$BASE_DIR/bin/rubyc-linux"
+    chmod +x "$BASE_DIR/bin/rubyc-linux"
+  fi
+
+  export CPPFLAGS="-P"
+  RUBYC="$BASE_DIR/bin/rubyc-linux" "$BASE_DIR"/script/build-rubyc-exe
+}
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+  build_linux_docker
+else
+  build_linux_local
+fi

--- a/script/packages/linux
+++ b/script/packages/linux
@@ -14,9 +14,10 @@
 #/   [VERSION]         (optional, default to current git branch or SHA1) version of licensed to build exe at
 #/
 
-set -e
+set -euo pipefail
 
 BASE_DIR="$(cd "$(dirname $0)/../.." && pwd)"
+VERSION=${VERSION:=""}
 
 build_linux_docker() {
   IMAGE="licensed/build-linux"

--- a/script/packages/mac
+++ b/script/packages/mac
@@ -14,7 +14,7 @@
 #/   [VERSION]         (optional, default to current git branch or SHA1) version of licensed to build exe at
 #/
 
-set -e
+set -euo pipefail
 
 if [[ "$(uname -s)" != "Darwin" ]]; then
   echo "A Mac OS is required to build a licensed executable for mac" >&2

--- a/script/packages/mac
+++ b/script/packages/mac
@@ -18,7 +18,7 @@ set -e
 
 if [[ "$(uname -s)" != "Darwin" ]]; then
   echo "A Mac OS is required to build a licensed executable for mac" >&2
-  exit 0
+  exit 1
 fi
 
 BASE_DIR="$(cd "$(dirname $0)/../.." && pwd)"

--- a/script/packages/mac
+++ b/script/packages/mac
@@ -1,0 +1,35 @@
+#!/bin/bash
+#/ Usage: script/packages/mac [VERSION]
+#/
+#/ WARNING: You should not need to call this directly. Please create packages using
+#/ `script/package [platform]` or `bundle exec rake package[platform]`
+#/
+#/ Builds a mac distributable package for licensed for a given licensed VERSION.
+#/ Packages are of the form licensed-$VERSION-darwin-x64.tar.gz and contain a `./licensed` executable
+#/ Built packages are placed in the <root>/pkg directory.
+#/
+#/ Must be called from a Mac OS.
+#/
+#/ OPTIONS:
+#/   [VERSION]         (optional, default to current git branch or SHA1) version of licensed to build exe at
+#/
+
+set -e
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "A Mac OS is required to build a licensed executable for mac" >&2
+  exit 0
+fi
+
+BASE_DIR="$(cd "$(dirname $0)/../.." && pwd)"
+
+brew update
+brew list "squashfs" &>/dev/null || brew install "squashfs"
+
+if [ ! -f "$BASE_DIR/bin/rubyc-darwin" ]; then
+  mkdir -p "$BASE_DIR/bin"
+  curl -L http://enclose.io/rubyc/rubyc-darwin-x64.gz | gunzip > "$BASE_DIR/bin/rubyc-darwin"
+  chmod +x "$BASE_DIR/bin/rubyc-darwin"
+fi
+
+RUBYC="$BASE_DIR/bin/rubyc-darwin" "$BASE_DIR"/script/build-rubyc-exe


### PR DESCRIPTION
Fixes https://github.com/github/licensed/issues/50.  Docker images are still interesting to consider however having an executable publicly available to download makes it fairly easy to use licensed from any existing docker image.

This PR introduces scripting for building licensed executables with [`ruby-packer`/`rubyc`](https://github.com/pmq20/ruby-packer).  The default `package` rake task is overridden to run the package scripting.

Building executables for a platform needs to happen on that platform, and this PR uses docker to try and make building packages as cross-platform as possible.  It currently includes packaging scripts for mac and linux.  

Building for windows is not supported.  I don't have a windows environment available to build windows exes, though if this approach is 👍 I'm going to open an issue to investigate if any of the [microsoft docker images](https://hub.docker.com/u/microsoft/) would suffice.  Licensed needs a few tweaks to work on windows anyways so this isn't yet the highest priority.

Building a mac exe needs to happen from MacOS due to (AFAIK) there not being any suitable mac docker images.

Building a linux exe can happen on any environment due to the abundance of linux images.  If a user is already on linux, building the linux exe will happen on the host system.

Note: Executables for versions 1.1.0 and prior will not work for sourcing bundler dependencies - please see https://github.com/github/licensed/pull/54 for a description and fix.