### PR TITLE
Add support for golang 1.11+, go modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ test/fixtures/npm/package-lock.json
 test/fixtures/go/src/*
 test/fixtures/go/pkg
 !test/fixtures/go/src/test
+!test/fixtures/go/src/modules_test
 test/fixtures/cabal/*
 !test/fixtures/cabal/app*
 test/fixtures/git_submodule/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,20 @@ matrix:
       go: "1.7.x"
       before_script: ./script/source-setup/go
       script: ./script/test go
-      env: NAME="go"
+      env: NAME="go 1.7.x"
 
     # go 1.10 tests
     - language: go
       go: "1.10.x"
       before_script: ./script/source-setup/go
       script: ./script/test go
-      env: NAME="go"
+      env: NAME="go 1.10.x"
+
+    - language: go
+      go: "1.11.1"
+      before_script: ./script/source-setup/go
+      script: ./script/test go
+      env: NAME="go 1.11.1"
 
     # dep tests
     - language: go

--- a/lib/licensed/source/go.rb
+++ b/lib/licensed/source/go.rb
@@ -176,7 +176,7 @@ module Licensed
 
       # Returns whether go source is found
       def go_source?
-        @go_source ||= with_configured_gopath { Licensed::Shell.success?("go", "doc") }
+        with_configured_gopath { Licensed::Shell.success?("go", "doc") }
       end
 
       # Returns a list of go standard packages

--- a/lib/licensed/source/go.rb
+++ b/lib/licensed/source/go.rb
@@ -29,7 +29,7 @@ module Licensed
               "summary"     => package["Doc"],
               "homepage"    => homepage(import_path),
               "search_root" => search_root(package_dir),
-              "version"     => package_version(package_dir)
+              "version"     => package_version(package)
             })
           end
         end
@@ -37,35 +37,80 @@ module Licensed
 
       # Returns an array of dependency package import paths
       def packages
-        return [] unless root_package["Deps"]
+        dependency_packages = if go_version < Gem::Version.new("1.11.0")
+          root_package_deps
+        else
+          go_list_deps
+        end
 
         # don't include go std packages
         # don't include packages under the root project that aren't vendored
-        root_package["Deps"]
-          .uniq
-          .reject { |name| @config.ignored?("type" => Go.type, "name" => name) }
+        dependency_packages
           .reject { |pkg| go_std_package?(pkg) }
-          .reject { |pkg| d.start_with?(root_package["ImportPath"]) && !vendored_path?(d) }
+          .reject { |pkg| local_package?(pkg) }
+      end
+
+      # Returns non-ignored packages found from the root packages "Deps" property
+      def root_package_deps
+        # check for ignored packages to avoid raising errors calling `go list`
+        # when ignored package is not found
+        Array(root_package["Deps"])
+          .reject { |name| @config.ignored?("type" => Go.type, "name" => name) }
           .map { |name| package_info(name) }
+      end
+
+      # Returns the list of dependencies as returned by "go list -json -deps"
+      # available in go 1.11
+      def go_list_deps
+        @go_list_deps ||= begin
+          deps = package_info_command("-deps")
+          # the CLI command returns packages in a pretty-printed JSON format but
+          # not separated by commas. this gsub adds commas after all non-indented
+          # "}" that close root level objects.
+          # (?!\z) uses negative lookahead to not match the final "}"
+          deps.gsub!(/^}(?!\z)$/m, "},")
+          JSON.parse("[#{deps}]")
+            .reject { |pkg| @config.ignored?("type" => Go.type, "name" => pkg["ImportPath"]) }
+            .each { |pkg| raise pkg.dig("Error", "Err") if pkg["Error"] }
+        end
       end
 
       # Returns whether the given package import path belongs to the
       # go std library or not
       #
-      # import_path - package import path to check
-      def go_std_package?(import_path)
+      # package - package to check as part of the go standard library
+      def go_std_package?(package)
+        return false unless package
+        return true if package["Standard"]
+
+        import_path = package["ImportPath"]
+        return false unless import_path
+
         # modify the import path to look like the import path `go list` returns for vendored std packages
         std_vendor_import_path = import_path.sub(%r{^#{root_package["ImportPath"]}/vendor/golang.org}, "vendor/golang_org")
         go_std_packages.include?(import_path) || go_std_packages.include?(std_vendor_import_path)
       end
 
-      # Returns the most recent git SHA for a package, or nil if SHA is
-      # not available
+      # Returns whether the package is local to the current project
+      def local_package?(package)
+        return false unless package && package["ImportPath"]
+        import_path = package["ImportPath"]
+        import_path.start_with?(root_package["ImportPath"]) && !vendored_path?(import_path)
+      end
+
+      # Returns the version for a given package
       #
-      # package_directory - package location
-      def package_version(package_directory)
+      # package - package to get version of
+      def package_version(package)
+        # use module version if it exists
+        go_mod = package["Module"]
+        return go_mod["Version"] if go_mod
+
+        package_directory = package["Dir"]
         return unless package_directory
 
+        # find most recent git SHA for a package, or nil if SHA is
+        # not available
         Dir.chdir package_directory do
           Licensed::Git.version(".")
         end
@@ -110,24 +155,23 @@ module Licensed
         import_path.split("vendor/")[1]
       end
 
-      # Returns package information, or {} if package isn't found
+      # Returns a hash of information about the package with a given import path
       #
-      # package - Go package import path
-      def package_info(package = nil)
-        JSON.parse(package_info_command(package))
+      # import_path - Go package import path
+      def package_info(import_path)
+        JSON.parse(package_info_command(import_path))
       end
 
       # Returns package information as a JSON string
       #
-      # package - Go package import path
-      def package_info_command(package)
-        package ||= ""
-        Licensed::Shell.execute("go", "list", "-json", package).strip
+      # args - additional arguments to `go list`, e.g. Go package import path
+      def package_info_command(*args)
+        Licensed::Shell.execute("go", "list", "-json", *Array(args)).strip
       end
 
       # Returns the info for the package under test
       def root_package
-        @root_package ||= package_info
+        @root_package ||= package_info(".")
       end
 
       # Returns whether go source is found
@@ -156,6 +200,15 @@ module Licensed
                            end
                     File.expand_path(path, root)
                   end
+      end
+
+      # Returns the current version of go available, as a Gem::Version
+      def go_version
+        @go_version ||= begin
+          full_version = Licensed::Shell.execute("go", "version").strip
+          version_string = full_version.gsub(%r{.*go(\d+\.\d+(\.\d+)?).*}, "\\1")
+          Gem::Version.new(version_string)
+        end
       end
 
       private

--- a/lib/licensed/source/go.rb
+++ b/lib/licensed/source/go.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require "json"
-require "English"
 require "pathname"
 
 module Licensed

--- a/lib/licensed/source/go.rb
+++ b/lib/licensed/source/go.rb
@@ -35,28 +35,6 @@ module Licensed
         end
       end
 
-      # Returns the most recent git SHA for a package, or nil if SHA is
-      # not available
-      #
-      # package_directory - package location
-      def package_version(package_directory)
-        return unless package_directory
-
-        Dir.chdir package_directory do
-          Licensed::Git.version(".")
-        end
-      end
-
-      # Returns the homepage for a package import_path.  Assumes that the
-      # import path itself is a url domain and path
-      def homepage(import_path)
-        return unless import_path
-
-        # hacky but generally works due to go packages looking like
-        # "github.com/..." or "golang.org/..."
-        "https://#{import_path}"
-      end
-
       # Returns an array of dependency package import paths
       def packages
         return [] unless root_package["Deps"]
@@ -79,6 +57,28 @@ module Licensed
         # modify the import path to look like the import path `go list` returns for vendored std packages
         std_vendor_import_path = import_path.sub(%r{^#{root_package["ImportPath"]}/vendor/golang.org}, "vendor/golang_org")
         go_std_packages.include?(import_path) || go_std_packages.include?(std_vendor_import_path)
+      end
+
+      # Returns the most recent git SHA for a package, or nil if SHA is
+      # not available
+      #
+      # package_directory - package location
+      def package_version(package_directory)
+        return unless package_directory
+
+        Dir.chdir package_directory do
+          Licensed::Git.version(".")
+        end
+      end
+
+      # Returns the homepage for a package import_path.  Assumes that the
+      # import path itself is a url domain and path
+      def homepage(import_path)
+        return unless import_path
+
+        # hacky but generally works due to go packages looking like
+        # "github.com/..." or "golang.org/..."
+        "https://#{import_path}"
       end
 
       # Returns the root directory to search for a package license

--- a/script/source-setup/go
+++ b/script/source-setup/go
@@ -12,8 +12,16 @@ export GOPATH="$BASE_PATH/test/fixtures/go"
 cd $BASE_PATH/test/fixtures/go
 
 if [ "$1" == "-f" ]; then
-  find . -not -regex "\.*" -and -not -path "*/src/test*" -and -not -path "*/src" -print0 | xargs -0 rm -rf
+  find . -not -regex "\.*" \
+    -and -not -path "*/src/test*" \
+    -and -not -path "*/src/modules_test*" \
+    -and -not -path "*/pkg/mod*" \
+    -and -not -path "*/pkg" \
+    -and -not -path "*/src" \
+    -print0 | xargs -0 rm -rf
+
+  go help mod >/dev/null && go clean -modcache
 fi
 
