### PR TITLE
Find bundler specification sources from host environment

### DIFF
--- a/docs/sources/bundler.md
+++ b/docs/sources/bundler.md
@@ -15,14 +15,14 @@ The bundler source determines which gem groups to include or exclude with the fo
 Strings and string arrays are both :+1:
 
 ```yml
-rubygems:
+rubygem:
   without: development
 ```
 
 or
 
 ```yml
-rubygems:
+rubygem:
   without:
     - build
     - development

--- a/lib/licensed/source/bundler.rb
+++ b/lib/licensed/source/bundler.rb
@@ -80,13 +80,11 @@ module Licensed
       def gem_spec(dependency)
         return unless dependency
 
-        # bundler specifications aren't put in ::Bundler.specs_path, even if the
-        # gem is a runtime dependency.  it needs to be handled specially
-        return bundler_spec if dependency.name == "bundler"
-
         # find a specifiction from the resolved ::Bundler::Definition specs
         spec = definition.resolve.find { |s| s.satisfies?(dependency) }
-        return spec unless spec.is_a?(::Bundler::LazySpecification)
+
+        # a nil spec should be rare, generally only seen from bundler
+        return bundle_exec_gem_spec(dependency.name) if spec.nil?
 
         # try to find a non-lazy specification that matches `spec`
         # spec.source.specs gives access to specifications with more
@@ -97,8 +95,11 @@ module Licensed
 
         # look for a specification at the bundler specs path
         spec_path = ::Bundler.specs_path.join("#{spec.full_name}.gemspec")
-        return unless File.exist?(spec_path.to_s)
-        Gem::Specification.load(spec_path.to_s)
+        return Gem::Specification.load(spec_path.to_s) if File.exist?(spec_path.to_s)
+
+        # if the specification file doesn't exist, get the specification using
+        # the bundler and gem CLI
+        bundle_exec_gem_spec(dependency.name)
       end
 
       # Returns whether a dependency should be included in the final
@@ -130,24 +131,15 @@ module Licensed
         end
       end
 
-      # Returns a gemspec for bundler, found and loaded by running `gem specification bundler`
-      # This is a hack to work around bundler not placing it's own spec at
-      # `::Bundler.specs_path` when it's an explicit dependency
-      def bundler_spec
-        # cache this so we run CLI commands as few times as possible
-        return @bundler_spec if defined?(@bundler_spec)
+      # Load a gem specification from the YAML returned from `gem specification`
+      # This is a last resort when licensed can't obtain a specification from other means
+      def bundle_exec_gem_spec(name)
+        # `gem` must be available to run `gem specification`
+        return unless Licensed::Shell.tool_available?("gem")
 
-        # finding the bundler gem is dependent on having `gem` available
-        unless Licensed::Shell.tool_available?("gem")
-          @bundler_spec = nil
-          return
-        end
-
-        # Bundler is always used from the default gem install location.
-        # we can use `gem specification bundler` with a clean ENV to
-        # get the system bundler gem as YAML
-        yaml = ::Bundler.with_original_env { Licensed::Shell.execute("gem", "specification", "bundler") }
-        @bundler_spec = Gem::Specification.from_yaml(yaml)
+        # use `gem specification` with a clean ENV to get gem specification YAML
+        yaml = ::Bundler.with_original_env { Licensed::Shell.execute("gem", "specification", name) }
+        Gem::Specification.from_yaml(yaml)
       end
 
       # Build the bundler definition
@@ -191,6 +183,15 @@ module Licensed
         # force bundler to use the local gem file
         original_bundle_gemfile, ENV["BUNDLE_GEMFILE"] = ENV["BUNDLE_GEMFILE"], gemfile_path.to_s
 
+        if ruby_packer?
+          # if running under ruby-packer, set environment from host
+
+          # hack: setting this ENV var allows licensed to use Gem paths outside
+          # of the ruby-packer filesystem.  this is needed to find spec sources
+          # from the host filesystem
+          ENV["ENCLOSE_IO_RUBYC_1ST_PASS"] = "1"
+        end
+
         # reset all bundler configuration
         ::Bundler.reset!
         # and re-configure with settings for current directory
@@ -198,10 +199,20 @@ module Licensed
 
         yield
       ensure
+        if ruby_packer?
+          # if running under ruby-packer, restore environment after block is finished
+          ENV.delete("ENCLOSE_IO_RUBYC_1ST_PASS")
+        end
+
         ENV["BUNDLE_GEMFILE"] = original_bundle_gemfile
         # restore bundler configuration
         ::Bundler.reset!
         ::Bundler.configure
+      end
+
+      # Returns whether the current licensed execution is running ruby-packer
+      def ruby_packer?
+        @ruby_packer ||= RbConfig::CONFIG["prefix"] =~ /__enclose_io_memfs__/
       end
     end
   end

--- a/lib/licensed/source/bundler.rb
+++ b/lib/licensed/source/bundler.rb
@@ -158,8 +158,9 @@ module Licensed
       # Defaults to [:development, :test] + ::Bundler.settings[:without]
       def exclude_groups
         @exclude_groups ||= begin
-          exclude = Array(@config.dig("rubygems", "without"))
-          exclude.push(*DEFAULT_WITHOUT_GROUPS) if exclude.empty?
+          exclude = Array(@config.dig("rubygem", "without"))
+          exclude = Array(@config.dig("rubygems", "without")) if exclude.empty? # :sad:
+          exclude = DEFAULT_WITHOUT_GROUPS if exclude.empty?
           exclude.uniq.map(&:to_sym)
         end
       end


### PR DESCRIPTION
**note:** the use of "source" in this PR refers to [`::Bundler::Source`](https://github.com/bundler/bundler/blob/master/lib/bundler/source.rb) and not a licensed dependency source

When licensed is run from a packaged executable, there are a number of differences from when it's run as a gem relating to running on a separate version of ruby and bundler.

By default, the bundler dependency enumerator, when run from ruby_packer, picks up it's own installation as a bundle specification source rather than specification sources from target directory on the host where licensed is run.  This becomes a problem particularly when there are platform-specific gems in the target directory on the host.  Platform-specificity is known by [specs obtained from the bundle source](), but not by the unrealized `::Bundler::LazySpecification`.

Due to this, the lazy specifications' `::Bundler::Specification#full_name` doesn't include any platform suffix in the gem name and will fail to match a specification under `::Bundle.specs_path`.

The cause of this bug is that ruby_packer doesn't normally allow setting [`GEM_PATH`](https://github.com/pmq20/ruby-packer/blob/e3d28dc56a9afe31e10639b9ae9afa95ec96300b/ruby/lib/rubygems/path_support.rb#L41-L48) or [`GEM_HOME`](https://github.com/pmq20/ruby-packer/blob/e3d28dc56a9afe31e10639b9ae9afa95ec96300b/ruby/lib/rubygems/path_support.rb#L28-L33) to paths on the host environment.   The restriction is in place to avoid loading and running code from the host machine - licensed is only interested in finding gems though, not loading or running them.

The workaround is to set a special ENV var that bypasses the ruby_packer restrictions and lets Bundler set GEM_PATH and GEM_HOME to paths on the host machine.  This is brittle and could break with future changes to ruby_packer but is seemingly the best way to ensure that licensed is able to correctly find gem information on the host machine.

I also found and fixed a small bug with a naming mismatch between the bundler type name "rubygem" and the "rubygems" configuration section for the "without" configuration value.