### PR TITLE
Fix returning to the correct branch after building executable packages

### DIFF
--- a/script/build-rubyc-exe
+++ b/script/build-rubyc-exe
@@ -37,8 +37,8 @@ BUILD_DEST="$(mktemp -d)"
 trap "rm -rf $BUILD_DEST" EXIT
 
 if [ -n "$VERSION" ]; then
-  git checkout "$VERSION"
   CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+  git checkout "$VERSION"
   trap "rm -rf $BUILD_DEST; git checkout $CURRENT_BRANCH" EXIT
 else
   VERSION="$(git rev-parse --abbrev-ref HEAD)"


### PR DESCRIPTION
A quick fix to get the current branch before `git checkout`-ing the target version.  This fixes a small issue during packaging where the previous branch was not being returned to properly.