### PR TITLE
Detect multiple unique versions of npm dependencies

### DIFF
--- a/test/source/npm_test.rb
+++ b/test/source/npm_test.rb
@@ -64,6 +64,25 @@ if Licensed::Shell.tool_available?("npm")
           end
         end
       end
+
+      describe "with multiple instances of a dependency" do
+        it "includes version in the dependency path for multiple unique versions" do
+          Dir.chdir fixtures do
+            graceful_fs_dependencies = @source.dependencies.select { |dep| dep["name"] == "graceful-fs" }
+            assert_equal 2, graceful_fs_dependencies.count
+            graceful_fs_dependencies.each do |dependency|
+              assert_equal "#{dependency["name"]}-#{dependency["version"]}", dependency["path"]
+            end
+          end
+        end
+
+        it "does not include version in the dependency path for a single unique version" do
+          Dir.chdir fixtures do
+            dep = @source.dependencies.detect { |dep| dep["name"] == "wrappy" }
+            assert_equal "wrappy", dep["path"]
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/github/licensed/issues/87

This PR allows for caching metadata for multiple versions of npm dependencies by 
1. detecting multiple unique versions of dependencies, based on the `version` metadata field
2. setting the file path of the cached metadata to `<name>-<version>` for each unique version by setting the `path` metadata property on each `Licensed::Dependency`

Previous behavior is maintained when there is a single unique version for a given dependency; the version is not included in the cached data's filename.

/cc @jclem @mlinksva 