-cd src/test
-go get
+(cd src/test && go get)
+go help mod >/dev/null && (cd src/modules_test && GO111MODULE=on go mod download)

--- a/script/source-setup/go
+++ b/script/source-setup/go
@@ -20,8 +20,12 @@ if [ "$1" == "-f" ]; then
     -and -not -path "*/src" \
     -print0 | xargs -0 rm -rf
 
-  go help mod >/dev/null && go clean -modcache
+  if go help mod >/dev/null; then
+    go clean -modcache
+  fi
 fi
 
 (cd src/test && go get)
-go help mod >/dev/null && (cd src/modules_test && GO111MODULE=on go mod download)
+if go help mod >/dev/null; then
+  (cd src/modules_test && GO111MODULE=on go mod download)
+fi

--- a/test/command/cache_test.rb
+++ b/test/command/cache_test.rb
@@ -29,17 +29,18 @@ describe Licensed::Command::Cache do
       let(:expected_dependency) { config["expected_dependency"] }
 
       it "extracts license info" do
-        Dir.chdir config.source_path do
-          skip "#{source_type} not available" unless source.enabled?
+        config.apps.each do |app|
+          enabled = Dir.chdir(app.source_path) { source.enabled? }
+          next unless enabled
+
+          generator.run
+
+          path = app.cache_path.join("#{source.class.type}/#{expected_dependency}.txt")
+          assert path.exist?
+          license = Licensed::License.read(path)
+          assert_equal expected_dependency, license["name"]
+          assert license["license"]
         end
