### PR TITLE
Don't include 'path' property in cached metadata output

### DIFF
--- a/lib/licensed/command/cache.rb
+++ b/lib/licensed/command/cache.rb
@@ -30,7 +30,7 @@ module Licensed
 
               # ensure each dependency is cached
               dependencies.each do |dependency|
-                name = dependency["path"] || dependency["name"]
+                name = dependency.name
                 version = dependency["version"]
 
                 names << name

--- a/lib/licensed/command/list.rb
+++ b/lib/licensed/command/list.rb
@@ -19,8 +19,7 @@ module Licensed
 
               source_dependencies = dependencies(app, source)
               source_dependencies.each do |dependency|
-                name = dependency["path"] || dependency["name"]
-                @config.ui.info "    Found #{name} (#{dependency["version"]})"
+                @config.ui.info "    Found #{dependency.name} (#{dependency["version"]})"
               end
 
               @config.ui.confirm "  * #{type} dependencies: #{source_dependencies.size}"
@@ -33,7 +32,7 @@ module Licensed
       def dependencies(app, source)
         source.dependencies
               .select { |d| !app.ignored?(d) }
-              .sort_by { |d| d["name"] }
+              .sort_by { |d| d.name }
       end
 
       def success?

--- a/lib/licensed/command/status.rb
+++ b/lib/licensed/command/status.rb
@@ -25,7 +25,7 @@ module Licensed
             @config.ui.info "Checking licenses for #{app['name']}: #{dependencies.size} dependencies"
 
             results = dependencies.map do |dependency|
-              name = dependency["path"] || dependency["name"]
+              name = dependency.name
               filename = app.cache_path.join(dependency["type"], "#{name}.txt")
 
               warnings = []

--- a/lib/licensed/dependency.rb
+++ b/lib/licensed/dependency.rb
@@ -7,9 +7,11 @@ module Licensed
 
     attr_reader :path
     attr_reader :search_root
+    attr_reader :name
 
     def initialize(path, metadata = {})
       @search_root = metadata.delete("search_root")
+      @name = metadata.delete("path") || metadata["name"]
       super metadata
 
       self.path = path

--- a/test/dependency_test.rb
+++ b/test/dependency_test.rb
@@ -156,4 +156,21 @@ describe Licensed::Dependency do
       end
     end
   end
+
+  it "does not include the 'path' metadata property when caching dependency data" do
+    dep = Licensed::Dependency.new(Dir.pwd, "path" => "dependency/path", "name" => "dependency")
+    assert_nil dep["path"]
+  end
+
+  describe "name" do
+    it "is the 'path' metadata property, if available" do
+      dep = Licensed::Dependency.new(Dir.pwd, "path" => "dependency/path", "name" => "dependency")
+      assert_equal "dependency/path", dep.name
+    end
+
+    it "defaults to the 'name' metadata property" do
+      dep = Licensed::Dependency.new(Dir.pwd, "name" => "dependency")
+      assert_equal "dependency", dep.name
+    end
+  end
 end

--- a/test/source/git_submodule_test.rb
+++ b/test/source/git_submodule_test.rb
@@ -46,7 +46,7 @@ if Licensed::Shell.tool_available?("git")
           dep = source.dependencies.find { |d| d["name"] == "submodule" }
           assert dep
           assert_equal latest_repository_commit(submodule_repo_path), dep["version"]
-          assert_equal "submodule", dep["path"]
+          assert_equal "submodule", dep.name
         end
       end
 
@@ -55,7 +55,7 @@ if Licensed::Shell.tool_available?("git")
           dep = source.dependencies.find { |d| d["name"] == "nested" }
           assert dep
           assert_equal latest_repository_commit(recursive_repo_path), dep["version"]
-          assert_equal "submodule/nested", dep["path"]
+          assert_equal "submodule/nested", dep.name
         end
       end
     end

--- a/test/source/npm_test.rb
+++ b/test/source/npm_test.rb
@@ -71,7 +71,7 @@ if Licensed::Shell.tool_available?("npm")
             graceful_fs_dependencies = @source.dependencies.select { |dep| dep["name"] == "graceful-fs" }
             assert_equal 2, graceful_fs_dependencies.count
             graceful_fs_dependencies.each do |dependency|
-              assert_equal "#{dependency["name"]}-#{dependency["version"]}", dependency["path"]
+              assert_equal "#{dependency["name"]}-#{dependency["version"]}", dependency.name
             end
           end
         end
@@ -79,7 +79,7 @@ if Licensed::Shell.tool_available?("npm")
         it "does not include version in the dependency path for a single unique version" do
           Dir.chdir fixtures do
             dep = @source.dependencies.detect { |dep| dep["name"] == "wrappy" }
-            assert_equal "wrappy", dep["path"]
+            assert_equal "wrappy", dep.name
           end
         end
       end


### PR DESCRIPTION
In https://github.com/github/licensed/pull/86, the ability to explicitly set a file path for a dependency was added.  This was done by passing the `path` property as metadata to a dependency.

All metadata set on a dependency gets cached, which had the result of also caching this new `path` property.  The `path` shouldn't be persisted though as it's only used to specify a path to cache metadata and doesn't relate directly to the dependency.

This PR deletes the `path` property from passed in metadata and assigns it to a `@name` instance variable.  `@name` defaults to the `name` property if `path` isn't available, maintaining backwards compatibility.  `@name` is then available from an `attr_reader` for the CLI commands to write/read files.