### PR TITLE
[Manifest] Specify files for the manifest source in the configuration

### DIFF
--- a/docs/sources/manifests.md
+++ b/docs/sources/manifests.md
@@ -1,6 +1,16 @@
 # Manifests
 
-The manifest source can be used when no package managers are available.
+The manifest source can be used when no package managers are available.  The manifest source will be enabled when a manifest file is found or a manifest is configured in the configuration file.
+
+## Manifest sources
+
+A dependency file manifest can be specified in two ways - a dependency manifest file or in the licensed configuration file as a set of patterns used to find files.
+
+Manifests are loaded from (in order)
+- A manifest file, if found
+- The licensed configuration file, if a manifest file is not found and the `manifest.dependencies` configuration property exists.
+
+### Manifest files
 
 Manifest files are used to match source files with their corresponding packages to find package dependencies.  Manifest file paths can be specified in the app configuration with the following setting:
 ```yml
@@ -19,13 +29,81 @@ The manifest can be a JSON or YAML file with a single root object and properties
 }
 ```
 
-File paths are relative to the git repository root.  Package names will be used for the metadata file names at `path/to/cache/manifest/<package>.txt`
+File paths are relative to the git repository root.  A metadata file, `path/to/cache/manifest/<package>.txt`, will be created for each package.
+
+**NOTE** It is the responsibility of the repository owner to maintain the manifest file.
+
+### Configured manifest
+
+Manifests can be specified using patterns specified in the configuration file.
+
+Dependencies are specified at the `manifest.dependencies` configuration property and should map dependency names to one or more patterns of files matching the dependencies.
+
+In the following example, there are two dependencies, `package` and `nested`, where `nested` is a sub-dependency in the `vendor/package` folder.  Using inclusion and exclusion patterns we can specify that files in the `vendor/package/nested` folder belong to the `nested` package, while all other files belong to `package`.
+
+```yaml
+manifest:
+  dependencies:
+    package:
+      - "vendor/package/**/*"
+      - "!vendor/package/nested/*"
+    nested: "vendor/package/nested/*"
+```
+
+This demonstrates that
+1. Dependencies can be mapped to a string or an array of strings
+2. Inclusion and exclusion patterns apply
+3. Patterns follow a glob-style format
+
+#### Pattern format
+
+Patterns are evaluated using [Dir.glob](https://ruby-doc.org/core/Dir.html#method-c-glob) and must follow these rules:
+1. Patterns are evaluated from the project root directory
+2. Patterns will only match files that are tracked by Git
+3. Patterns should follow standard shell glob syntax
+4. Patterns are evaluated in the order specified - order matters!
+5. `!` can be appended to any pattern to indicate a negative pattern
+   - Negative patterns exclude matching files from the result set
+   - If a pattern should match files starting with `!`, escape the leading `!` with `\` -> `\!filename`
+6. Patterns will match dotfiles
+
+**NOTE** If the first, or only, pattern for a dependency is a negative pattern, it will not affect the set of files matched to a dependency.  An inclusion pattern should always be specified before any negative patterns for a dependency.
+
+#### Restrictions for specifying dependency patterns via configuration
+
+The following restrictions will raise errors if they are not met when specifying manifest dependency patterns in the configuration file
+
+1. The dependencies key is specified but is empty
+2. A file in the project is not attributed to any of the configured dependencies
+   - The manifest by default will track all files in the project to ensure that license metadata updates occur when dependencies change
+   - See [Globally excluding files](#globally-excluding-files) to limit the scope of files that are tracked
+3. A file in the project is attributed to multiple configured dependencies
+   - All files must be tracked by a single dependency
+
+#### Globally excluding files
+
+Tracking project files is needed to make sure that any changes to dependencies does not go unnoticed.  What about non-dependency code?
+
+To reduce friction on changes to project code, global exclusion patterns can be added to the configuration that will cause any matching files to **NOT** be tracked as a dependency of the project.
+
+Global exclusion patterns follow the same rules as [dependency patterns](#pattern-format) and are set on the `manifest.exclude` property.
+
+The following example excludes all files that are not under the `vendor` folder.
+
+```yaml
+manifest:
+  exclude:
+    - "**/*"
+    - "!vendor/**/*"
+```
+
+## Finding license content
+
+### From common source file directories
 
 If multiple source files map to a single package and they share a common path under the git repository root, that directory will be used to find license information, if available.
 
-It is the responsibility of the repository owner to maintain the manifest file.
-
-### Finding license content from source file comments
+### From source file comments
 
 When a file containing license content is not found for a group of source files,
 Licensed will attempt to parse license text from source file comments.

--- a/lib/licensed/git.rb
+++ b/lib/licensed/git.rb
@@ -37,7 +37,8 @@ module Licensed
 
       def files
         return unless available?
-        Licensed::Shell.execute("git", "ls-tree", "--full-tree", "-r", "--name-only", "HEAD")
+        output = Licensed::Shell.execute("git", "ls-tree", "--full-tree", "-r", "--name-only", "HEAD")
+        output.lines.map(&:strip)
       end
     end
   end

--- a/lib/licensed/git.rb
+++ b/lib/licensed/git.rb
@@ -34,6 +34,11 @@ module Licensed
         return unless available? && sha
         Licensed::Shell.execute("git", "show", "-s", "-1", "--format=%ct", sha)
       end
+
+      def files
+        return unless available?
+        Licensed::Shell.execute("git", "ls-tree", "--full-tree", "-r", "--name-only", "HEAD")
+      end
     end
   end
 end

--- a/lib/licensed/source/manifest.rb
+++ b/lib/licensed/source/manifest.rb
@@ -18,11 +18,12 @@ module Licensed
 
       def dependencies
         @dependencies ||= packages.map do |package_name, sources|
-          Dependency.new(sources, {
-            "type"     => Manifest.type,
-            "name"     => package_name,
-            "version"  => package_version(sources)
-          })
+          Licensed::Source::Manifest::Dependency.new(sources, {
+              "type"     => Manifest.type,
+              "name"     => package_name,
+              "version"  => package_version(sources)
+            }
+          )
         end
       end
 

--- a/lib/licensed/source/manifest.rb
+++ b/lib/licensed/source/manifest.rb
@@ -13,7 +13,7 @@ module Licensed
       end
 
       def enabled?
-        File.exist?(manifest_path)
+        File.exist?(manifest_path) || generate_manifest?
       end
 
       def dependencies
@@ -45,8 +45,10 @@ module Licensed
         end
       end
 
-      # Returns parsed manifest data for the app
+      # Returns parsed or generated manifest data for the app
       def manifest
+        return generate_manifest if generate_manifest?
+
         case manifest_path.extname.downcase.delete "."
         when "json"
           JSON.parse(File.read(manifest_path))
@@ -57,10 +59,96 @@ module Licensed
 
       # Returns the manifest location for the app
       def manifest_path
-        path = @config["manifest"]["path"] if @config["manifest"]
+        path = @config.dig("manifest", "path")
         return Licensed::Git.repository_root.join(path) if path
 
         @config.cache_path.join("manifest.json")
+      end
+
+      # Returns whether a manifest should be generated automatically
+      def generate_manifest?
+        !File.exist?(manifest_path) && !@config.dig("manifest", "dependencies").nil?
+      end
+
+      # Returns a manifest of files generated automatically based on patterns
+      # set in the licensed configuration file
+      def generate_manifest
+        verify_configured_dependencies!
+        configured_dependencies.each_with_object({}) do |(name, files), hsh|
+          files.each { |f| hsh[f] = name }
+        end
+      end
+
+      # Verify that the licensed configuration file is valid for the current project.
+      # Raises errors for issues found with configuration
+      def verify_configured_dependencies!
+        # verify that dependencies are configured
+        if configured_dependencies.empty?
+          raise "The manifest \"dependencies\" cannot be empty!"
+        end
+
+        # verify all included files match a single configured dependency
+        errors = included_files.map do |file|
+          matches = configured_dependencies.select { |name, files| files.include?(file) }
+                                           .map { |name, files| name }
+          case matches.size
+          when 0
+            "#{file} did not match a configured dependency"
+          when 1
+            nil
+          else
+            "#{file} matched multiple configured dependencies: #{matches.join(", ")}"
+          end
+        end
+
+        errors.compact!
+        raise errors.join($/) unless errors.empty?
+      end
+
+      # Returns the project dependencies specified from the licensed configuration
+      def configured_dependencies
+        @configured_dependencies ||= begin
+          dependencies = @config.dig("manifest", "dependencies")&.dup || {}
+
+          dependencies.each do |name, patterns|
+            # map glob pattern(s) listed for the dependency to a listing
+            # of files that match the patterns and are not excluded
+            dependencies[name] = files_from_pattern_list(patterns) & included_files
+          end
+
+          dependencies
+        end
+      end
+
+      # Returns the set of project files that are included in dependency evaluation
+      def included_files
+        @sources ||= all_files - files_from_pattern_list(@config.dig("manifest", "exclude"))
+      end
+
+      # Finds and returns all files in the project that match
+      # the glob pattern arguments.
+      def files_from_pattern_list(patterns)
+        return Set.new if patterns.nil? || patterns.empty?
+
+        # evaluate all patterns from the project root
+        Dir.chdir Licensed::Git.repository_root do
+          Array(patterns).reduce(Set.new) do |files, pattern|
+            if pattern.start_with?("!")
+              # if the pattern is an exclusion, remove all matching files
+              # from the result
+              files - Dir.glob(pattern[1..-1], File::FNM_DOTMATCH)
+            else
+              # if the pattern is an inclusion, add all matching files
+              # to the result
+              files + Dir.glob(pattern, File::FNM_DOTMATCH)
+            end
+          end
+        end
+      end
+
+      # Returns all tracked files in the project
+      def all_files
+        @all_files ||= Set.new(Licensed::Git.files || [])
       end
 
       class Dependency < Licensed::Dependency

--- a/test/fixtures/manifest/generated_manifest/nested/nested.c
+++ b/test/fixtures/manifest/generated_manifest/nested/nested.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 GitHub
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+ #include <stdio.h>
+
+ int main()
+ {
+   printf("I have a license, which shouldn't be used!");
+ }

--- a/test/fixtures/manifest/generated_manifest/source.c
+++ b/test/fixtures/manifest/generated_manifest/source.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 GitHub
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+ #include "source.h"
+
+ void say_hi()
+ {
+   printf("I have a license, which shouldn't be used!");
+ }

--- a/test/fixtures/manifest/generated_manifest/source.h
+++ b/test/fixtures/manifest/generated_manifest/source.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 GitHub
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+ #include <stdio.h>
+
+ void say_hi();

--- a/test/source/manifest_test.rb
+++ b/test/source/manifest_test.rb
@@ -8,11 +8,22 @@ describe Licensed::Source::Manifest do
   let(:source) { Licensed::Source::Manifest.new(config) }
 
   describe "enabled?" do
-    it "is true if manifest.json exists in license directory" do
+    it "is true if manifest file exists" do
+      # test uses the default manifest file path <cache path>/manifest.json
       assert source.enabled?
     end
 
-    it "is false if manifest.json does not exist in license directory" do
+    it "is true if dependencies are configured" do
+      config["cache_path"] = Dir.tmpdir
+      config["manifest"] = {
+        "dependencies" => {
+          "manifest_test" => "**/*"
+        }
+      }
+      assert source.enabled?
+    end
+
+    it "is false if manifest file does not exist and dependencies are not configured" do
       config["cache_path"] = Dir.tmpdir
       refute source.enabled?
     end
@@ -80,18 +91,150 @@ describe Licensed::Source::Manifest do
   end
 
   describe "manifest" do
-    it "loads json" do
-      manifest_path = File.join(fixtures, "manifest.json")
-      config["manifest"] = { "path" => manifest_path }
+    describe "from a manifest file" do
+      it "loads json" do
+        manifest_path = File.join(fixtures, "manifest.json")
+        config["manifest"] = { "path" => manifest_path }
 
-      assert source.manifest && !source.manifest.empty?
+        assert source.manifest && !source.manifest.empty?
+      end
+
+      it "loads yaml" do
+        manifest_path = File.join(fixtures, "manifest.yml")
+        config["manifest"] = { "path" => manifest_path }
+
+        assert source.manifest && !source.manifest.empty?
+      end
     end
 
-    it "loads yaml" do
-      manifest_path = File.join(fixtures, "manifest.yml")
-      config["manifest"] = { "path" => manifest_path }
+    describe "from a generated manifest" do
+      let(:manifest_config) do
+        {
+          # exclude all files that aren't in the generated manifest test folder
+          "exclude" => [
+            "**/*",
+            "!test/fixtures/manifest/generated_manifest/**/*"
+          ]
+        }
+      end
+      let(:config) { Licensed::Configuration.new("manifest" => manifest_config) }
 
-      assert source.manifest && !source.manifest.empty?
+      it "excludes files matching patterns in the \"exclude\" setting" do
+        config["manifest"]["dependencies"] = {
+          "manifest_test" => "**/*"
+        }
+        manifest = source.manifest
+        assert manifest.all? { |file, _| file.include?("test/fixtures/manifest/generated_manifest") }
+      end
+
+      it "matches files to dependencies using glob patterns" do
+        config["manifest"]["dependencies"] = {
+          "manifest_test" => ["**/*", "!**/nested/*"],
+          "nested" => "**/nested/*"
+        }
+
+        source.manifest.each do |file, dependency|
+          if file.include?("nested")
+            assert_equal "nested", dependency
+          else
+            assert_equal "manifest_test", dependency
+          end
+        end
+      end
+
+      it "raises an error if the \"dependencies\" setting is empty" do
+        config["manifest"]["dependencies"] = {}
+
+        err = assert_raises RuntimeError do
+          source.manifest
+        end
+
+        assert err.message.include?("\"dependencies\" cannot be empty")
+      end
+
+      it "raises an error if any files match multiple dependencies" do
+        config["manifest"]["dependencies"] = {
+          "manifest_test" => "**/*",
+          "manifest_test_2" => "**/*"
+        }
+
+        err = assert_raises RuntimeError do
+          source.manifest
+        end
+        assert err.message.include?("matched multiple configured dependencies: manifest_test, manifest_test_2")
+      end
+
+      it "raises an error if any files do not match any dependencies" do
+        config["manifest"]["dependencies"] = {
+          "manifest_test" => "!**/nested/*"
+        }
+
+        err = assert_raises RuntimeError do
+          source.manifest
+        end
+        assert err.message.include?("nested.c did not match a configured dependency")
+      end
+    end
+  end
+
+  describe "generate_manifest?" do
+    it "is false when a manifest file exists" do
+      # test uses the default manifest file path <cache_path>/manifest.json
+      refute source.generate_manifest?
+    end
+
+    it "is false when manifest dependencies are not configured" do
+      config["cache_path"] = Dir.tmpdir
+      config["manifest"] = {}
+      refute source.generate_manifest?
+    end
+
+    it "is true when a manifest file does not exist and dependencies are configured" do
+      config["cache_path"] = Dir.tmpdir
+      config["manifest"] = {
+        "dependencies" => {
+          "manifest_test" => "**/*"
+        }
+      }
+
+      assert source.generate_manifest?
+    end
+  end
+
+  describe "files_from_pattern_list" do
+    it "returns an empty set if the patterns argument is nil or empty" do
+      assert_equal Set.new, source.files_from_pattern_list(nil)
+      assert_equal Set.new, source.files_from_pattern_list([])
+      assert_equal Set.new, source.files_from_pattern_list("")
+    end
+
+    it "finds files for a single pattern" do
+      files = source.files_from_pattern_list(["lib/**/*.rb"])
+      assert files.include?("lib/licensed/source/manifest.rb")
+      assert files.include?("lib/licensed/command/list.rb")
+      refute files.include?("test/command/cache_test.rb")
+    end
+
+    it "finds files for an array of patterns" do
+      files = source.files_from_pattern_list(["lib/**/manifest.rb", "lib/**/list.rb"])
+      assert files.include?("lib/licensed/source/manifest.rb")
+      assert files.include?("lib/licensed/command/list.rb")
+    end
+
+    it "finds files for a directory pattern" do
+      files = source.files_from_pattern_list(["lib/**/source/*"])
+      assert files.include?("lib/licensed/source/manifest.rb")
+      assert files.include?("lib/licensed/source/bundler.rb")
+    end
+
+    it "understands exclusion patterns" do
+      files = source.files_from_pattern_list(["lib/**/source/*", "!**/manifest.rb"])
+      refute files.include?("lib/licensed/source/manifest.rb")
+    end
+
+    it "finds filenames starting with \".\"" do
+      files = source.files_from_pattern_list("*")
+      assert files.include?(".gitignore")
     end
   end
 


### PR DESCRIPTION
Fixes https://github.com/github/licensed/issues/58

This PR gives an alternate way of creating the file map used in the manifest source.  It uses glob patterns specified in the configuration file to find files and match them to dependencies.

This PR is backwards compatible.  It does not remove or change the support for manifest files, and if a manifest file is found it will continue to be used over a manifest sourced from glob patterns.

Glob patterns are used to match files to dependencies and for restricting which files are considered to be dependencies at the top level.  Errors are raised unless a file matches to exactly one dependency.  If a file does not match any dependencies it means there are dependencies without metadata.  If a file matches more than one dependency it means different license terms could apply to a single file, and the manifest is not configured properly.

Usage, including pattern syntax is outlined in the manifest source [documentation](https://github.com/github/licensed/compare/manifest-from-config?expand=1#diff-b4a31c79438ac9e0ce2e9d474e3fd95cR36), though it'll be helpful to include details of the pattern requirements here:

Patterns are evaluated using [Dir.glob](https://ruby-doc.org/core/Dir.html#method-c-glob) and must follow these rules:
1. Patterns are evaluated from the project root directory
2. Patterns will only match files that are tracked by Git
3. Patterns should follow standard shell glob syntax
4. Patterns are evaluated in the order specified - order matters!
5. `!` can be appended to any pattern to indicate a negative pattern
   - Negative patterns exclude matching files from the result set
   - If a pattern should match files starting with `!`, escape the leading `!` with `\` -> `\!filename`
6. Patterns will match dotfiles