### PR TITLE
Add option to configure root path, removing hard dependency on git

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,6 +4,16 @@ A configuration file specifies the details of enumerating and operating on licen
 
 Configuration can be specified in either YML or JSON formats.  Examples below are given in YML.
 
+## Configuration Paths
+
+`licensed` requires a path to enumerate dependencies at (`source_path`) and a path to store cached metadata (`cache_path`).
+
+To determine these paths across multiple environments where absolute paths will differ, a known root path is needed to evaluate relative paths against.
+In using a single root, relative source and cache paths can be specified in the configuration file.
+
+A root path can be manually configured as a path relative to the configuration file using the `root` property.  If a root path is not specified,
+it will default to using the root of the local git repository.
+
 ## Restricting sources
 
 The `sources` configuration property specifies which sources `licensed` will use to enumerate dependencies.
@@ -44,11 +54,16 @@ Configuration can be set up for single or multiple applications in the same repo
 # If not set, defaults to the directory name of `source_path`
 name: 'My application'
 
-# Path is relative to git repository root
+# Path is relative to the location of the configuration file and specifies
+# the root to expand all paths from
+# If not set, defaults to a git repository root
+root: 'relative/path/from/configuration/file/directory'
+
+# Path is relative to configuration root
 # If not set, defaults to '.licenses'
 cache_path: 'relative/path/to/cache'
 
-# Path is relative to git repository root and specifies the working directory when enumerating dependencies
+# Path is relative to configuration root and specifies the working directory when enumerating dependencies
 # Optional for single app configuration, required when specifying multiple apps
 # Defaults to current directory when running `licensed`
 source_path: 'relative/path/to/source'

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,10 +9,13 @@ Configuration can be specified in either YML or JSON formats.  Examples below ar
 `licensed` requires a path to enumerate dependencies at (`source_path`) and a path to store cached metadata (`cache_path`).
 
 To determine these paths across multiple environments where absolute paths will differ, a known root path is needed to evaluate relative paths against.
-In using a single root, relative source and cache paths can be specified in the configuration file.
+In using a root, relative source and cache paths can be specified in the configuration file.
 
-A root path can be manually configured as a path relative to the configuration file using the `root` property.  If a root path is not specified,
-it will default to using the root of the local git repository.
+When using a configuration file, the root property can be set as either a path that can be expanded from the configuration file directory using `File.expand_path`, or the value `true` to use the configuration file directory as the root.
+
+When creating a `Licensed::Dependency` manually with a `root` property, the property must be an absolute path - no path expansion will occur.
+
+If a root path is not specified, it will default to using the root of the local git repository.
 
 ## Restricting sources
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,7 +15,9 @@ When using a configuration file, the root property can be set as either a path t
 
 When creating a `Licensed::Dependency` manually with a `root` property, the property must be an absolute path - no path expansion will occur.
 
-If a root path is not specified, it will default to using the root of the local git repository.
+If a root path is not specified, it will default to using the following, in order of precedence
+1. the root of the local git repository, if run inside a git repository
+2. the current directory
 
 ## Restricting sources
 

--- a/lib/licensed/configuration.rb
+++ b/lib/licensed/configuration.rb
@@ -191,10 +191,7 @@ module Licensed
       end
 
       if config["apps"]&.any?
-        config["apps"].each do |app_config|
-          next unless app_config["root"]
-          app_config["root"] = File.expand_path(app_config["root"], File.dirname(config_path))
-        end
+        config["apps"].each { |app_config| expand_config_roots(app_config, config_path) }
       end
     end
 

--- a/lib/licensed/configuration.rb
+++ b/lib/licensed/configuration.rb
@@ -186,7 +186,9 @@ module Licensed
     # Expand any roots specified in a configuration file based on the configuration
     # files directory.
     def self.expand_config_roots(config, config_path)
-      if config["root"]
+      if config["root"] == true
+        config["root"] = File.dirname(config_path)
+      elsif config["root"]
         config["root"] = File.expand_path(config["root"], File.dirname(config_path))
       end
 

--- a/lib/licensed/configuration.rb
+++ b/lib/licensed/configuration.rb
@@ -27,8 +27,9 @@ module Licensed
       self["ignored"] ||= {}
       self["allowed"] ||= []
 
-      # default the root to the git repository root if not configured
-      self["root"] ||= Licensed::Git.repository_root
+      # default the root to the git repository root,
+      # or the current directory if no other options are available
+      self["root"] ||= Licensed::Git.repository_root || Dir.pwd
 
       verify_arg "source_path"
       verify_arg "cache_path"
@@ -37,7 +38,6 @@ module Licensed
     # Returns the path to the workspace root as a Pathname.
     # Defaults to Licensed::Git.repository_root if not explicitly set
     def root
-      return unless self["root"]
       Pathname.new(self["root"])
     end
 

--- a/lib/licensed/configuration.rb
+++ b/lib/licensed/configuration.rb
@@ -27,18 +27,28 @@ module Licensed
       self["ignored"] ||= {}
       self["allowed"] ||= []
 
+      # default the root to the git repository root if not configured
+      self["root"] ||= Licensed::Git.repository_root
+
       verify_arg "source_path"
       verify_arg "cache_path"
     end
 
+    # Returns the path to the workspace root as a Pathname.
+    # Defaults to Licensed::Git.repository_root if not explicitly set
+    def root
+      return unless self["root"]
+      Pathname.new(self["root"])
+    end
+
     # Returns the path to the app cache directory as a Pathname
     def cache_path
-      Licensed::Git.repository_root.join(self["cache_path"])
+      root.join(self["cache_path"])
     end
 
     # Returns the path to the app source directory as a Pathname
     def source_path
