### PR TITLE
Save license and notice content as yaml

### DIFF
--- a/lib/licensed/command/cache.rb
+++ b/lib/licensed/command/cache.rb
@@ -31,7 +31,7 @@ module Licensed
                 version = dependency.version
 
                 names << name
-                filename = cache_path.join("#{name}.txt")
+                filename = cache_path.join("#{name}.dependency")
 
                 # try to load existing license from disk
                 # or default to a blank license
@@ -53,10 +53,10 @@ module Licensed
               end
 
               # Clean up cached files that dont match current dependencies
-              Dir.glob(cache_path.join("**/*.txt")).each do |file|
+              Dir.glob(cache_path.join("**/*.dependency")).each do |file|
                 file_path = Pathname.new(file)
                 relative_path = file_path.relative_path_from(cache_path).to_s
-                FileUtils.rm(file) unless names.include?(relative_path.chomp(".txt"))
+                FileUtils.rm(file) unless names.include?(relative_path.chomp(".dependency"))
               end
 
               "* #{app_name} #{type} dependencies: #{source.dependencies.size}"

--- a/lib/licensed/command/cache.rb
+++ b/lib/licensed/command/cache.rb
@@ -31,7 +31,7 @@ module Licensed
                 version = dependency.version
 
                 names << name
-                filename = cache_path.join("#{name}.dependency")
+                filename = cache_path.join("#{name}.#{License::EXTENSION}")
 
                 # try to load existing license from disk
                 # or default to a blank license
@@ -53,10 +53,10 @@ module Licensed
               end
 
               # Clean up cached files that dont match current dependencies
-              Dir.glob(cache_path.join("**/*.dependency")).each do |file|
+              Dir.glob(cache_path.join("**/*.#{License::EXTENSION}")).each do |file|
                 file_path = Pathname.new(file)
                 relative_path = file_path.relative_path_from(cache_path).to_s
-                FileUtils.rm(file) unless names.include?(relative_path.chomp(".dependency"))
+                FileUtils.rm(file) unless names.include?(relative_path.chomp(".#{License::EXTENSION}"))
               end
 
               "* #{app_name} #{type} dependencies: #{source.dependencies.size}"

--- a/lib/licensed/command/status.rb
+++ b/lib/licensed/command/status.rb
@@ -22,7 +22,7 @@ module Licensed
 
             results = dependencies.map do |dependency|
               name = dependency.name
-              filename = app.cache_path.join(dependency.data["type"], "#{name}.txt")
+              filename = app.cache_path.join(dependency.data["type"], "#{name}.dependency")
 
               warnings = []
 

--- a/lib/licensed/command/status.rb
+++ b/lib/licensed/command/status.rb
@@ -22,7 +22,7 @@ module Licensed
 
             results = dependencies.map do |dependency|
               name = dependency.name
-              filename = app.cache_path.join(dependency.data["type"], "#{name}.dependency")
+              filename = app.cache_path.join(dependency.data["type"], "#{name}.#{License::EXTENSION}")
 
               warnings = []
 

--- a/lib/licensed/dependency.rb
+++ b/lib/licensed/dependency.rb
@@ -39,14 +39,15 @@ module Licensed
     # except the package file, which doesn't contain license text.
     def license_contents
       matched_files.reject { |f| f == package_file }
-                   .map(&:content)
+                   .group_by(&:content)
+                   .map { |content, files| { "sources" => content_sources(files), "text" => content } }
     end
 
     # Returns legal notices found at the dependency path
     def notice_contents
       notice_files.sort # sorted by the path
-                  .map { |f| File.read(f).rstrip } # read the file contents
-                  .select { |t| t.length > 0 } # files with content only
+                  .map { |file| { "sources" => content_sources(file), "text" => File.read(file).rstrip } }
+                  .select { |text| text.length > 0 } # files with content only
     end
 
     # Returns an array of file paths used to locate legal notices
@@ -59,6 +60,30 @@ module Licensed
     end
 
     private
