### PR TITLE
Configured manifest should not use files that are git-tracked but deleted

### DIFF
--- a/lib/licensed/source/manifest.rb
+++ b/lib/licensed/source/manifest.rb
@@ -149,7 +149,9 @@ module Licensed
 
       # Returns all tracked files in the project
       def all_files
+        # remove files if they are tracked but don't exist on the file system
         @all_files ||= Set.new(Licensed::Git.files || [])
+                          .delete_if { |f| !File.exist?(f) }
       end
 
       class Dependency < Licensed::Dependency


### PR DESCRIPTION
Fixes an issue with the manifest changes from https://github.com/github/licensed/pull/63 that I had made locally and never pushed up 🤦‍♂️ .

This removes files that `git ls-tree` knows about but don't exist on the file tree any longer.