### PR TITLE
[Bundler] Use found non-lazy gem specification objects if available

### DIFF
--- a/lib/licensed/source/bundler.rb
+++ b/lib/licensed/source/bundler.rb
@@ -88,18 +88,12 @@ module Licensed
         spec = definition.resolve.find { |s| s.satisfies?(dependency) }
         return spec unless spec.is_a?(::Bundler::LazySpecification)
 
-        # if the specification is coming from a gemspec source,
-        # we can get a non-lazy specification straight from the source
-        if spec.source.is_a?(::Bundler::Source::Gemspec) || spec.source.is_a?(::Bundler::Source::Path)
-          return spec.source.specs.first
-        end
-
+        # try to find a non-lazy specification that matches `spec`
         # spec.source.specs gives access to specifications with more
         # information than spec itself, including platform-specific gems.
-        # try to find a specification that matches `spec`
-        if source_spec = spec.source.specs.find { |s| s.name == spec.name && s.version == spec.version }
-          spec = source_spec
-        end
+        # these objects should have all the information needed to detect license metadata
+        source_spec = spec.source.specs.find { |s| s.name == spec.name && s.version == spec.version }
+        return source_spec if source_spec
 
         # look for a specification at the bundler specs path
         spec_path = ::Bundler.specs_path.join("#{spec.full_name}.gemspec")


### PR DESCRIPTION
This solves an edge case when licensed is able to find a non-lazy specification through a lazy specifications gem source, but the non-lazy specifications are not located in bundlers known specification directory.

Non-lazy specifications should already contain all of the expected licensing metadata.  There's no need to look further and try to find a specification file under `::Bundler.specs_path`.

As an added bonus, this simplifies the code a little and should make things just a bit more performant.

The edge case behind this change isn't easy to replicate, and I haven't added a new test.  If all existing test are 💚 that should be enough confidence that the change is 👍 

/cc @jhawthorn FYI