-
-        generator.run
-
-        path = config.cache_path.join("#{source.class.type}/#{expected_dependency}.txt")
-        assert path.exist?
-        license = Licensed::License.read(path)
-        assert_equal expected_dependency, license["name"]
-        assert license["license"]
       end
     end
   end

--- a/test/command/list_test.rb
+++ b/test/command/list_test.rb
@@ -22,13 +22,14 @@ describe Licensed::Command::List do
       let(:expected_dependency) { config["expected_dependency"] }
 
       it "lists dependencies" do
-        Dir.chdir config.source_path do
-          skip "#{source_type} not available" unless source.enabled?
-        end
+        config.apps.each do |app|
+          enabled = Dir.chdir(app.source_path) { source.enabled? }
+          next unless enabled
 
-        out, = capture_io { command.run }
-        assert_match(/Found #{expected_dependency}/, out)
-        assert_match(/#{source.class.type} dependencies:/, out)
+          out, = capture_io { command.run }
+          assert_match(/Found #{expected_dependency}/, out)
+          assert_match(/#{source.class.type} dependencies:/, out)
+        end
       end
     end
   end

--- a/test/fixtures/command/go.yml
+++ b/test/fixtures/command/go.yml
@@ -1,4 +1,7 @@
 expected_dependency: github.com/gorilla/context
-source_path: test/fixtures/go/src/test
 go:
   GOPATH: test/fixtures/go
+
+apps:
+  - source_path: test/fixtures/go/src/test
+  - source_path: test/fixtures/go

--- a/test/fixtures/go/src/modules_test/go.mod
+++ b/test/fixtures/go/src/modules_test/go.mod
@@ -1,0 +1,7 @@
+module modules_test
+
+require (
+	github.com/gorilla/context v1.1.1
+	github.com/hashicorp/golang-lru v0.5.0
+	golang.org/x/net v0.0.0-20181220203305-927f97764cc3
+)

--- a/test/fixtures/go/src/modules_test/go.sum
+++ b/test/fixtures/go/src/modules_test/go.sum
@@ -1,0 +1,6 @@
+github.com/gorilla/context v1.1.1 h1:AWwleXJkX/nhcU9bZSnZoi3h/qGYqQAGhq6zZe/aQW8=
+github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
+github.com/hashicorp/golang-lru v0.5.0 h1:CL2msUPvZTLb5O648aiLNJw3hnBxN2+1Jq8rCOH9wdo=
+github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+golang.org/x/net v0.0.0-20181220203305-927f97764cc3 h1:eH6Eip3UpmR+yM/qI9Ijluzb1bNv/cAU/n+6l8tRSis=
+golang.org/x/net v0.0.0-20181220203305-927f97764cc3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/test/fixtures/go/src/modules_test/test.go
+++ b/test/fixtures/go/src/modules_test/test.go
@@ -1,0 +1,13 @@
+package test
+
+import (
+  lru "github.com/hashicorp/golang-lru"
+  ctx "github.com/gorilla/context"
+  "golang.org/x/net/http2/hpack"
+)
+
+func main() { 
+  lru.New(1)
+  ctx.Purge(0)
+  _ = hpack.ErrInvalidHuffman
+}


### PR DESCRIPTION
This PR updates the Go dependency source enumerator to better support newer versions of the Go language.

1. Uses the `go list -deps` option to get all dependencies in a single call rather than needing to call `go list` for each dependency.
2. If a go project is set up to use modules, uses the modules version number instead of a git SHA1 for version information

This ended up including a non-trivial refactor of the go dependency source to give an easy branching point for sourcing package information for older go versions vs `go list -deps` as described in (1) ☝️ .