### PR TITLE
cleanup command test fixtures

### DIFF
--- a/test/command/cache_test.rb
+++ b/test/command/cache_test.rb
@@ -23,11 +23,10 @@ describe Licensed::Command::Cache do
 
   each_source do |source_type|
     describe "with #{source_type}" do
-      let(:yaml) { YAML.load_file(File.join(fixtures, "command/#{source_type.to_s.downcase}.yml")) }
-      let(:expected_dependency) { yaml["expected_dependency"] }
-
-      let(:config) { Licensed::Configuration.new(yaml["config"]) }
+      let(:config_file) { File.join(fixtures, "command/#{source_type.to_s.downcase}.yml") }
+      let(:config) { Licensed::Configuration.load_from(config_file) }
       let(:source) { Licensed::Source.const_get(source_type).new(config) }
+      let(:expected_dependency) { config["expected_dependency"] }
 
       it "extracts license info" do
         Dir.chdir config.source_path do

--- a/test/command/list_test.rb
+++ b/test/command/list_test.rb
@@ -16,11 +16,10 @@ describe Licensed::Command::List do
 
   each_source do |source_type|
     describe "with #{source_type}" do
-      let(:yaml) { YAML.load_file(File.join(fixtures, "command/#{source_type.to_s.downcase}.yml")) }
-      let(:expected_dependency) { yaml["expected_dependency"] }
-
-      let(:config) { Licensed::Configuration.new(yaml["config"]) }
+      let(:config_file) { File.join(fixtures, "command/#{source_type.to_s.downcase}.yml") }
+      let(:config) { Licensed::Configuration.load_from(config_file) }
       let(:source) { Licensed::Source.const_get(source_type).new(config) }
+      let(:expected_dependency) { config["expected_dependency"] }
 
       it "lists dependencies" do
         Dir.chdir config.source_path do

--- a/test/fixtures/command/bower.yml
+++ b/test/fixtures/command/bower.yml
@@ -1,3 +1,2 @@
 expected_dependency: jquery
-config:
-  source_path: test/fixtures/bower
+source_path: test/fixtures/bower

--- a/test/fixtures/command/bundler.yml
+++ b/test/fixtures/command/bundler.yml
@@ -1,3 +1,2 @@
 expected_dependency: semantic
-config:
-  source_path: test/fixtures/bundler
+source_path: test/fixtures/bundler

--- a/test/fixtures/command/cabal.yml
+++ b/test/fixtures/command/cabal.yml
@@ -1,8 +1,7 @@
 expected_dependency: zlib
-config:
-  source_path: test/fixtures/cabal
-  cabal:
-    ghc_package_db:
-      - global
-      - test/fixtures/cabal/dist-newstyle/packagedb/ghc-<ghc_version>
-      - ~/.cabal/store/ghc-<ghc_version>/package.db
+source_path: test/fixtures/cabal
+cabal:
+  ghc_package_db:
+    - global
+    - test/fixtures/cabal/dist-newstyle/packagedb/ghc-<ghc_version>
+    - ~/.cabal/store/ghc-<ghc_version>/package.db

--- a/test/fixtures/command/dep.yml
+++ b/test/fixtures/command/dep.yml
@@ -1,5 +1,4 @@
 expected_dependency: github.com/gorilla/context
-config:
-  source_path: test/fixtures/go/src/test
-  dep:
-    allow_ignored: true
+source_path: test/fixtures/go/src/test
+dep:
+  allow_ignored: true

--- a/test/fixtures/command/gitsubmodule.yml
+++ b/test/fixtures/command/gitsubmodule.yml
@@ -1,3 +1,2 @@
 expected_dependency: submodule
-config:
-  source_path: test/fixtures/git_submodule/project
+source_path: test/fixtures/git_submodule/project

--- a/test/fixtures/command/go.yml
+++ b/test/fixtures/command/go.yml
@@ -1,5 +1,4 @@
 expected_dependency: github.com/gorilla/context
-config:
-  source_path: test/fixtures/go/src/test
-  go:
-    GOPATH: test/fixtures/go
+source_path: test/fixtures/go/src/test
+go:
+  GOPATH: test/fixtures/go

--- a/test/fixtures/command/manifest.yml
+++ b/test/fixtures/command/manifest.yml
@@ -1,5 +1,4 @@
 expected_dependency: manifest_test
-config:
-  source_path: test/fixtures/manifest
-  manifest:
-    path: test/fixtures/manifest/manifest.yml
+source_path: test/fixtures/manifest
+manifest:
+  path: test/fixtures/manifest/manifest.yml

--- a/test/fixtures/command/npm.yml
+++ b/test/fixtures/command/npm.yml
@@ -1,3 +1,2 @@
 expected_dependency: autoprefixer
-config:
-  source_path: test/fixtures/npm
+source_path: test/fixtures/npm

--- a/test/fixtures/command/pip.yml
+++ b/test/fixtures/command/pip.yml
@@ -1,5 +1,4 @@
 expected_dependency: MarkupSafe
-config:
-  source_path: test/fixtures/pip
-  python:
-    virtual_env_dir: "test/fixtures/pip/venv"
+source_path: test/fixtures/pip
+python:
+  virtual_env_dir: "test/fixtures/pip/venv"


### PR DESCRIPTION
This PR loads `cache` and `list` command test fixtures using `Licensed::Configuration.load_from` rather than parsing the yml content and loading directly with `Licensed::Configuration.new`