### PR TITLE
[Manifest] Use licenses from source file comments if license is not otherwise found

### DIFF
--- a/docs/sources/manifests.md
+++ b/docs/sources/manifests.md
@@ -24,3 +24,35 @@ File paths are relative to the git repository root.  Package names will be used 
 If multiple source files map to a single package and they share a common path under the git repository root, that directory will be used to find license information, if available.
 
 It is the responsibility of the repository owner to maintain the manifest file.
+
+### Finding license content from source file comments
+
+When a file containing license content is not found for a group of source files,
+Licensed will attempt to parse license text from source file comments.
+
+There are some limitations on this functionality:
+
+1. Comments MUST contain a copyright statement
+2. Comments MUST be C-style multiline comments, e.g. `/* comment */`
+3. Comments SHOULD contain identical indentation for each content line.
+
+The following examples are all :+1:.  Licensed will try to preserve formatting,
+however for best results comments should not mix tabs and spaces in leading whitespace.
+```
+/*
+   <copyright statement>
+
+   <license text>
+ */
+
+/* <copyright statement>
+   <license text>
+ */
+
+/*
+ * <copyright statement>
+ * <license text>
+ *
+ * <license text>
+ */
+```

--- a/lib/licensed/dependency.rb
+++ b/lib/licensed/dependency.rb
@@ -37,7 +37,7 @@ module Licensed
     # `dependency["license"]` and legal text is set to `dependency.text`
     def detect_license!
       self["license"] = license_key
-      self.text = [license_text, *notices].join("\n" + TEXT_SEPARATOR + "\n").strip
+      self.text = [license_text, *notices].join("\n" + TEXT_SEPARATOR + "\n").rstrip
     end
 
     # Extract legal notices from the dependency source
@@ -45,7 +45,7 @@ module Licensed
       local_files.uniq # unique local file paths
            .sort # sorted by the path
            .map { |f| File.read(f) } # read the file contents
-           .map(&:strip) # strip whitespace
+           .map(&:rstrip) # strip whitespace
            .select { |t| t.length > 0 } # files with content only
     end
 

--- a/lib/licensed/dependency.rb
+++ b/lib/licensed/dependency.rb
@@ -65,14 +65,12 @@ module Licensed
 
     private
 
+    # Resets all local project and license information
     def reset_license!
       @project = nil
       @matched_project_file = nil
       self.delete("license")
       self.text = nil
-
-      # don't need to reset @remote_license_file as it's not affected by path or
-      # project resets
     end
 
     # Returns the Licensee::ProjectFile representing the matched_project_file

--- a/lib/licensed/license.rb
+++ b/lib/licensed/license.rb
@@ -54,7 +54,7 @@ module Licensed
       # if the text didn't contain the separator, the text itself is the entirety
       # of the license text
       split = text.split(TEXT_SEPARATOR)
-      split.length > 1 ? split.first.strip : text.strip
+      split.length > 1 ? split.first.rstrip : text.rstrip
     end
     alias_method :content, :license_text # use license_text for content matching
 

--- a/lib/licensed/license.rb
+++ b/lib/licensed/license.rb
@@ -11,6 +11,7 @@ module Licensed
 
     YAML_FRONTMATTER_PATTERN = /\A---\s*\n(.*?\n?)^---\s*$\n?(.*)\z/m
     TEXT_SEPARATOR = ("-" * 80).freeze
+    LICENSE_SEPARATOR = ("*" * 80).freeze
 
     # Read an existing license file
     #

--- a/lib/licensed/license.rb
+++ b/lib/licensed/license.rb
@@ -23,7 +23,7 @@ module Licensed
       new(YAML.load(match[1]), match[2])
     end
 
-    def_delegators :@metadata, :[], :[]=
+    def_delegators :@metadata, :[], :[]=, :delete
 
     # The license text and other legal notices
     attr_accessor :text

--- a/lib/licensed/source/manifest.rb
+++ b/lib/licensed/source/manifest.rb
@@ -28,6 +28,9 @@ module Licensed
 
       # Returns the top-most directory that is common to all paths in `sources`
       def sources_license_path(sources)
