### PR TITLE
CLI: exit unhappily when a CLI error is encountered

### DIFF
--- a/lib/licensed/cli.rb
+++ b/lib/licensed/cli.rb
@@ -37,6 +37,11 @@ module Licensed
       run Licensed::Command::Version.new
     end
 
+    # If an error occurs (e.g. a missing command or argument), exit 1.
+    def self.exit_on_failure?
+      true
+    end
+
     private
 
     # Returns a configuration object for the CLI command

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -82,4 +82,11 @@ describe "licensed" do
       assert_equal out, expected_out
     end
   end
+
+  describe "missing subcommand" do
+    it "exits 1 when a subcommand isn't defined" do
+      _, _, status = Open3.capture3 "bundle exec exe/licensed verify"
+      refute status.success?
+    end
+  end
 end


### PR DESCRIPTION
👋 @jonabc!

This addresses the issue I mentioned about `licensed verify` exiting with status 0. It turns out that Thor catches CLI errors and automatically turns them into 0 exit codes unless you explicitly tell it not to! This PR tells it not to.

Fixes https://github.com/github/licensed/issues/110.