### PR TITLE
COPYING is a license file, shouldn't need to be treated as additional legal file

### DIFF
--- a/lib/licensed/dependency.rb
+++ b/lib/licensed/dependency.rb
@@ -3,7 +3,7 @@ require "licensee"
 
 module Licensed
   class Dependency < License
-    LEGAL_FILES = /\A(AUTHORS|COPYING|NOTICE|LEGAL)(?:\..*)?\z/i
+    LEGAL_FILES = /\A(AUTHORS|NOTICE|LEGAL)(?:\..*)?\z/i
 
     attr_reader :path
     attr_reader :search_root

--- a/test/dependency_test.rb
+++ b/test/dependency_test.rb
@@ -63,14 +63,12 @@ describe Licensed::Dependency do
     it "extracts other legal notices" do
       mkproject do |dependency|
         File.write "AUTHORS", "authors"
-        File.write "COPYING", "copying"
         File.write "NOTICE", "notice"
         File.write "LEGAL", "legal"
 
         dependency.detect_license!
 
         assert_match(/authors/, dependency.text)
-        assert_match(/copying/, dependency.text)
         assert_match(/notice/, dependency.text)
         assert_match(/legal/, dependency.text)
       end
@@ -79,14 +77,12 @@ describe Licensed::Dependency do
     it "does not extract empty legal notices" do
       mkproject do |dependency|
         File.write "AUTHORS", ""
-        File.write "COPYING", "copying"
         File.write "NOTICE", ""
         File.write "LEGAL", "legal"
 
         dependency.detect_license!
 
         refute_match(/authors/, dependency.text)
-        assert_match(/copying/, dependency.text)
         refute_match(/notice/, dependency.text)
         assert_match(/legal/, dependency.text)
       end


### PR DESCRIPTION
In short, I don't think `Licensed::Dependency::LEGAL_FILES` needs to match anything that `Licensee::ProjectFiles::LicenseFile::FILENAME_REGEXES` matches because licensee will provide texts matching the latter.

I don't think this will cause any behavior change.