+
+    # Returns the sources for a group of license or notice file contents
+    #
+    # Sources are returned as a single string with sources separated by ", "
+    def content_sources(files)
+      paths = Array(files).map do |file|
+        path = if file.is_a?(Licensee::ProjectFiles::ProjectFile)
+          dir_path.join(file[:dir], file[:name])
+        else
+          Pathname.new(file).expand_path(dir_path)
+        end
+
+        if path.fnmatch?(dir_path.join("**").to_path)
+          # files under the dependency path return the relative path to the file
+          path.relative_path_from(dir_path).to_path
+        else
+          # otherwise return the source_path as the immediate parent folder name
+          # joined with the file name
+          path.dirname.basename.join(path.basename).to_path
+        end
+      end
+
+      paths.join(", ")
+    end
 
     # Returns the metadata that represents this dependency.  This metadata
     # is written to YAML in the dependencys cached text file

--- a/lib/licensed/license.rb
+++ b/lib/licensed/license.rb
@@ -8,6 +8,8 @@ module Licensed
     include Licensee::ContentHelper
     extend Forwardable
 
+    EXTENSION = "dep.yml".freeze
+
     # Read an existing license file
     #
     # filename - A String path to the file

--- a/lib/licensed/license.rb
+++ b/lib/licensed/license.rb
@@ -70,7 +70,7 @@ module Licensed
     # Returns whether two licenses match based on their contents
     def matches?(other)
       return false unless other.is_a?(License)
-      return false if self.content_normalized.nil?
+      return false if self.content.nil?
 
       self.content_normalized == other.content_normalized
     end

--- a/lib/licensed/license.rb
+++ b/lib/licensed/license.rb
@@ -34,8 +34,8 @@ module Licensed
     # notices - a string, or array of strings, representing the
     # metadata - a Hash of the metadata for the package
     def initialize(licenses: [], notices: [], metadata: {})
-      @licenses = Array(licenses).compact
-      @notices = Array(notices).compact
+      @licenses = [licenses].flatten.compact
+      @notices = [notices].flatten.compact
       @metadata = metadata
     end
 
@@ -56,7 +56,13 @@ module Licensed
     # `Licensee::CotentHelper`
     def content
       return if licenses.nil? || licenses.empty?
-      licenses.join
+      licenses.map do |license|
+        if license.is_a?(String)
+          license
+        elsif license.respond_to?(:[])
+          license["text"]
+        end
+      end.join
     end
 
     # Returns whether two licenses match based on their contents

--- a/test/command/cache_test.rb
+++ b/test/command/cache_test.rb
@@ -36,7 +36,7 @@ describe Licensed::Command::Cache do
 
           generator.run
 
-          path = app.cache_path.join("#{source_type}/#{expected_dependency}.dependency")
+          path = app.cache_path.join("#{source_type}/#{expected_dependency}.#{Licensed::License::EXTENSION}")
           assert path.exist?
           license = Licensed::License.read(path)
           assert_equal expected_dependency, license["name"]
@@ -48,23 +48,23 @@ describe Licensed::Command::Cache do
 
   it "cleans up old dependencies" do
     FileUtils.mkdir_p config.cache_path.join("test")
-    File.write config.cache_path.join("test/old_dep.dependency"), ""
+    File.write config.cache_path.join("test/old_dep.#{Licensed::License::EXTENSION}"), ""
     generator.run
-    refute config.cache_path.join("test/old_dep.dependency").exist?
+    refute config.cache_path.join("test/old_dep.#{Licensed::License::EXTENSION}").exist?
   end
 
   it "cleans up ignored dependencies" do
     FileUtils.mkdir_p config.cache_path.join("test")
-    File.write config.cache_path.join("test/dependency.dependency"), ""
+    File.write config.cache_path.join("test/dependency.#{Licensed::License::EXTENSION}"), ""
     config.ignore "type" => "test", "name" => "dependency"
     generator.run
-    refute config.cache_path.join("test/dependency.dependency").exist?
+    refute config.cache_path.join("test/dependency.#{Licensed::License::EXTENSION}").exist?
   end
 
   it "uses cached license if license text does not change" do
     generator.run
 
-    path = config.cache_path.join("test/dependency.dependency")
+    path = config.cache_path.join("test/dependency.#{Licensed::License::EXTENSION}")
     license = Licensed::License.read(path)
     license["license"] = "test"
     license["version"] = "0.0"
@@ -80,7 +80,7 @@ describe Licensed::Command::Cache do
   it "does not reuse nil license version" do
     generator.run
 
