### PR TITLE
Support Gemfile 'path' option for gem source.

### DIFF
--- a/lib/licensed/source/bundler.rb
+++ b/lib/licensed/source/bundler.rb
@@ -90,7 +90,7 @@ module Licensed
 
         # if the specification is coming from a gemspec source,
         # we can get a non-lazy specification straight from the source
-        if spec.source.is_a?(::Bundler::Source::Gemspec)
+        if spec.source.is_a?(::Bundler::Source::Gemspec) || spec.source.is_a?(::Bundler::Source::Path)
           return spec.source.specs.first
         end
 

--- a/test/fixtures/bundler/Gemfile
+++ b/test/fixtures/bundler/Gemfile
@@ -22,3 +22,5 @@ end
 group :test do
  gem "minitest", "5.11.3"
 end
+
+gem "pathed-gem-fixture", path: "pathed-gem-fixture"

--- a/test/fixtures/bundler/pathed-gem-fixture/fixture.rb
+++ b/test/fixtures/bundler/pathed-gem-fixture/fixture.rb
@@ -1,0 +1,5 @@
+class PathedGemFixture
+  def hello
+    p "world"
+  end
+end

--- a/test/fixtures/bundler/pathed-gem-fixture/pathed-gem-fixture.gemspec
+++ b/test/fixtures/bundler/pathed-gem-fixture/pathed-gem-fixture.gemspec
@@ -1,0 +1,12 @@
+Gem::Specification.new do |spec|
+  spec.name          = "pathed-gem-fixture"
+  spec.version       = "0.0.1"
+  spec.authors       = ["GitHub"]
+  spec.email         = ["opensource+licensed@github.com"]
+
+  spec.summary       = %q{a gem to test finding specs installed via :path property}
+  spec.homepage      = "https://github.com/github/licensed"
+  spec.license       = "MIT"
+
+  spec.files = ["fixture.rb"]
+end

--- a/test/source/bundler_test.rb
+++ b/test/source/bundler_test.rb
@@ -116,6 +116,14 @@ if Licensed::Shell.tool_available?("bundle")
         end
       end
 
+      it "finds dependencies from path sources" do
+        Dir.chdir(fixtures) do
+          dep = source.dependencies.find { |d| d["name"] == "pathed-gem-fixture" }
+          assert dep
+          assert_equal "0.0.1", dep["version"]
+        end
+      end
+
       describe "when bundler is a listed dependency" do
         it "includes bundler as a dependency" do
           Dir.chdir(fixtures) do


### PR DESCRIPTION
Gems loaded via Gemfile `path:` option fail with `RuntimeError: Unable to find a specification for <gem> in any sources`

My app uses the CBRA ["Component Based Rails Applications" ](http://shageman.github.io/cbra.info/) methodology.  One of the key parts of this is, to divide the application into "components" which, are really just Rails Engines.  These engines are then loaded into a root, container app, via a Gemfile "path:" option, like so:

    gem 'api', '0.0.1', path: 'components/api'

When running `licensed` against this app, I get this error:

```
RuntimeError: Unable to find a specification for messaging (= 0.0.1) in any sources
  /.rbenv/versions/2.4.4/lib/ruby/gems/2.4.0/gems/licensed-1.2.0/lib/licensed/source/bundler.rb:74:in `block in specs_for_dependencies'
  /.rbenv/versions/2.4.4/lib/ruby/gems/2.4.0/gems/licensed-1.2.0/lib/licensed/source/bundler.rb:73:in `map'
```

Tracking it down, it only took me a few minutes to solve the problem, via changing this line in licensed's `bundler.rb` file:

```
- if spec.source.is_a?(::Bundler::Source::Gemspec)
+ if spec.source.is_a?(::Bundler::Source::Gemspec) || spec.source.is_a?(::Bundler::Source::Path)
  return spec.source.specs.first
end
```

If you think this change makes sense and, is harmless, than, perhaps this can be merged into the mainstream.

Thank you!