### PR TITLE
Exclude path pathed-gem-fixture from deletion

### DIFF
--- a/script/source-setup/bundler
+++ b/script/source-setup/bundler
@@ -14,7 +14,7 @@ cd $BASE_PATH/test/fixtures/bundler
 unset BUNDLE_GEMFILE
 
 if [ "$1" == "-f" ]; then
-  find . -not -regex "\.*" -and -not -name "Gemfile" -print0 | xargs -0 rm -rf
+  find . -not -regex "\.*" -and -not -name "Gemfile" -and -not \( -path ./pathed-gem-fixture -prune \) -print0 | xargs -0 rm -rf
 fi
 
 bundle install --path vendor/gems --without ignore


### PR DESCRIPTION
What problem does this PR fix?

Under https://github.com/github/licensed#development step 3, if running with the -f flag, for bundler test fixture dir pathed-gem-fixture is deleted, making the operation fail. This was added in https://github.com/github/licensed/commit/f7206b944fff64cb901e0c444e8c564a646e50dc#diff-d770942fbfe9a22001fe856a9fa834da

Solution proposal in this PR:
Avoid deleting that dir by excluding it in the deletion shell-script.