-    path = config.cache_path.join("test/dependency.dependency")
+    path = config.cache_path.join("test/dependency.#{Licensed::License::EXTENSION}")
     license = Licensed::License.read(path)
     license["license"] = "test"
     license.save(path)
@@ -105,7 +105,7 @@ describe Licensed::Command::Cache do
   it "does not reuse empty license version" do
     generator.run
 
-    path = config.cache_path.join("test/dependency.dependency")
+    path = config.cache_path.join("test/dependency.#{Licensed::License::EXTENSION}")
     license = Licensed::License.read(path)
     license["license"] = "test"
     license["version"] = ""
@@ -134,7 +134,7 @@ describe Licensed::Command::Cache do
     count = out.match(/dependencies: (\d+)/)[1].to_i
 
     FileUtils.mkdir_p config.cache_path.join("test")
-    File.write config.cache_path.join("test/dependency.dependency"), ""
+    File.write config.cache_path.join("test/dependency.#{Licensed::License::EXTENSION}"), ""
     config.ignore "type" => "test", "name" => "dependency"
 
     out, _ = capture_io { generator.run }
@@ -161,8 +161,8 @@ describe Licensed::Command::Cache do
 
     it "caches metadata for all apps" do
       generator.run
-      assert config["apps"][0].cache_path.join("test/dependency.dependency").exist?
-      assert config["apps"][1].cache_path.join("test/dependency.dependency").exist?
+      assert config["apps"][0].cache_path.join("test/dependency.#{Licensed::License::EXTENSION}").exist?
+      assert config["apps"][1].cache_path.join("test/dependency.#{Licensed::License::EXTENSION}").exist?
     end
   end
 
@@ -180,7 +180,7 @@ describe Licensed::Command::Cache do
 
     it "caches metadata at the given file path" do
       generator.run
-      assert config.cache_path.join("test/dependency/path.dependency").exist?
+      assert config.cache_path.join("test/dependency/path.#{Licensed::License::EXTENSION}").exist?
     end
   end
 end

--- a/test/command/cache_test.rb
+++ b/test/command/cache_test.rb
@@ -36,7 +36,7 @@ describe Licensed::Command::Cache do
 
           generator.run
 
-          path = app.cache_path.join("#{source_type}/#{expected_dependency}.txt")
+          path = app.cache_path.join("#{source_type}/#{expected_dependency}.dependency")
           assert path.exist?
           license = Licensed::License.read(path)
           assert_equal expected_dependency, license["name"]
@@ -48,23 +48,23 @@ describe Licensed::Command::Cache do
 
   it "cleans up old dependencies" do
     FileUtils.mkdir_p config.cache_path.join("test")
-    File.write config.cache_path.join("test/old_dep.txt"), ""
+    File.write config.cache_path.join("test/old_dep.dependency"), ""
     generator.run
-    refute config.cache_path.join("test/old_dep.txt").exist?
+    refute config.cache_path.join("test/old_dep.dependency").exist?
   end
 
   it "cleans up ignored dependencies" do
     FileUtils.mkdir_p config.cache_path.join("test")
-    File.write config.cache_path.join("test/dependency.txt"), ""
+    File.write config.cache_path.join("test/dependency.dependency"), ""
     config.ignore "type" => "test", "name" => "dependency"
     generator.run
-    refute config.cache_path.join("test/dependency.txt").exist?
+    refute config.cache_path.join("test/dependency.dependency").exist?
   end
 
   it "uses cached license if license text does not change" do
     generator.run
 
-    path = config.cache_path.join("test/dependency.txt")
+    path = config.cache_path.join("test/dependency.dependency")
     license = Licensed::License.read(path)
     license["license"] = "test"
     license["version"] = "0.0"
@@ -80,7 +80,7 @@ describe Licensed::Command::Cache do
   it "does not reuse nil license version" do
     generator.run
 
-    path = config.cache_path.join("test/dependency.txt")
+    path = config.cache_path.join("test/dependency.dependency")
     license = Licensed::License.read(path)
     license["license"] = "test"
     license.save(path)
@@ -105,7 +105,7 @@ describe Licensed::Command::Cache do
   it "does not reuse empty license version" do
     generator.run
 
