### PR TITLE
Use ruby version from host for enumerating gems with licensed executable

### DIFF
--- a/docs/sources/bundler.md
+++ b/docs/sources/bundler.md
@@ -2,6 +2,18 @@
 
 The bundler source will detect dependencies `Gemfile` and `Gemfile.lock` files are found at an apps `source_path`.  The source uses the `Bundler` API to enumerate dependencies from `Gemfile` and `Gemfile.lock`.
 
+### Enumerating bundler dependencies when using the licensed executable
+
+**Note** this content only applies to running licensed from an executable.  It does not apply when using licensed as a gem.
+
+_It is strongly recommended that ruby and bundler are always available when running the licensed executable._
+
+The licensed executable contains and runs a version of ruby.  When using the Bundler APIs, a mismatch between the version of ruby built into the licensed executable and the version of licensed used during `bundle install` can occur.  This mismatch can lead to licensed raising errors due to not finding dependencies.
+
+For example, if `bundle install` was run with ruby 2.5.0 then the bundler specification path would be `<bundle path>/ruby/2.5.0/specifications`.  However, if the licensed executable contains ruby 2.4.0, then licensed will be looking for specifications at `<bundle path>/ruby/2.4.0/specifications`.  That path may not exist, or it may contain invalid or stale content.
+
+If both ruby and bundler are available when running licensed, licensed will determine the ruby version used during `bundle install` and prefer that version string over the version contained in the executable.
+
 ### Excluding gem groups
 
 The bundler source determines which gem groups to include or exclude with the following logic, in order of precedence.

--- a/docs/sources/bundler.md
+++ b/docs/sources/bundler.md
@@ -6,13 +6,13 @@ The bundler source will detect dependencies `Gemfile` and `Gemfile.lock` files a
 
 **Note** this content only applies to running licensed from an executable.  It does not apply when using licensed as a gem.
 
-_It is strongly recommended that ruby and bundler are always available when running the licensed executable._
+_It is strongly recommended that ruby is always available when running the licensed executable._
 
 The licensed executable contains and runs a version of ruby.  When using the Bundler APIs, a mismatch between the version of ruby built into the licensed executable and the version of licensed used during `bundle install` can occur.  This mismatch can lead to licensed raising errors due to not finding dependencies.
 
 For example, if `bundle install` was run with ruby 2.5.0 then the bundler specification path would be `<bundle path>/ruby/2.5.0/specifications`.  However, if the licensed executable contains ruby 2.4.0, then licensed will be looking for specifications at `<bundle path>/ruby/2.4.0/specifications`.  That path may not exist, or it may contain invalid or stale content.
 
-If both ruby and bundler are available when running licensed, licensed will determine the ruby version used during `bundle install` and prefer that version string over the version contained in the executable.
+If ruby is available when running licensed, licensed will determine the ruby version used during `bundle install` and prefer that version string over the version contained in the executable.  If bundler is also available, then the ruby command will be run from a `bundle exec` context.
 
 ### Excluding gem groups
 

--- a/lib/licensed/configuration.rb
+++ b/lib/licensed/configuration.rb
@@ -11,8 +11,12 @@ module Licensed
     ].freeze
     SOURCE_TYPES = Source.constants.map { |c| Source.const_get(c) }.freeze
 
+    attr_reader :ui
+
     def initialize(options = {}, inherited_options = {})
       super()
+
+      @ui = Licensed::UI::Shell.new
 
       # update order:
       # 1. anything inherited from root config
@@ -120,8 +124,6 @@ module Licensed
   class Configuration < AppConfiguration
     class LoadError < StandardError; end
 
-    attr_accessor :ui
-
     # Loads and returns a Licensed::Configuration object from the given path.
     # The path can be relative or absolute, and can point at a file or directory.
     # If the path given is a directory, the directory will be searched for a
@@ -133,8 +135,6 @@ module Licensed
     end
 
     def initialize(options = {})
-      @ui = Licensed::UI::Shell.new
-
       apps = options.delete("apps") || []
       super(default_options.merge(options))
 

--- a/lib/licensed/source/bundler.rb
+++ b/lib/licensed/source/bundler.rb
@@ -207,6 +207,19 @@ module Licensed
             # set the ruby version in Gem::ConfigMap to the ruby version from the host.
             # this helps Bundler find the correct spec sources and paths
             Gem::ConfigMap[:ruby_version] = bundle_exec_ruby_version
+          else
+            # running a ruby-packer-built licensed exe when ruby and bundler aren't available
+            # is possible but could lead to errors if the host ruby version doesn't
+            # match the built executable's ruby version
+            @config.ui.warn <<~WARNING
+              Ruby and/or bundler weren't found when enumerating bundler
+              dependencies using the licensed executable.  This can cause a
+              ruby mismatch between licensed and bundled dependencies and a
+              failure to find gem specifications.
+
+              If licensed is unable to find gem specifications that you believe are present,
+              please ensure that ruby and bundler are available and try again.
+            WARNING
           end
         end
 

--- a/test/source/bundler_test.rb
+++ b/test/source/bundler_test.rb
@@ -196,5 +196,21 @@ if Licensed::Shell.tool_available?("bundle")
         end
       end
     end
+
+    describe "bundler_exe" do
+      it "returns bundle if not configured" do
+        assert_equal "bundle", source.bundler_exe
+      end
+
+      it "returns the configured value if specifying an available tool" do
+        (config["rubygem"] ||= {})["bundler_exe"] = "ruby"
+        assert_equal "ruby", source.bundler_exe
+      end
+
+      it "returns the configured value relative to the configuration root" do
+        (config["rubygem"] ||= {})["bundler_exe"] = "lib/licensed.rb"
+        assert_equal config.root.join("lib/licensed.rb"), source.bundler_exe
+      end
+    end
   end
 end

--- a/test/source/bundler_test.rb
+++ b/test/source/bundler_test.rb
@@ -212,5 +212,19 @@ if Licensed::Shell.tool_available?("bundle")
         assert_equal config.root.join("lib/licensed.rb"), source.bundler_exe
       end
     end
+
+    describe "ruby_command_args" do
+      it "returns 'bundle exec args' when bundler exe is available'" do
+        Licensed::Shell.stub(:tool_available?, true) do
+          assert_equal "bundle exec test", source.ruby_command_args("test").join(" ")
+        end
+      end
+
+      it "returns args when bundler exe is not available'" do
+        Licensed::Shell.stub(:tool_available?, false) do
+          assert_equal "test", source.ruby_command_args("test").join(" ")
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/github/licensed/issues/99

As mentioned in the attached issue, there is the potential for a ruby version mismatch when using the licensed executable.  This PR solves the problem by obtaining and setting `Gem::ConfigMap[:ruby_version]` from the host environment when running licensed from the built executable.  `Gem::ConfigMap[:ruby_version]` is used by bundler to construct it's gem and specification paths.

When the ruby version is set to the `Gem::ConfigMap` value found in the host environment, bundler can construct paths that match the host ruby environment rather than the ruby environment packaged into the licensed executable.