### PR TITLE
[Cabal] Use the first package id returned from `ghc-pkg field <pkg> id`

### DIFF
--- a/lib/licensed/source/cabal.rb
+++ b/lib/licensed/source/cabal.rb
@@ -173,7 +173,12 @@ module Licensed
 
       # Returns an installed package id for the package.
       def cabal_package_id(package_name)
-        field = ghc_pkg_field_command(package_name, ["id"])
+        # using the first returned id assumes that package resolvers
+        # order returned package information in the same order that it would
+        # be used during build
+        field = ghc_pkg_field_command(package_name, ["id"]).lines.first
+        return unless field
+
         id = field.split(":", 2)[1]
         id.strip if id
       end

--- a/lib/licensed/source/cabal.rb
+++ b/lib/licensed/source/cabal.rb
@@ -163,12 +163,11 @@ module Licensed
           # add any dependencies for matched targets from the cabal file.
           # by default this will find executable and library dependencies
           content.scan(cabal_file_regex).each do |match|
-            # match[1] is a string of "," separated dependencies
-            dependencies = match[1].split(",").map(&:strip)
-
-            # the dependency might have a version specifier.
-            # remove it so we can get the full id specifier for each package
-            targets.merge(dependencies.map { |dep| dep.split(/\s/)[0] })
+            # match[1] is a string of "," separated dependencies.
+            # dependency packages might have a version specifier, remove them
+            # to get the full id specifier for each package
+            dependencies = match[1].split(",").map { |dep| dep.strip.split(/\s/)[0] }
+            targets.merge(dependencies)
           end
         end
       end


### PR DESCRIPTION
When using the cabal dependency source it's possible that calling `ghc-pkg field <pkg> id` will return multiple ids for a package name.  This was seen using stack, where stack installed a second version of the `haskeline 0.7.4.2` package, resulting in two ids being returned like:
```
haskeline-0.7.4.2-<hash>
haskeline-0.7.4.2
```

When there are multiple versions of a package available, `licensed` will assume that GHC package dbs are configured properly for package preference and that the first listed package id should be used.

In debugging this I also found a performance bug that should result in a nice performance boost.  `cabal_file_dependencies` was being called from both `#enabled?` and `#package_ids` but wasn't caching the results.  This call was parsing the cabal file and loading the package id for each found dependency.

The cleanup pulls package id enumeration out of `cabal_file_dependencies`, so that it's not performed during `#enabled?` as well as caching the results of `cabal_file_dependencies` file parsing.