### PR TITLE
Remove AppConfiguration#ui

### DIFF
--- a/docs/sources/bundler.md
+++ b/docs/sources/bundler.md
@@ -6,13 +6,13 @@ The bundler source will detect dependencies `Gemfile` and `Gemfile.lock` files a
 
 **Note** this content only applies to running licensed from an executable.  It does not apply when using licensed as a gem.
 
-_It is strongly recommended that ruby is always available when running the licensed executable._
+_It is required that the ruby runtime is available when running the licensed executable._
 
 The licensed executable contains and runs a version of ruby.  When using the Bundler APIs, a mismatch between the version of ruby built into the licensed executable and the version of licensed used during `bundle install` can occur.  This mismatch can lead to licensed raising errors due to not finding dependencies.
 
 For example, if `bundle install` was run with ruby 2.5.0 then the bundler specification path would be `<bundle path>/ruby/2.5.0/specifications`.  However, if the licensed executable contains ruby 2.4.0, then licensed will be looking for specifications at `<bundle path>/ruby/2.4.0/specifications`.  That path may not exist, or it may contain invalid or stale content.
 
-If ruby is available when running licensed, licensed will determine the ruby version used during `bundle install` and prefer that version string over the version contained in the executable.  If bundler is also available, then the ruby command will be run from a `bundle exec` context.
+To prevent confusion, licensed uses the local ruby runtime to determine the ruby version for local gems during `bundle install`.  If bundler is also available, then the ruby command will be run from a `bundle exec` context.
 
 ### Excluding gem groups
 

--- a/lib/licensed/configuration.rb
+++ b/lib/licensed/configuration.rb
@@ -10,12 +10,8 @@ module Licensed
       ".licensed.json".freeze
     ].freeze
 
-    attr_reader :ui
-
     def initialize(options = {}, inherited_options = {})
       super()
-
-      @ui = Licensed::UI::Shell.new
 
       # update order:
       # 1. anything inherited from root config

--- a/lib/licensed/reporters/status_reporter.rb
+++ b/lib/licensed/reporters/status_reporter.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "byebug"
 
 module Licensed
   module Reporters

--- a/test/commands/cache_test.rb
+++ b/test/commands/cache_test.rb
@@ -9,7 +9,6 @@ describe Licensed::Commands::Cache do
   let(:fixtures) { File.expand_path("../../fixtures", __FILE__) }
 
   before do
-    config.ui.level = "silent"
     config.apps.each do |app|
       app.sources.clear
       app.sources << source

--- a/test/commands/status_test.rb
+++ b/test/commands/status_test.rb
@@ -13,9 +13,7 @@ describe Licensed::Commands::Status do
       app.sources << source
     end
 
-    config.ui.silence do
-      Licensed::Commands::Cache.new(config.dup, reporter).run(force: true)
-    end
+    Licensed::Commands::Cache.new(config.dup, reporter).run(force: true)
   end
 
   after do

--- a/test/reporters/status_reporter_test.rb
+++ b/test/reporters/status_reporter_test.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require "test_helper"
-require "byebug"
 
 describe Licensed::Reporters::StatusReporter do
   let(:shell) { TestShell.new }

--- a/test/sources/npm_test.rb
+++ b/test/sources/npm_test.rb
@@ -5,24 +5,22 @@ require "fileutils"
 
 if Licensed::Shell.tool_available?("npm")
   describe Licensed::Sources::NPM do
-    before do
-      @config = Licensed::Configuration.new
-      @source = Licensed::Sources::NPM.new(@config)
-    end
+    let(:config) { Licensed::Configuration.new }
+    let(:source) { Licensed::Sources::NPM.new(config) }
 
     describe "enabled?" do
       it "is true if package.json exists" do
         Dir.mktmpdir do |dir|
           Dir.chdir(dir) do
             File.write "package.json", ""
-            assert @source.enabled?
+            assert source.enabled?
           end
         end
       end
 
       it "is false no npm configs exist" do
         Dir.chdir(Dir.tmpdir) do
-          refute @source.enabled?
+          refute source.enabled?
         end
       end
     end
@@ -32,7 +30,7 @@ if Licensed::Shell.tool_available?("npm")
 
       it "includes declared dependencies" do
         Dir.chdir fixtures do
