### PR TITLE
Find bundler specifications that include platform information

### DIFF
--- a/lib/licensed/source/bundler.rb
+++ b/lib/licensed/source/bundler.rb
@@ -94,6 +94,13 @@ module Licensed
           return spec.source.specs.first
         end
 
+        # spec.source.specs gives access to specifications with more
+        # information than spec itself, including platform-specific gems.
+        # try to find a specification that matches `spec`
+        if source_spec = spec.source.specs.find { |s| s.name == spec.name && s.version == spec.version }
+          spec = source_spec
+        end
+
         # look for a specification at the bundler specs path
         spec_path = ::Bundler.specs_path.join("#{spec.full_name}.gemspec")
         return unless File.exist?(spec_path.to_s)

--- a/test/fixtures/bundler/Gemfile
+++ b/test/fixtures/bundler/Gemfile
@@ -22,3 +22,7 @@ end
 group :test do
  gem "minitest", "5.11.3"
 end
+
+# verify https://github.com/github/licensed/issues/71
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
+gem "mini_racer"

--- a/test/source/bundler_test.rb
+++ b/test/source/bundler_test.rb
@@ -116,6 +116,12 @@ if Licensed::Shell.tool_available?("bundle")
         end
       end
 
+      it "finds platform-specific dependencies" do
+        Dir.chdir(fixtures) do
+          assert source.dependencies.find { |d| d["name"] == "libv8" }
+        end
+      end
+
       describe "when bundler is a listed dependency" do
         it "includes bundler as a dependency" do
           Dir.chdir(fixtures) do


### PR DESCRIPTION
Fixes https://github.com/github/licensed/issues/71

The problem in the issue is that the installed gem is platform specific and includes `x86_64-darwin-16` in the gem file name.  The `LazySpecification` specs that licensed was using apparently wasn't platform aware, and `LazySpecification#full_name` didn't include the platform suffix.

It's possible to obtain a gem specification that is platform aware through `LazySpecification#source`.  I'm not sure that this is a 100% fix because bundler does a LOT internally, but it resolves the issue and doesn't seem to be a change for the worse.

This is a small change to try and find a spec in `spec.source.specs` that matches the lazy specifications name and version.  If found, it will be used to find the relevant `gemspec`.