### PR TITLE
Use a safer check for if a directory is a git repo

### DIFF
--- a/lib/licensed/git.rb
+++ b/lib/licensed/git.rb
@@ -16,7 +16,7 @@ module Licensed
 
       # Returns true if a git repository is found, false otherwise
       def git_repo?
-        repository_root.empty?
+        !repository_root.empty?
       end
 
       # Returns the most recent git SHA for a file or directory

--- a/lib/licensed/git.rb
+++ b/lib/licensed/git.rb
@@ -16,7 +16,7 @@ module Licensed
 
       # Returns true if a git repository is found, false otherwise
       def git_repo?
-        !repository_root.empty?
+        !repository_root.to_s.empty?
       end
 
       # Returns the most recent git SHA for a file or directory

--- a/lib/licensed/git.rb
+++ b/lib/licensed/git.rb
@@ -7,16 +7,16 @@ module Licensed
         @git ||= Licensed::Shell.tool_available?("git")
       end
 
-      def git_repo?
-        return false unless available?
-        !Licensed::Shell.execute("git", "rev-parse", "HEAD", allow_failure: true).empty?
-      end
-
       # Returns the root of the current git repository
       # or nil if not in a git repository.
       def repository_root
-        return unless git_repo?
-        Licensed::Shell.execute("git", "rev-parse", "--show-toplevel")
+        return unless available?
+        Licensed::Shell.execute("git", "rev-parse", "--show-toplevel", allow_failure: true)
+      end
+
+      # Returns true if a git repository is found, false otherwise
+      def git_repo?
+        repository_root.empty?
       end
 
       # Returns the most recent git SHA for a file or directory

--- a/lib/licensed/git.rb
+++ b/lib/licensed/git.rb
@@ -9,7 +9,7 @@ module Licensed
 
       def git_repo?
         return false unless available?
-        !Licensed::Shell.execute("git", "status", allow_failure: true).empty?
+        !Licensed::Shell.execute("git", "rev-parse", "HEAD", allow_failure: true).empty?
       end
 
       # Returns the root of the current git repository


### PR DESCRIPTION
This uses rev-parse to check whether a repository is a git repository. This is a safer operation than using git status, as git status might end up modifying .git/index and updating it, especially in the case of a dirty tree.