### PR TITLE
[GitSubmodule] check for .gitmodules in current dir

### DIFF
--- a/lib/licensed/source/git_submodule.rb
+++ b/lib/licensed/source/git_submodule.rb
@@ -28,7 +28,7 @@ module Licensed
         @dependencies ||= git_submodules_command.lines.map do |line|
           displaypath, toplevel, version, homepage = line.strip.split
           name = File.basename(displaypath)
-          submodule_path = if toplevel == Licensed::Git.repository_root.to_s
+          submodule_path = if toplevel == @config.pwd.to_s
             name
           else
             parent = File.basename(toplevel)
@@ -36,7 +36,7 @@ module Licensed
           end
           submodule_paths[name] = submodule_path
 
-          Licensed::Dependency.new(Licensed::Git.repository_root.join(displaypath), {
+          Licensed::Dependency.new(@config.pwd.join(displaypath), {
             "type" => self.class.type,
             "name" => name,
             "version" => version,
@@ -55,7 +55,7 @@ module Licensed
       end
 
       def gitmodules_path
-        Licensed::Git.repository_root.join(".gitmodules")
+        @config.pwd.join(".gitmodules")
       end
     end
   end

--- a/test/source/git_submodule_test.rb
+++ b/test/source/git_submodule_test.rb
@@ -47,13 +47,6 @@ if Licensed::Shell.tool_available?("git")
           assert dep
           assert_equal latest_repository_commit(submodule_repo_path), dep["version"]
           assert_equal "submodule", dep["path"]
-
-          # TODO: this should be tested from test/command/cache_test.rb,
-          # however due to the caching of Licensed::Git.repository_root and
-          # this source testing a git repo within a git repo (test fixtures),
-          # it's difficult to properly test from caching
-          dep.detect_license!
-          assert_equal "mit", dep["license"]
         end
       end
 
@@ -63,13 +56,6 @@ if Licensed::Shell.tool_available?("git")
           assert dep
           assert_equal latest_repository_commit(recursive_repo_path), dep["version"]
           assert_equal "submodule/nested", dep["path"]
-
-          # TODO: this should be tested from test/command/cache_test.rb,
-          # however due to the caching of Licensed::Git.repository_root and
-          # this source testing a git repo within a git repo (test fixtures),
-          # it's difficult to properly test from caching
-          dep.detect_license!
-          assert_equal "mit", dep["license"]
         end
       end
     end


### PR DESCRIPTION
This PR fixes a problem found when writing out tests for the GitSubmodules source.

The GitSubmodule source currently checks for a `.gitmodules` file at the git repository root.  This was implemented based on the [gitmodules documentation](https://git-scm.com/docs/gitmodules) mentioning that the gitmodules file will always be at the git repository root.  In practice licensed expects that files required for a source to work are present in the current directory, dictated by the `source_path` property.

This fixes that discrepancy for the GitSubmodule source by changing the source to look for the `.gitmodules` file, and calculate all paths based off the current directory rather than the git repository root.