### PR TITLE
Dependencies cache all available license files

### DIFF
--- a/lib/licensed/dependency.rb
+++ b/lib/licensed/dependency.rb
@@ -68,14 +68,8 @@ module Licensed
     # Resets all local project and license information
     def reset_license!
       @project = nil
-      @project_license = nil
       self.delete("license")
       self.text = nil
-    end
-
-    # Finds and returns a license from the Licensee::FSProject for this dependency.
-    def project_license
-      @project_license ||= project.license
     end
 
     # Returns a Licensee::LicenseFile with the content of the license in the
@@ -96,11 +90,8 @@ module Licensed
 
     # Returns a string representing the project's license
     def license_key
-      if project_license
-        project_license.key
-      else
-        "none"
-      end
+      return "none" unless project.license
+      project.license.key
     end
   end
 end

--- a/lib/licensed/dependency.rb
+++ b/lib/licensed/dependency.rb
@@ -81,7 +81,7 @@ module Licensed
       elsif project.license_files.map(&:license).uniq.size > 1
         # if there are multiple license types found from license files,
         # return 'other'
-        Licensee::License.find('other')
+        Licensee::License.find("other")
       else
         # check other project files if we haven't yet found a license type
         project.licenses.reject(&:other?).first


### PR DESCRIPTION
Fixes https://github.com/github/licensed/issues/22.

This PR updates the `licensee` usage to cache all license texts associated with a dependency.  The implementation changes
- `#license_text` to account for using `project.license_files` over `project.license_file`
- `#matched_project_file` -> `project_license`, which checks for (in order)
   1. A non-other licensee `project.license` 👍  
   2. Multiple non-unique license files to match as `other` (should this match to "multiple"?)
   3. Legacy behavior that ends up calling into `project.matched_files...`
- removes `#project_file` and instead moves `#remote_license_file` usage directly into `#license_key`

This is not a breaking change, however it will cause a mismatch between license text cached from `licensed <= 1.2.0` and license text cached `licensed > 1.2.0` for dependencies with multiple license files.  In that scenario, the cached license metadata field will not be reused per https://github.com/github/licensed/pull/21

/cc @benbalter added you as reviewer for changes to how we're using `licensee`