-          dep = @source.dependencies.detect { |d| d.name == "autoprefixer" }
+          dep = source.dependencies.detect { |d| d.name == "autoprefixer" }
           assert dep
           assert_equal "npm", dep.record["type"]
           assert_equal "5.2.0", dep.version
@@ -43,20 +41,20 @@ if Licensed::Shell.tool_available?("npm")
 
       it "includes transient dependencies" do
         Dir.chdir fixtures do
-          assert @source.dependencies.detect { |dep| dep.name == "autoprefixer" }
+          assert source.dependencies.detect { |dep| dep.name == "autoprefixer" }
         end
       end
 
       it "does not include dev dependencies" do
         Dir.chdir fixtures do
-          refute @source.dependencies.detect { |dep| dep.name == "string.prototype.startswith" }
+          refute source.dependencies.detect { |dep| dep.name == "string.prototype.startswith" }
         end
       end
 
       it "does not include ignored dependencies" do
         Dir.chdir fixtures do
-          @config.ignore({ "type" => Licensed::Sources::NPM.type, "name" => "autoprefixer" })
-          refute @source.dependencies.detect { |dep| dep.name == "autoprefixer" }
+          config.ignore({ "type" => Licensed::Sources::NPM.type, "name" => "autoprefixer" })
+          refute source.dependencies.detect { |dep| dep.name == "autoprefixer" }
         end
       end
 
@@ -64,7 +62,7 @@ if Licensed::Shell.tool_available?("npm")
         Dir.mktmpdir do |dir|
           FileUtils.cp(File.join(fixtures, "package.json"), File.join(dir, "package.json"))
           Dir.chdir(dir) do
-            error = assert_raises(Licensed::Shell::Error) { @source.dependencies }
+            error = assert_raises(Licensed::Shell::Error) { source.dependencies }
             assert_includes error.message, "command exited with status 1"
             assert_includes error.message, "npm ERR! missing: autoprefixer@"
           end
@@ -74,10 +72,10 @@ if Licensed::Shell.tool_available?("npm")
       describe "with multiple instances of a dependency" do
         it "includes version in the dependency name for multiple unique versions" do
           Dir.chdir fixtures do
-            graceful_fs_dependencies = @source.dependencies.select { |dep| dep.name == /graceful-fs/ }
+            graceful_fs_dependencies = source.dependencies.select { |dep| dep.name == /graceful-fs/ }
             assert_empty graceful_fs_dependencies
 
-            graceful_fs_dependencies = @source.dependencies.select { |dep| dep.name =~ /graceful-fs/ }
+            graceful_fs_dependencies = source.dependencies.select { |dep| dep.name =~ /graceful-fs/ }
             assert_equal 2, graceful_fs_dependencies.size
             graceful_fs_dependencies.each do |dependency|
               assert_equal "#{dependency.record["name"]}-#{dependency.version}", dependency.name
@@ -87,7 +85,7 @@ if Licensed::Shell.tool_available?("npm")
 
         it "does not include version in the dependency name for a single unique version" do
           Dir.chdir fixtures do
-            dep = @source.dependencies.detect { |d| d.name == "wrappy" }
+            dep = source.dependencies.detect { |d| d.name == "wrappy" }
             assert_equal "wrappy", dep.name
           end
         end

--- a/test/sources/npm_test.rb
+++ b/test/sources/npm_test.rb
@@ -7,7 +7,6 @@ if Licensed::Shell.tool_available?("npm")
   describe Licensed::Sources::NPM do
     before do
       @config = Licensed::Configuration.new
-      @config.ui.level = "silent"
       @source = Licensed::Sources::NPM.new(@config)
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require "bundler/setup"
 require "minitest/autorun"
+require "byebug"
 require "licensed"
 require "English"
 require "test_helpers/test_shell"


### PR DESCRIPTION
With the addition of reporters, all output should be going through a reporter when dependencies are enumerated.

This PR removes the direct shell UI access through a configuration.  The only remaining usage was to print a warning in the bundler dependency source for a specific edge case.  In this scenario it made more sense to remove the warning and prevent against the edge case in the first place than to try and figure out a good technical solution to including the warning in the reporters output.

I also found a little bit of code that could be cleaned up which I included here.