-    path = config.cache_path.join("test/dependency.txt")
+    path = config.cache_path.join("test/dependency.dependency")
     license = Licensed::License.read(path)
     license["license"] = "test"
     license["version"] = ""
@@ -134,7 +134,7 @@ describe Licensed::Command::Cache do
     count = out.match(/dependencies: (\d+)/)[1].to_i
 
     FileUtils.mkdir_p config.cache_path.join("test")
-    File.write config.cache_path.join("test/dependency.txt"), ""
+    File.write config.cache_path.join("test/dependency.dependency"), ""
     config.ignore "type" => "test", "name" => "dependency"
 
     out, _ = capture_io { generator.run }
@@ -161,8 +161,8 @@ describe Licensed::Command::Cache do
 
     it "caches metadata for all apps" do
       generator.run
-      assert config["apps"][0].cache_path.join("test/dependency.txt").exist?
-      assert config["apps"][1].cache_path.join("test/dependency.txt").exist?
+      assert config["apps"][0].cache_path.join("test/dependency.dependency").exist?
+      assert config["apps"][1].cache_path.join("test/dependency.dependency").exist?
     end
   end
 
@@ -180,7 +180,7 @@ describe Licensed::Command::Cache do
 
     it "caches metadata at the given file path" do
       generator.run
-      assert config.cache_path.join("test/dependency/path.txt").exist?
+      assert config.cache_path.join("test/dependency/path.dependency").exist?
     end
   end
 end

--- a/test/command/status_test.rb
+++ b/test/command/status_test.rb
@@ -36,11 +36,11 @@ describe Licensed::Command::Status do
 
   it "does not warn if dependency is ignored" do
     out, _ = capture_io { verifier.run }
-    assert_match(/dependency.txt/, out)
+    assert_match(/dependency.dependency/, out)
 
     config.ignore "type" => "test", "name" => "dependency"
     out, _ = capture_io { verifier.run }
-    refute_match(/dependency.txt/, out)
+    refute_match(/dependency.dependency/, out)
   end
 
   it "does not warn if dependency is reviewed" do
@@ -53,7 +53,7 @@ describe Licensed::Command::Status do
   end
 
   it "warns if license is empty" do
-    filename = config.cache_path.join("test/dependency.txt")
+    filename = config.cache_path.join("test/dependency.dependency")
     license = Licensed::License.new
     license.save(filename)
 
@@ -62,7 +62,7 @@ describe Licensed::Command::Status do
   end
 
   it "warns if license is empty with notices" do
-    filename = config.cache_path.join("test/dependency.txt")
+    filename = config.cache_path.join("test/dependency.dependency")
     license = Licensed::License.new(notices: ["notice"])
     license.save(filename)
 
@@ -71,7 +71,7 @@ describe Licensed::Command::Status do
   end
 
   it "does not warn if license is not empty" do
-    filename = config.cache_path.join("test/dependency.txt")
+    filename = config.cache_path.join("test/dependency.dependency")
     license = Licensed::License.new(licenses: ["license"])
     license.save(filename)
 
@@ -80,7 +80,7 @@ describe Licensed::Command::Status do
   end
 
   it "warns if versions do not match" do
-    filename = config.cache_path.join("test/dependency.txt")
+    filename = config.cache_path.join("test/dependency.dependency")
     license = Licensed::License.read(filename)
     license["version"] = "9001"
     license.save(filename)
@@ -90,13 +90,13 @@ describe Licensed::Command::Status do
   end
 
   it "warns if cached license data missing" do
-    FileUtils.rm config.cache_path.join("test/dependency.txt")
+    FileUtils.rm config.cache_path.join("test/dependency.dependency")
     out, _ = capture_io { verifier.run }
     assert_match(/cached license data missing/, out)
   end
 
   it "does not warn if cached license data missing for ignored gem" do
-    FileUtils.rm config.cache_path.join("test/dependency.txt")
+    FileUtils.rm config.cache_path.join("test/dependency.dependency")
     config.ignore "type" => "test", "name" => "dependency"
 
     out, _ = capture_io { verifier.run }
@@ -152,7 +152,7 @@ describe Licensed::Command::Status do
     let(:source) { TestSource.new(config, "dependency/path", "name" => "dependency") }
 
     it "verifies content at explicit path" do
