### PR TITLE
Use `git ls-files` instead of `git ls-tree` to find files in the git repo

### DIFF
--- a/lib/licensed/git.rb
+++ b/lib/licensed/git.rb
@@ -37,7 +37,7 @@ module Licensed
 
       def files
         return unless available?
-        output = Licensed::Shell.execute("git", "ls-tree", "--full-tree", "-r", "--name-only", "HEAD")
+        output = Licensed::Shell.execute("git", "ls-files", "--full-name", "--recurse-submodules")
         output.lines.map(&:strip)
       end
     end

--- a/lib/licensed/git.rb
+++ b/lib/licensed/git.rb
@@ -18,13 +18,7 @@ module Licensed
       # descriptor - file or directory to retrieve latest SHA for
       def version(descriptor)
         return unless available? && descriptor
-
-        dir = File.directory?(descriptor) ? descriptor : File.dirname(descriptor)
-        file = File.directory?(descriptor) ? "." : File.basename(descriptor)
-
-        Dir.chdir dir do
-          Licensed::Shell.execute("git", "rev-list", "-1", "HEAD", "--", file, allow_failure: true)
-        end
+        Licensed::Shell.execute("git", "rev-list", "-1", "HEAD", "--", descriptor, allow_failure: true)
       end
 
       # Returns the commit date for the provided SHA as a timestamp

--- a/lib/licensed/source/go.rb
+++ b/lib/licensed/source/go.rb
@@ -36,9 +36,21 @@ module Licensed
               "summary"     => package["Doc"],
               "homepage"    => homepage(import_path),
               "search_root" => search_root(package_dir),
-              "version"     => Licensed::Git.version(package_dir)
+              "version"     => package_version(package_dir)
             })
           end.compact
+        end
+      end
+
+      # Returns the most recent git SHA for a package, or nil if SHA is
+      # not available
+      #
+      # package_directory - package location
+      def package_version(package_directory)
+        return unless package_directory
+
+        Dir.chdir package_directory do
+          Licensed::Git.version(".")
         end
       end
 

--- a/test/license_test.rb
+++ b/test/license_test.rb
@@ -66,7 +66,7 @@ describe Licensed::License do
     end
 
     it "returns true if the normalized content is the same" do
-      license = Licensed::License.new({}, "test content")
+      license = Licensed::License.new({}, "- test content")
       other = Licensed::License.new({}, "* test content")
 
       assert license.license_text_match?(other)


### PR DESCRIPTION
Fixes https://github.com/github/licensed/issues/77

The manifest source is not finding files inside of submodules due to using `git ls-tree` to find files in the git repo.  This PR uses `git ls-files --recurse-submodules --full-name` instead which can enumerate files from within submodules.

Using `--full-name` returns the full path to the files from the repository root, no matter where in the repository the command is called.

In looking up the differences between the two functions online, it seems like `git ls-files` returns files based on the cached index while `git ls-tree` is finding files specifically for the `HEAD` tree.  The difference should be negligible though, as both solutions require the source to be run after the last commit to pick up the most recent commit hash for versioning.