+        # return the source directory if there is only one source given
+        return source_directory(sources[0]) if sources.size == 1
+
         common_prefix = Pathname.common_prefix(*sources).to_path
 
         # don't allow the repo root to be used as common prefix
@@ -35,8 +38,15 @@ module Licensed
         # or ignored in the config.  any license in the root should be ignored.
         return common_prefix if common_prefix != Licensed::Git.repository_root
 
-        # use the first source file as the license path.
-        sources.first
+        # use the first source directory as the license path.
+        source_directory(sources.first)
+      end
+
+      # Returns the directory for the source.  Checks whether the source
+      # is a file or a directory
+      def source_directory(source)
+        return File.dirname(source) if File.file?(source)
+        source
       end
 
       # Returns the latest git SHA available from `sources`

--- a/lib/licensed/source/manifest.rb
+++ b/lib/licensed/source/manifest.rb
@@ -64,7 +64,7 @@ module Licensed
       end
 
       class Dependency < Licensed::Dependency
-        ANY_EXCEPT_COMMENT_CLOSE_REGEX = /(\*(?!\/)|[^*])*/m.freeze
+        ANY_EXCEPT_COMMENT_CLOSE_REGEX = /(\*(?!\/)|[^\*])*/m.freeze
         HEADER_LICENSE_REGEX = /
           \/\*
             (#{ANY_EXCEPT_COMMENT_CLOSE_REGEX}#{Licensee::Matchers::Copyright::COPYRIGHT_SYMBOLS}#{ANY_EXCEPT_COMMENT_CLOSE_REGEX})

--- a/lib/licensed/source/manifest.rb
+++ b/lib/licensed/source/manifest.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 require "pathname/common_prefix"
+require "tmpdir"
+require "fileutils"
 
 module Licensed
   module Source
@@ -18,35 +20,12 @@ module Licensed
 
       def dependencies
         @dependencies ||= packages.map do |package_name, sources|
-          Dependency.new(sources_license_path(sources), {
+          Dependency.new(sources, {
             "type"     => Manifest.type,
             "name"     => package_name,
             "version"  => package_version(sources)
           })
         end
-      end
-
-      # Returns the top-most directory that is common to all paths in `sources`
-      def sources_license_path(sources)
-        # return the source directory if there is only one source given
-        return source_directory(sources[0]) if sources.size == 1
-
-        common_prefix = Pathname.common_prefix(*sources).to_path
-
-        # don't allow the repo root to be used as common prefix
-        # the project this is run for should be excluded from the manifest,
-        # or ignored in the config.  any license in the root should be ignored.
-        return common_prefix if common_prefix != Licensed::Git.repository_root
-
-        # use the first source directory as the license path.
-        source_directory(sources.first)
-      end
-
-      # Returns the directory for the source.  Checks whether the source
-      # is a file or a directory
-      def source_directory(source)
-        return File.dirname(source) if File.file?(source)
-        source
       end
 
       # Returns the latest git SHA available from `sources`
@@ -84,6 +63,90 @@ module Licensed
         return Licensed::Git.repository_root.join(path) if path
 
         @config.cache_path.join("manifest.json")
+      end
+
+      class Dependency < Licensed::Dependency
+        ANY_EXCEPT_COMMENT_CLOSE_REGEX = /(\*(?!\/)|[^*])*/m.freeze
+        HEADER_LICENSE_REGEX = /
+          \/\*
+            (#{ANY_EXCEPT_COMMENT_CLOSE_REGEX}copyright#{ANY_EXCEPT_COMMENT_CLOSE_REGEX})
+          \*\/
+        /imx.freeze
+
+        def initialize(sources, metadata = {})
+          @sources = sources
+          super sources_license_path(sources), metadata
+        end
+
+        # Detects license information and sets it on this dependency object.
+        #  After calling `detect_license!``, the license is set at
+        # `dependency["license"]` and legal text is set to `dependency.text`
+        def detect_license!
+          tmp = nil
+
+          # if no license key is found for the project, try to create a
+          # temporary LICENSE file from unique source file license headers
+          if license_key == "none"
+            tmp = Dir.mktmpdir
+            write_license_from_source_licenses(tmp, @sources)
+            self.path = tmp
+          end
+
+          super
+        ensure
+          FileUtils.rm_rf(tmp) if tmp && File.exist?(tmp)
+        end
+
+        private
+
+        # Returns the top-most directory that is common to all paths in `sources`
+        def sources_license_path(sources)
+          # return the source directory if there is only one source given
+          return source_directory(sources[0]) if sources.size == 1
+
+          common_prefix = Pathname.common_prefix(*sources).to_path
+
+          # don't allow the repo root to be used as common prefix
+          # the project this is run for should be excluded from the manifest,
+          # or ignored in the config.  any license in the root should be ignored.
+          return common_prefix if common_prefix != Licensed::Git.repository_root
+
+          # use the first source directory as the license path.
+          source_directory(sources.first)
+        end
+
+        # Returns the directory for the source.  Checks whether the source
+        # is a file or a directory
+        def source_directory(source)
+          return File.dirname(source) if File.file?(source)
+          source
+        end
+
+        # Writes any licenses found in source file comments to a LICENSE
+        # file at `dir`
+        # Returns the path to the license file
+        def write_license_from_source_licenses(dir, sources)
+          license_path = File.join(dir, "LICENSE")
+          File.open(license_path, 'w') do |f|
+            licenses = source_comment_licenses(sources).uniq
+            f.puts(licenses.join("\n#{LICENSE_SEPARATOR}\n"))
+          end
+
+          license_path
+        end
+
+        # Returns a list of unique licenses parsed from source comments
+        def source_comment_licenses(sources)
+          comments = sources.select { |s| File.file?(s) }.flat_map do |source|
+            content = File.read(source)
+            content.scan(HEADER_LICENSE_REGEX).map { |match| match[0] }
+          end
+
+          comments.map do |comment|
+            # strip leading "*" and whitespace
+            comment.lines.map { |line| line[/(\s*\*)?(.*)/m, 2].lstrip }.join
+          end
+        end
       end
     end
   end

--- a/lib/licensed/source/manifest.rb
+++ b/lib/licensed/source/manifest.rb
@@ -150,7 +150,7 @@ module Licensed
               # insert newline for each line until a word character is found
               next "\n" unless indent
 
-              line[/([^\r\n]{0,#{indent}})(.*)/m, 2]
+              line[/([^\w\r\n]{0,#{indent}})(.*)/m, 2]
             end.join
           end
         end

--- a/lib/licensed/source/manifest.rb
+++ b/lib/licensed/source/manifest.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 require "pathname/common_prefix"
-require "tmpdir"
-require "fileutils"
 
 module Licensed
   module Source
@@ -82,19 +80,16 @@ module Licensed
         #  After calling `detect_license!``, the license is set at
         # `dependency["license"]` and legal text is set to `dependency.text`
         def detect_license!
-          tmp = nil
-
           # if no license key is found for the project, try to create a
           # temporary LICENSE file from unique source file license headers
           if license_key == "none"
-            tmp = Dir.mktmpdir
-            write_license_from_source_licenses(tmp, @sources)
-            self.path = tmp
+            tmp_license_file = write_license_from_source_licenses(self.path, @sources)
+            reset_license!
           end
 
           super
         ensure
-          FileUtils.rm_rf(tmp) if tmp && File.exist?(tmp)
+          File.delete(tmp_license_file) if tmp_license_file && File.exist?(tmp_license_file)
         end
 
         private

--- a/lib/licensed/source/manifest.rb
+++ b/lib/licensed/source/manifest.rb
@@ -127,7 +127,7 @@ module Licensed
         # Returns the path to the license file
         def write_license_from_source_licenses(dir, sources)
           license_path = File.join(dir, "LICENSE")
-          File.open(license_path, 'w') do |f|
+          File.open(license_path, "w") do |f|
             licenses = source_comment_licenses(sources).uniq
             f.puts(licenses.join("\n#{LICENSE_SEPARATOR}\n"))
           end

--- a/lib/licensed/source/manifest.rb
+++ b/lib/licensed/source/manifest.rb
@@ -69,7 +69,7 @@ module Licensed
         ANY_EXCEPT_COMMENT_CLOSE_REGEX = /(\*(?!\/)|[^*])*/m.freeze
         HEADER_LICENSE_REGEX = /
           \/\*
-            (#{ANY_EXCEPT_COMMENT_CLOSE_REGEX}copyright#{ANY_EXCEPT_COMMENT_CLOSE_REGEX})
+            (#{ANY_EXCEPT_COMMENT_CLOSE_REGEX}#{Licensee::Matchers::Copyright::COPYRIGHT_SYMBOLS}#{ANY_EXCEPT_COMMENT_CLOSE_REGEX})
           \*\/
         /imx.freeze
 

--- a/test/dependency_test.rb
+++ b/test/dependency_test.rb
@@ -133,7 +133,7 @@ describe Licensed::Dependency do
 
         # the text should always start with license text (even if empty),
         # followed by a separator if there are any legal notices
-        assert_match(/\A#{Licensed::License::TEXT_SEPARATOR}\n/, dependency.text)
+        assert_match(/\A\n#{Licensed::License::TEXT_SEPARATOR}\n/, dependency.text)
       end
     end
 

--- a/test/fixtures/manifest/manifest.json
+++ b/test/fixtures/manifest/manifest.json
@@ -6,5 +6,6 @@
   "test/fixtures/manifest/single_license_header/source_2.c": "bsd3_single_header_license",
   "test/fixtures/manifest/multiple_license_headers/source.c": "bsd3_multi_header_license",
   "test/fixtures/manifest/multiple_license_headers/source_2.c": "bsd3_multi_header_license",
-  "test/fixtures/manifest/with_license_file/source.c": "mit_license_file"
+  "test/fixtures/manifest/with_license_file/source.c": "mit_license_file",
+  "test/fixtures/manifest/with_notices/source.c": "notices"
 }

--- a/test/fixtures/manifest/manifest.json
+++ b/test/fixtures/manifest/manifest.json
@@ -1,5 +1,10 @@
 {
   "test/fixtures/manifest/test_1.c": "manifest_test",
   "test/fixtures/manifest/subfolder/test_2.c": "manifest_test",
-  "script/console": "other"
+  "script/console": "other",
+  "test/fixtures/manifest/single_license_header/source.c": "bsd3_single_header_license",
+  "test/fixtures/manifest/single_license_header/source_2.c": "bsd3_single_header_license",
+  "test/fixtures/manifest/multiple_license_headers/source.c": "bsd3_multi_header_license",
+  "test/fixtures/manifest/multiple_license_headers/source_2.c": "bsd3_multi_header_license",
+  "test/fixtures/manifest/with_license_file/source.c": "mit_license_file"
 }

--- a/test/fixtures/manifest/manifest.yml
+++ b/test/fixtures/manifest/manifest.yml
@@ -6,3 +6,4 @@ test/fixtures/manifest/single_license_header/source_2.c: bsd3_single_header_lice
 test/fixtures/manifest/multiple_license_headers/source.c: bsd3_multi_header_license
 test/fixtures/manifest/multiple_license_headers/source_2.c: bsd3_multi_header_license
 test/fixtures/manifest/with_license_file/source.c: mit_license_file
+test/fixtures/manifest/with_notices/source.c: notices

--- a/test/fixtures/manifest/manifest.yml
+++ b/test/fixtures/manifest/manifest.yml
@@ -1,3 +1,8 @@
 test/fixtures/manifest/test_1.c: manifest_test
 test/fixtures/manifest/subfolder/test_2.c: manifest_test
 script/console: other
+test/fixtures/manifest/single_license_header/source.c: bsd3_single_header_license
+test/fixtures/manifest/single_license_header/source_2.c: bsd3_single_header_license
+test/fixtures/manifest/multiple_license_headers/source.c: bsd3_multi_header_license
+test/fixtures/manifest/multiple_license_headers/source_2.c: bsd3_multi_header_license
+test/fixtures/manifest/with_license_file/source.c: mit_license_file

--- a/test/fixtures/manifest/multiple_license_headers/source.c
+++ b/test/fixtures/manifest/multiple_license_headers/source.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 GitHub
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+ #include <stdio.h>
+
+ int main()
+ {
+   printf("I have a license!");
+ }

--- a/test/fixtures/manifest/multiple_license_headers/source_2.c
+++ b/test/fixtures/manifest/multiple_license_headers/source_2.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 GitHub, Foo-Corp
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+ #include <stdio.h>
+
+ int main()
+ {
+   printf("I have a license!");
+ }

--- a/test/fixtures/manifest/single_license_header/source.c
+++ b/test/fixtures/manifest/single_license_header/source.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 GitHub
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+ #include <stdio.h>
+
+ int main()
+ {
+   printf("I have a license!");
+ }

--- a/test/fixtures/manifest/single_license_header/source_2.c
+++ b/test/fixtures/manifest/single_license_header/source_2.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 GitHub
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+ #include <stdio.h>
+
+ int main()
+ {
+   printf("I have a license!");
+ }

--- a/test/fixtures/manifest/with_license_file/LICENSE
+++ b/test/fixtures/manifest/with_license_file/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 GitHub
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/test/fixtures/manifest/with_license_file/source.c
+++ b/test/fixtures/manifest/with_license_file/source.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 GitHub
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+ #include <stdio.h>
+
+ int main()
+ {
+   printf("I have a license, which shouldn't be used!");
+ }

--- a/test/fixtures/manifest/with_notices/COPYING
+++ b/test/fixtures/manifest/with_notices/COPYING
@@ -1,0 +1,9 @@
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum sed mollis
+magna. Integer vehicula condimentum justo, a ornare urna congue sit amet.
+Nulla quis hendrerit metus, eu iaculis dui. Integer vitae turpis sapien.
+Maecenas sed ultrices mauris. Nunc posuere dictum malesuada. Cras sapien eros,
+pulvinar vitae orci sed, euismod pretium lectus. Sed varius sodales dui, quis
+lobortis turpis elementum in. Vestibulum accumsan lectus eget ipsum rutrum,
+quis malesuada elit euismod. Proin porta sem posuere tempor gravida. Duis
+lacinia diam in neque faucibus, sed egestas erat suscipit. Aenean blandit diam
+sem.

--- a/test/fixtures/manifest/with_notices/source.c
+++ b/test/fixtures/manifest/with_notices/source.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 GitHub
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+int main() { }

--- a/test/source/manifest_test.rb
+++ b/test/source/manifest_test.rb
@@ -66,6 +66,14 @@ describe Licensed::Source::Manifest do
       refute_nil dep.text
       assert dep.text.include?(Licensed::License::LICENSE_SEPARATOR)
     end
+
+    it "preserves legal notices when detecting license content from comments" do
+      dep = source.dependencies.detect { |d| d["name"] == "notices" }
+      assert dep
+      dep.detect_license!
+      refute_nil dep.text
+      assert dep.text.include?(dep.notices.join("\n#{Licensed::License::TEXT_SEPARATOR}\n").strip)
+    end
   end
 
   describe "manifest" do

--- a/test/source/manifest_test.rb
+++ b/test/source/manifest_test.rb
@@ -53,6 +53,9 @@ describe Licensed::Source::Manifest do
       assert_equal "bsd-3-clause", dep["license"]
       refute_nil dep.text
       refute dep.text.include?(Licensed::License::LICENSE_SEPARATOR)
+
+      # verify that the license file was removed after evaluation
+      refute File.exist?(File.join(dep.path, "LICENSE"))
     end
 
     it "detects unique license content from multiple headers" do


### PR DESCRIPTION
Fixes https://github.com/github/licensed/issues/59

This PR updates the manifest dependency enumerator to parse unique license content from source file comments when license content is not otherwise found.

The manifest source uses a specialized `Dependency` class that has a backup implementation for finding license content if `license_key` is "none".  When needed, it will pull all unique comments containing `copyright` text into a separate `LICENSE` file which is then used by `licensee` to determine the license.

Questions
1. How should we handle when there is both a LICENSE type file, and license content in source file comments?  Currently this is not looking at source files if a license is found, even when it's "other".
2. `Licensed::Source::Manifest::Dependency` is only checking the license key when determining whether to pull license content from source files.  Do we need to also consider legal notices?
3. License content is being found based on whether a comment contains the word `copyright`.  Is that appropriate, or is there better content to match on that is more indicative of the comment containing licensing content?