-      filename = config.cache_path.join("test/dependency/path.txt")
+      filename = config.cache_path.join("test/dependency/path.dependency")
       license = Licensed::License.new
       license.save(filename)
 

--- a/test/command/status_test.rb
+++ b/test/command/status_test.rb
@@ -36,11 +36,11 @@ describe Licensed::Command::Status do
 
   it "does not warn if dependency is ignored" do
     out, _ = capture_io { verifier.run }
-    assert_match(/dependency.dependency/, out)
+    assert_match(/dependency.#{Licensed::License::EXTENSION}/, out)
 
     config.ignore "type" => "test", "name" => "dependency"
     out, _ = capture_io { verifier.run }
-    refute_match(/dependency.dependency/, out)
+    refute_match(/dependency.#{Licensed::License::EXTENSION}/, out)
   end
 
   it "does not warn if dependency is reviewed" do
@@ -53,7 +53,7 @@ describe Licensed::Command::Status do
   end
 
   it "warns if license is empty" do
-    filename = config.cache_path.join("test/dependency.dependency")
+    filename = config.cache_path.join("test/dependency.#{Licensed::License::EXTENSION}")
     license = Licensed::License.new
     license.save(filename)
 
@@ -62,7 +62,7 @@ describe Licensed::Command::Status do
   end
 
   it "warns if license is empty with notices" do
-    filename = config.cache_path.join("test/dependency.dependency")
+    filename = config.cache_path.join("test/dependency.#{Licensed::License::EXTENSION}")
     license = Licensed::License.new(notices: ["notice"])
     license.save(filename)
 
@@ -71,7 +71,7 @@ describe Licensed::Command::Status do
   end
 
   it "does not warn if license is not empty" do
-    filename = config.cache_path.join("test/dependency.dependency")
+    filename = config.cache_path.join("test/dependency.#{Licensed::License::EXTENSION}")
     license = Licensed::License.new(licenses: ["license"])
     license.save(filename)
 
@@ -80,7 +80,7 @@ describe Licensed::Command::Status do
   end
 
   it "warns if versions do not match" do
-    filename = config.cache_path.join("test/dependency.dependency")
+    filename = config.cache_path.join("test/dependency.#{Licensed::License::EXTENSION}")
     license = Licensed::License.read(filename)
     license["version"] = "9001"
     license.save(filename)
@@ -90,13 +90,13 @@ describe Licensed::Command::Status do
   end
 
   it "warns if cached license data missing" do
-    FileUtils.rm config.cache_path.join("test/dependency.dependency")
+    FileUtils.rm config.cache_path.join("test/dependency.#{Licensed::License::EXTENSION}")
     out, _ = capture_io { verifier.run }
     assert_match(/cached license data missing/, out)
   end
 
   it "does not warn if cached license data missing for ignored gem" do
-    FileUtils.rm config.cache_path.join("test/dependency.dependency")
+    FileUtils.rm config.cache_path.join("test/dependency.#{Licensed::License::EXTENSION}")
     config.ignore "type" => "test", "name" => "dependency"
 
     out, _ = capture_io { verifier.run }
@@ -152,7 +152,7 @@ describe Licensed::Command::Status do
     let(:source) { TestSource.new(config, "dependency/path", "name" => "dependency") }
 
     it "verifies content at explicit path" do
-      filename = config.cache_path.join("test/dependency/path.dependency")
+      filename = config.cache_path.join("test/dependency/path.#{Licensed::License::EXTENSION}")
       license = Licensed::License.new
       license.save(filename)
 

--- a/test/dependency_test.rb
+++ b/test/dependency_test.rb
@@ -25,8 +25,10 @@ describe Licensed::Dependency do
         assert_equal "mit", dependency.data["license"]
         assert_equal "test", dependency.data["name"]
         assert_equal "1.0", dependency.version
-        assert_includes dependency.data.licenses, Licensee::License.find("mit").text
-        assert_includes dependency.data.notices, "author"
+        assert_includes dependency.data.licenses,
+                        { "sources" => "LICENSE", "text" => Licensee::License.find("mit").text }
+        assert_includes dependency.data.notices,
+                        { "sources" => "AUTHORS", "text" => "author" }
       end
     end
 
@@ -111,21 +113,23 @@ describe Licensed::Dependency do
     it "gets license content from license file" do
       mkproject do |dependency|
         File.write "LICENSE", Licensee::License.find("mit").text
-        assert_includes dependency.license_contents, Licensee::License.find("mit").text
+        assert_includes dependency.data.licenses,
+                        { "sources" => "LICENSE", "text" => Licensee::License.find("mit").text }
       end
     end
 
     it "does not get license content from package manager file" do
       mkproject do |dependency|
         File.write "project.gemspec", "s.license = 'mit'"
-        assert_empty dependency.license_contents
+        assert_empty dependency.data.licenses
       end
     end
 
     it "gets license from readme" do
       mkproject do |dependency|
         File.write "README.md", "# License\n" + Licensee::License.find("mit").text
-        assert_includes dependency.license_contents, Licensee::License.find("mit").text.rstrip
+        assert_includes dependency.data.licenses,
+                        { "sources" => "README.md", "text" => Licensee::License.find("mit").text.rstrip }
       end
     end
 
@@ -133,7 +137,8 @@ describe Licensed::Dependency do
       mkproject do |dependency|
         File.write "project.gemspec", "foo"
         File.write "README.md", "# License\n" + Licensee::License.find("mit").text
-        assert_includes dependency.license_contents, Licensee::License.find("mit").text.rstrip
+        assert_includes dependency.data.licenses,
+                        { "sources" => "README.md", "text" => Licensee::License.find("mit").text.rstrip }
       end
     end
 
@@ -142,8 +147,10 @@ describe Licensed::Dependency do
         File.write "LICENSE", Licensee::License.find("mit").text
         File.write "LICENSE.md", Licensee::License.find("bsd-3-clause").text
 
-        assert_includes dependency.license_contents, Licensee::License.find("mit").text
-        assert_includes dependency.license_contents, Licensee::License.find("bsd-3-clause").text
+        assert_includes dependency.data.licenses,
+                        { "sources" => "LICENSE", "text" => Licensee::License.find("mit").text }
+        assert_includes dependency.data.licenses,
+                        { "sources" => "LICENSE.md", "text" => Licensee::License.find("bsd-3-clause").text }
       end
     end
 
@@ -152,8 +159,10 @@ describe Licensed::Dependency do
         File.write "LICENSE", Licensee::License.find("mit").text
         File.write "README.md", "# License\n" + Licensee::License.find("bsd-3-clause").text
 
-        assert_includes dependency.license_contents, Licensee::License.find("mit").text
-        assert_includes dependency.license_contents, Licensee::License.find("bsd-3-clause").text.rstrip
+        assert_includes dependency.data.licenses,
+                        { "sources" => "LICENSE", "text" => Licensee::License.find("mit").text }
+        assert_includes dependency.data.licenses,
+                        { "sources" => "README.md", "text" => Licensee::License.find("bsd-3-clause").text.rstrip }
       end
     end
 
@@ -165,9 +174,21 @@ describe Licensed::Dependency do
           Dir.mkdir "dependency"
           Dir.chdir "dependency" do
             dep = Licensed::Dependency.new(name: "test", version: "1.0", path: Dir.pwd, search_root: File.expand_path(".."))
-            assert_includes dep.license_contents, "license"
+            source = Pathname.new(dir).basename.join("LICENSE").to_path
+            assert_includes dep.data.licenses,
+                            { "sources" => source, "text" => "license" }
           end
         end
+      end
+    end
+
+    it "attributes the same content to multiple sources" do
+      mkproject do |dependency|
+        File.write "LICENSE", Licensee::License.find("mit").text
+        File.write "LICENSE.md", Licensee::License.find("mit").text
+
+        assert_includes dependency.data.licenses,
+                        { "sources" => "LICENSE, LICENSE.md", "text" => Licensee::License.find("mit").text }
       end
     end
   end
@@ -179,9 +200,12 @@ describe Licensed::Dependency do
         File.write "NOTICE", "notice"
         File.write "LEGAL", "legal"
 
-        assert_includes dependency.notice_contents, "authors"
-        assert_includes dependency.notice_contents, "notice"
-        assert_includes dependency.notice_contents, "legal"
+        assert_includes dependency.data.notices,
+                        { "sources" => "AUTHORS", "text" => "authors" }
+        assert_includes dependency.data.notices,
+                        { "sources" => "NOTICE", "text" => "notice" }
+        assert_includes dependency.data.notices,
+                        { "sources" => "LEGAL", "text" => "legal" }
       end
     end
 
@@ -191,9 +215,12 @@ describe Licensed::Dependency do
         File.write "NOTICE", ""
         File.write "LEGAL", "legal"
 
-        refute_includes dependency.notice_contents, "authors"
-        refute_includes dependency.notice_contents, "notice"
-        assert_includes dependency.notice_contents, "legal"
+        refute_includes dependency.data.notices,
+                        { "sources" => "AUTHORS", "text" => "authors" }
+        refute_includes dependency.data.notices,
+                        { "sources" => "NOTICE", "text" => "notice" }
+        assert_includes dependency.data.notices,
+                        { "sources" => "LEGAL", "text" => "legal" }
       end
     end
   end

--- a/test/license_test.rb
+++ b/test/license_test.rb
@@ -16,18 +16,12 @@ describe Licensed::License do
     end
 
     it "loads dependency information from a file" do
-      File.write(@filename, <<~CONTENT.rstrip)
-        ---
-        name: test
-        ---
-        license1
-        #{Licensed::License::LICENSE_SEPARATOR}
-        license2
-        #{Licensed::License::TEXT_SEPARATOR}
-        notice
-        #{Licensed::License::TEXT_SEPARATOR}
-        author
-      CONTENT
+      data = {
+        "name" => "test",
+        "licenses" => ["license1", "license2"],
+        "notices" => ["notice", "author"]
+      }
+      File.write(@filename, data.to_yaml)
 
       content = Licensed::License.read(@filename)
       assert_equal "test", content["name"]
@@ -47,22 +41,21 @@ describe Licensed::License do
       assert_equal <<~CONTENT, File.read(@filename)
         ---
         name: test
-        ---
-        license
-        #{Licensed::License::TEXT_SEPARATOR}
-        notice
+        licenses:
+        - license
+        notices:
+        - notice
       CONTENT
     end
 
-    it "always contains a license text section if there are legal notices" do
-      license = Licensed::License.new(notices: "notice", metadata: { "name" => "test" })
+    it "always contains a licenses and notices properties" do
+      license = Licensed::License.new(metadata: { "name" => "test" })
       license.save(@filename)
       assert_equal <<~CONTENT, File.read(@filename)
         ---
         name: test
-        ---
-        #{Licensed::License::TEXT_SEPARATOR}
-        notice
+        licenses: []
+        notices: []
       CONTENT
     end
   end

--- a/test/license_test.rb
+++ b/test/license_test.rb
@@ -68,7 +68,7 @@ describe Licensed::License do
 
     it "returns joined text of all licenses" do
       license = Licensed::License.new(licenses: ["license1", "license2"])
-      assert_equal license.licenses.join, license.content
+      assert_equal "license1license2", license.content
     end
   end
 
@@ -79,9 +79,17 @@ describe Licensed::License do
       refute license.matches? ""
     end
 
-    it "returns true if the normalized content is the same" do
+    it "returns true if the normalized content is the same for strings" do
       license = Licensed::License.new(licenses: "- test content")
       other = Licensed::License.new(licenses: "* test content")
+
+      assert license.matches?(other)
+    end
+
+    it "returns true if the normalized content is the same for text+source data" do
+
+      license = Licensed::License.new(licenses: { "text" => "- test content" })
+      other = Licensed::License.new(licenses: { "text" => "* test content" })
 
       assert license.matches?(other)
     end

--- a/test/sources/go_test.rb
+++ b/test/sources/go_test.rb
@@ -104,11 +104,13 @@ if Licensed::Shell.tool_available?("go")
 
           # find the license one directory higher
           license_path = File.join(fixtures, "vendor/github.com/davecgh/go-spew/LICENSE")
-          assert_includes dep.data.licenses, File.read(license_path)
+          assert_includes dep.data.licenses,
+                          { "sources" => "go-spew/LICENSE", "text" => File.read(license_path) }
 
           # do not find the license outside the vendor folder
           license_path = File.join(fixtures, "LICENSE")
-          refute_includes dep.data.licenses, File.read(license_path)
+          refute_includes dep.data.licenses,
+                          { "sources" => "LICENSE", "text" => File.read(license_path) }
         end
       end
 
@@ -118,7 +120,8 @@ if Licensed::Shell.tool_available?("go")
           assert dep
 
           license_path = File.join(gopath, "src/github.com/hashicorp/golang-lru/LICENSE")
-          assert_includes dep.data.licenses, File.read(license_path)
+          assert_includes dep.data.licenses,
+                          { "sources" => "golang-lru/LICENSE", "text" => File.read(license_path) }
         end
       end
 

--- a/test/sources/manifest_test.rb
+++ b/test/sources/manifest_test.rb
@@ -49,7 +49,8 @@ describe Licensed::Sources::Manifest do
       assert_equal "mit", dep.data["license"]
 
       license_path = File.join(config.root, config.dig("manifest", "licenses", "manifest_test"))
-      assert_includes dep.data.licenses, File.read(license_path)
+      assert_includes dep.data.licenses,
+                      { "sources" => "LICENSE", "text" => File.read(license_path) }
     end
 
     it "prefers licenses from license files" do
@@ -59,18 +60,22 @@ describe Licensed::Sources::Manifest do
       refute_empty dep.data.licenses
     end
 
-    it "detects license from source header comments if license files are not found" do
+    it "detects unique license content from redundant source header comments" do
       dep = source.dependencies.detect { |d| d.name == "bsd3_single_header_license" }
       assert dep
       assert_equal "bsd-3-clause", dep.data["license"]
-      assert_equal 1, dep.data.licenses.uniq.size
+      assert_equal 1, dep.data.licenses.size
+
+      _, sources = source.packages.detect { |name, _| name == "bsd3_single_header_license" }
+      assert_equal sources.map { |s| File.basename(s) }.join(", "),
+                   dep.data.licenses.first["sources"]
     end
 
     it "detects unique license content from multiple headers" do
       dep = source.dependencies.detect { |d| d.name == "bsd3_multi_header_license" }
       assert dep
       assert_equal "bsd-3-clause", dep.data["license"]
-      assert_equal 2, dep.data.licenses.uniq.size
+      assert_equal 2, dep.data.licenses.size
     end
 
     it "preserves legal notices when detecting license content from comments" do


### PR DESCRIPTION
This change saves detected license and notice files contents as YAML in order to make the file contents easier to parse by automated tools.

<details>
<summary>Example YAML contents</summary>

```
---
name: test
version: '1.0'
license: other
licenses:
- sources: LICENSE, LICENSE.md
  text: |
    MIT License

    Copyright (c) [year] [fullname]

    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal
    in the Software without restriction, including without limitation the rights
    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
    copies of the Software, and to permit persons to whom the Software is
    furnished to do so, subject to the following conditions:

    The above copyright notice and this permission notice shall be included in all
    copies or substantial portions of the Software.

    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
    SOFTWARE.
- sources: COPYING
  text: |
    BSD 3-Clause License

    Copyright (c) [year], [fullname]
    All rights reserved.

    Redistribution and use in source and binary forms, with or without
    modification, are permitted provided that the following conditions are met:

    * Redistributions of source code must retain the above copyright notice, this
      list of conditions and the following disclaimer.

    * Redistributions in binary form must reproduce the above copyright notice,
      this list of conditions and the following disclaimer in the documentation
      and/or other materials provided with the distribution.

    * Neither the name of the copyright holder nor the names of its
      contributors may be used to endorse or promote products derived from
      this software without specific prior written permission.

    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
notices: []
```
</details>
<br/>

Besides the obvious breaking change of the file format, I've also renamed the file extension to `.dependency`.  These files are pure YAML, however I have a small concern that there the licensed configuration file could be saved to the license cache directory, both to collocate relevant files and to avoid polluting the root project directory.  Using a unique extension should make it easier to distinguish the saved dependency information from other YAML files.

In saving the text contents to YAML properties, I've added the content source information per @mlinksva's [suggestion](https://github.com/github/licensed/pull/118#issuecomment-451357851).  For licenses, I've grouped the sources based on each licenses content - if two or more licenses match exactly on their content, the content will only be displayed once and the sources field will reference both files that the data came from.  See above for an example where both `LICENSE` and `LICENSE.md` contained the same data and are grouped together.