-      Licensed::Git.repository_root.join(self["source_path"])
+      root.join(self["source_path"])
     end
 
     def pwd
@@ -88,6 +98,8 @@ module Licensed
     def allow(license)
       self["allowed"] << license
     end
+
+    private
 
     def defaults_for(options, inherited_options)
       name = options["name"] || File.basename(options["source_path"])
@@ -158,13 +170,31 @@ module Licensed
       return {} unless config_path.file?
 
       extension = config_path.extname.downcase.delete "."
-      case extension
+      config = case extension
       when "json"
         JSON.parse(File.read(config_path))
       when "yml", "yaml"
         YAML.load_file(config_path)
       else
         raise LoadError, "Unknown file type #{extension} for #{config_path}"
+      end
+
+      expand_config_roots(config, config_path)
+      config
+    end
+
+    # Expand any roots specified in a configuration file based on the configuration
+    # files directory.
+    def self.expand_config_roots(config, config_path)
+      if config["root"]
+        config["root"] = File.expand_path(config["root"], File.dirname(config_path))
+      end
+
+      if config["apps"]&.any?
+        config["apps"].each do |app_config|
+          next unless app_config["root"]
+          app_config["root"] = File.expand_path(app_config["root"], File.dirname(config_path))
+        end
       end
     end
 

--- a/lib/licensed/source/cabal.rb
+++ b/lib/licensed/source/cabal.rb
@@ -137,7 +137,7 @@ module Licensed
         Array(@config["cabal"]["ghc_package_db"]).map do |path|
           next "--#{path}" if %w(global user).include?(path)
           path = realized_ghc_package_path(path)
-          path = File.expand_path(path, Licensed::Git.repository_root)
+          path = File.expand_path(path, @config.root)
 
           next unless File.exist?(path)
           "--package-db=#{path}"

--- a/lib/licensed/source/go.rb
+++ b/lib/licensed/source/go.rb
@@ -154,7 +154,7 @@ module Licensed
                     ENV["GOPATH"]
                   else
                     root = begin
-                             Licensed::Git.repository_root
+                             @config.root
                            rescue Licensed::Shell::Error
                              Pathname.pwd
                            end

--- a/lib/licensed/source/pip.rb
+++ b/lib/licensed/source/pip.rb
@@ -63,7 +63,7 @@ module Licensed
         return @virtual_env_dir if defined?(@virtual_env_dir)
         @virtual_env_dir = begin
           venv_dir = @config.dig("python", "virtual_env_dir")
-          File.expand_path(venv_dir, Licensed::Git.repository_root) if venv_dir
+          File.expand_path(venv_dir, @config.root) if venv_dir
         end
       end
     end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -205,10 +205,16 @@ describe Licensed::Configuration do
   end
 
   describe "root" do
-    it "can be set from a configuration file" do
+    it "can be set to a path from a configuration file" do
       file = File.join(fixtures, "root.yml")
       config = Licensed::Configuration.load_from(file)
-      assert_equal File.join(Licensed::Git.repository_root, "test"), config.root.to_s
+      assert_equal File.expand_path("../..", fixtures), config.root.to_s
+    end
+
+    it "can be set to true in a configuration file" do
+      file = File.join(fixtures, "root_at_configuration.yml")
+      config = Licensed::Configuration.load_from(file)
+      assert_equal fixtures, config.root.to_s
     end
 
     it "defaults to the git repository root" do

--- a/test/fixtures/config/root.yml
+++ b/test/fixtures/config/root.yml
@@ -1,0 +1,2 @@
+name: licensed
+root: ../.. # <root>/test folder

--- a/test/fixtures/config/root_at_configuration.yml
+++ b/test/fixtures/config/root_at_configuration.yml
@@ -1,0 +1,2 @@
+name: licensed
+root: true # configuration file directory

--- a/test/source/manifest_test.rb
+++ b/test/source/manifest_test.rb
@@ -61,7 +61,7 @@ describe Licensed::Source::Manifest do
       dep.detect_license!
       assert_equal "mit", dep["license"]
 
-      license_path = File.join(Licensed::Git.repository_root, config.dig("manifest", "licenses", "manifest_test"))
+      license_path = File.join(config.root, config.dig("manifest", "licenses", "manifest_test"))
       assert_equal File.read(license_path).strip, dep.text
     end
 


### PR DESCRIPTION
Fixes https://github.com/github/licensed/issues/1

This PR adds the ability to configure a `root` property that will be used to calculate paths used in `licensed`.  As the linked issue describes, using absolute paths in a configuration file isn't a good idea and as a result all configured paths are expected to be resolved based on a root.

Currently there is a hard dependency on git being available to use licensed because the git repository root is used as the root for all path expansion.  This change removes that hard dependency by allowing users to manually configure a root path using the configuration `root` property.

If a configuration file specifies a path for `root`, the relative path will be expanded to an absolute path after parsing the file contents.  For example, the following configuration sets a root path relative to the configuration file directory.

```yaml
# configuration file at ~/licensed/test/project/.licensed.yaml

root: "../.."                                                    # ~/licensed
source_path: "test/project/subproject"    # ~/licensed/test/project/subproject
```

Alternatively, a configuration file can set `root` to the boolean `true` to use the configuration file's directory as the root path.  For the example above, setting `true` would look like:

```yaml
# configuration file at ~/licensed/test/project/.licensed.yaml

root: true                                   # ~/licensed/test/project
source_path: "subproject"       # ~/licensed/test/project/subproject
```

Root path expansion will only occur when set in a configuration file.  If a `root` property is passed to `Licensed::Configuration.new` it will not be adjusted and is expected to be an absolute path.