### PR TITLE
Remove deprecated options in v2

### DIFF
--- a/lib/licensed/cli.rb
+++ b/lib/licensed/cli.rb
@@ -8,8 +8,6 @@ module Licensed
     desc "cache", "Cache the licenses of dependencies"
     method_option :force, type: :boolean,
       desc: "Overwrite licenses even if version has not changed."
-    method_option :offline, type: :boolean,
-      desc: "This option is deprecated and will be removed in the next major release."
     method_option :config, aliases: "-c", type: :string,
       desc: "Path to licensed configuration file"
     def cache


### PR DESCRIPTION
This PR removes the deprecated `licensed cache --offline` option as part of the cleanup and breaking changes for a v2 release.

I couldn't find any references to the option remaining in the codebase so it shouldn't require more than the simple cleanup.