### PR TITLE
Refactor command code to base class + inheritance

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,32 +50,11 @@ For example, on macOS with Homebrew: `brew install cmake pkg-config` and on Ubun
 ## Usage
 
 - `licensed list`: Output enumerated dependencies only.
-
 - `licensed cache`: Cache licenses and metadata.
-
 - `licensed status`: Check status of dependencies' cached licenses. For example:
-
-```
-$ bundle exec licensed status
-Checking cached dependency records for licensed
-..F.F....F...
-
-Errors:
-
-* bundler.pathname-common_prefix
-  filename: /Users/jonabc/github/licensed/.licenses/bundler/pathname-common_prefix.dep.yml
-    - license needs reviewed: other
-
-* bundler.bundler
-  filename: /Users/jonabc/github/licensed/.licenses/bundler/bundler.dep.yml
-    - cached dependency record not found  
-
-* bundler.addressable
-  filename: /Users/jonabc/github/licensed/.licenses/bundler/addressable.dep.yml
-    - license needs reviewed: apache-2.0
-```
-
 - `licensed version`: Show current installed version of Licensed. Aliases: `-v|--version`
+
+See the [commands documentation](./docs/commands.md) for additional documentation, or run `licensed -h` to see all of the current available commands.
 
 ### Configuration
 
@@ -138,6 +117,12 @@ if Licensed::Shell.tool_available?('bundle')
   end
 end
 ```
+
+See the [documentation on adding new sources](./docs/adding_a_new_source.md) for more information.
+
+#### Adding Commands
+
+See the [documentation on commands](./docs/commands.md) for information about adding a new CLI command.
 
 ## Contributing
 

--- a/docs/adding_a_new_source.md
+++ b/docs/adding_a_new_source.md
@@ -20,7 +20,21 @@ This section covers the `Licensed::Sources::Source#enabled?` method.  This metho
 whether `Licensed::Source::Sources#enumerate_dependencies` should be called on the current dependency source object.
 
 Determining whether dependencies should be enumerated depends on whether all the tools or files needed to find dependencies are present.
-For example, to enumerate `npm` dependencies the `npm` CLI tool must be reachable and a `package.json` file needs to exist in the licensed app's configured [`source_path`](./configuration.md#configuration-paths).
+For example, to enumerate `npm` dependencies the `npm` CLI tool must be found with `Licensed::Shell.tool_available?` and a `package.json` file needs to exist in the licensed app's configured [`source_path`](./configuration.md#configuration-paths).
+
+#### Gating functionality when required tools are not available.
+
+When adding new dependency sources, ensure that `script/bootstrap` scripting and tests are only run if the required tooling is available on the development machine.
+
+* See `script/bootstrap` for examples of gating scripting based on whether tooling executables are found.
+* Use `Licensed::Shell.tool_available?` when writing test files to gate running a test suite when tooling executables aren't available.
+```ruby
+if Licensed::Shell.tool_available?('bundle')
+  describe Licensed::Source::Bundler do
+    ...
+  end
+end
+```
 
 ## Enumerating dependencies
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,81 @@
+# Commands
+
+Run `licensed -h` to see help content for running licensed commands.
+
+## `list`
+
+Running the list command finds the dependencies for all sources in all configured applications.  No additional actions are taken on each dependency.
+
+## `cache`
+
+The cache command finds all dependencies and ensures that each dependency has an up-to-date cached record.
+
+Dependency records will be saved if:
+1. The `force` option is set
+2. No cached record is found
+3. The cached record's version is different than the current dependency's version
+   - If the cached record's license text contents matches the current dependency's license text then the `license` metadata from the cached record is retained for the new saved record.
+
+After the cache command is run, any cached records that don't match up to a current application dependency will be deleted.
+
+## `status`
+
+The status command finds all dependencies and checks whether each dependency has a valid cached record.
+
+A dependency will fail the status checks if:
+1. No cached record is found
+2. The cached record's version is different than the current dependency's version
+3. The cached record doesn't contain any license text
+4. The cached record's `license` metadata doesn't match an `allowed` license from the dependency's application configuration.
+
+## `version`
+
+Displays the current licensed version.
+
+# Adding a new command
+
+## Implement new `Command` class
+
+Licensed commands inherit and override the [`Licensed::Sources::Command`](../lib/licensed/commands/command.rb) class.
+
+#### Required method overrides
+1. `Licensed::Commands::Command#evaluate_dependency`
+   - Runs a command execution on an application dependency.
+   
+The `evaluate_dependency` method should contain the specific command logic.  This method has access to the application configuration, dependency source enumerator and dependency currently being evaluated as well as a reporting hash to contain information about the command execution.
+
+#### Optional method overrides
+
+The following methods break apart the different levels of command execution.  Each method wraps lower levels of command execution in a corresponding reporter method.
+
+1. `Licensed::Commands::Command#run`
+   - Runs `run_app` for each application configuration found.  Wraps the execution of all applications in `Reporter#report_run`.
+2. `Licensed::Commands::Command#run_app`
+   - Runs `run_source` for each dependency source enumerator enabled for the application configuration.  Wraps the execution of all sources in `Reporter#report_app`.
+3. `Licensed::Commands::Command#run_source`
+   - Runs `run_dependency` for each dependency found in the source.  Wraps the execution of all dependencies in `Reporter#report_source`.
+4. `Licensed::Commands::Command#run_dependency`
+   - Runs `evaluate_dependency` for the dependency.  Wraps the execution of all dependencies in `Reporter#report_dependency`.
+
+As an example, `Licensed::Commands::Command#run_app` calls `Reporter#report_app` to wrap every call to `Licensed::Commands::Command#run_source`.
+
+##### Overriding optional methods
+
+The `run` methods can be overridden to provide additional reporting data or functionality.  Overriding a method should call the original method with a block for the additional logic.
+
+```ruby
+def run_app(app)
+  super do |report|
+    result = yield report
+    
+    # do other thing
+    call_additional_functionality(app)
+    
+    # add reporting information
+    report["result"] = result
+    
+    # return the result
+    result
+  end
+end
+```

--- a/lib/licensed/cli.rb
+++ b/lib/licensed/cli.rb
@@ -11,21 +11,21 @@ module Licensed
     method_option :config, aliases: "-c", type: :string,
       desc: "Path to licensed configuration file"
     def cache
-      run Licensed::Commands::Cache.new(config), force: options[:force]
+      run Licensed::Commands::Cache.new(config: config), force: options[:force]
     end
 
     desc "status", "Check status of dependencies' cached licenses"
     method_option :config, aliases: "-c", type: :string,
       desc: "Path to licensed configuration file"
     def status
-      run Licensed::Commands::Status.new(config)
+      run Licensed::Commands::Status.new(config: config)
     end
 
     desc "list", "List dependencies"
     method_option :config, aliases: "-c", type: :string,
       desc: "Path to licensed configuration file"
     def list
-      run Licensed::Commands::List.new(config)
+      run Licensed::Commands::List.new(config: config)
     end
 
     map "-v" => :version
@@ -53,8 +53,8 @@ module Licensed
       options["config"] || Dir.pwd
     end
 
-    def run(command, *args)
-      exit command.run(*args)
+    def run(command, **args)
+      exit command.run(args)
     end
   end
 end

--- a/lib/licensed/commands.rb
+++ b/lib/licensed/commands.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 module Licensed
   module Commands
+    require "licensed/commands/command"
     require "licensed/commands/cache"
     require "licensed/commands/status"
     require "licensed/commands/list"

--- a/lib/licensed/commands/cache.rb
+++ b/lib/licensed/commands/cache.rb
@@ -21,26 +21,25 @@ module Licensed
         result
       end
 
-      # Run the command for a dependency
+      # Cache dependency record data.
       #
       # app - The application configuration for the dependency
       # source - The dependency source enumerator for the dependency
       # dependency - An application dependency
+      # report - A report hash for the command to provide extra data for the report output.
       #
-      # Returns true
-      def run_dependency(app, source, dependency)
+      # Returns true.
+      def evaluate_dependency(app, source, dependency, report)
         filename = app.cache_path.join(source.class.type, "#{dependency.name}.#{DependencyRecord::EXTENSION}")
-        reporter.report_dependency(dependency) do |report|
-          cached_record = Licensed::DependencyRecord.read(filename)
-          report["cached"] = options[:force] || save_dependency_record?(dependency, cached_record)
-          if report["cached"]
-            # use the cached license value if the license text wasn't updated
-            dependency.record["license"] = cached_record["license"] if dependency.record.matches?(cached_record)
-            dependency.record.save(filename)
-          end
-
-          true
+        cached_record = Licensed::DependencyRecord.read(filename)
+        report["cached"] = options[:force] || save_dependency_record?(dependency, cached_record)
+        if report["cached"]
+          # use the cached license value if the license text wasn't updated
+          dependency.record["license"] = cached_record["license"] if dependency.record.matches?(cached_record)
+          dependency.record.save(filename)
         end
+
+        true
       end
 
       # Determine if the current dependency's record should be saved.

--- a/lib/licensed/commands/cache.rb
+++ b/lib/licensed/commands/cache.rb
@@ -1,79 +1,45 @@
 # frozen_string_literal: true
 module Licensed
   module Commands
-    class Cache
-      attr_reader :config
-      attr_reader :reporter
-      attr_reader :force
-
-      def initialize(config, reporter = Licensed::Reporters::CacheReporter.new)
-        @config = config
-        @reporter = reporter
+    class Cache < Command
+      def initialize(config:, reporter: Licensed::Reporters::CacheReporter.new)
+        super(config: config, reporter: reporter)
       end
 
-      # Cache any stale or missing license dependency records
-      #
-      # force - Set to true to for all records to be cached
-      #
-      # Returns whether the command was a success
-      def run(force: false)
-        @force = force
-        begin
-          reporter.report_run do
-            config.apps.each { |app| cache_app(app) }
-          end
-        ensure
-          @force = nil
-        end
+      protected
 
-        true
-      end
-
-      # Cache any stale or missing dependency records for an application.
+      # Run the command for an application configuration.
       # Will remove any cached records that don't match a current application
       # dependency.
       #
       # app - An application configuration
       #
-      # Returns nothing
-      def cache_app(app)
-        reporter.report_app(app) do
-          Dir.chdir app.source_path do
-            app.sources.each { |source| cache_source(app, source) }
-            clear_stale_cached_records(app)
-          end
-        end
+      # Returns whether the command succeeded for the application.
+      def run_app(app)
+        result = super
+        clear_stale_cached_records(app)
+        result
       end
 
-      # Cache any stale or missing dependency records for a dependency source
-      #
-      # app - The application configuration for the source
-      # source - A dependency source enumerator
-      #
-      # Returns nothing
-      def cache_source(app, source)
-        reporter.report_source(source) do
-          source.dependencies.each { |dependency| cache_dependency(app, source, dependency) }
-        end
-      end
-
-      # Cache any stale or missing dependency records for a dependency
+      # Run the command for a dependency
       #
       # app - The application configuration for the dependency
       # source - The dependency source enumerator for the dependency
       # dependency - An application dependency
       #
-      # Returns nothing
-      def cache_dependency(app, source, dependency)
+      # Returns true
+      def run_dependency(app, source, dependency)
         filename = app.cache_path.join(source.class.type, "#{dependency.name}.#{DependencyRecord::EXTENSION}")
         reporter.report_dependency(dependency) do |report|
           cached_record = Licensed::DependencyRecord.read(filename)
-          report["cached"] = force || save_dependency_record?(dependency, cached_record)
+          report["cached"] = options[:force] || save_dependency_record?(dependency, cached_record)
           if report["cached"]
             # use the cached license value if the license text wasn't updated
             dependency.record["license"] = cached_record["license"] if dependency.record.matches?(cached_record)
             dependency.record.save(filename)
           end
+
+          true
         end
       end
 

--- a/lib/licensed/commands/command.rb
+++ b/lib/licensed/commands/command.rb
@@ -64,7 +64,21 @@ module Licensed
       #
       # Returns whether the command succeeded for the dependency
       def run_dependency(app, source, dependency)
-        raise "run_for_dependency must be implemented by a command"
+        reporter.report_dependency(dependency) do |report|
+          evaluate_dependency(app, source, dependency, report)
+        end
+      end
+
+      # Evaluate a dependency for the command.  Must be implemented by a command implementation.
+      #
+      # app - The application configuration for the dependency
+      # source - The dependency source enumerator for the dependency
+      # dependency - An application dependency
+      # report - A report hash for the command to provide extra data for the report output.
+      #
+      # Returns whether the command succeeded for the dependency
+      def evaluate_dependency(app, source, dependency, report)
+        raise "`evaluate_dependency` must be implemented by a command"
       end
     end
   end

--- a/lib/licensed/commands/command.rb
+++ b/lib/licensed/commands/command.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+module Licensed
+  module Commands
+    class Command
+      attr_reader :config
+      attr_reader :reporter
+      attr_reader :options
+
+      def initialize(config:, reporter:)
+        @config = config
+        @reporter = reporter
+      end
+
+      # Run the command
+      #
+      # options - Options to run the command with
+      #
+      # Returns whether the command was a success
+      def run(**options)
+        @options = options
+        begin
+          result = reporter.report_run do
+            config.apps.map { |app| run_app(app) }.all?
+          end
+        ensure
+          @options = nil
+        end
+
+        result
+      end
+
+      protected
+
+      # Run the command for an application configuration.
+      #
+      # app - An application configuration
+      #
+      # Returns whether the command succeeded for the application.
+      def run_app(app)
+        reporter.report_app(app) do
+          Dir.chdir app.source_path do
+            app.sources.map { |source| run_source(app, source) }.all?
+          end
+        end
+      end
+
+      # Run the command for a dependency source enumerator
+      #
+      # app - The application configuration for the source
+      # source - A dependency source enumerator
+      #
+      # Returns whether the command succeeded for the dependency source enumerator
+      def run_source(app, source)
+        reporter.report_source(source) do
+          source.dependencies.map { |dependency| run_dependency(app, source, dependency) }.all?
+        end
+      end
+
+      # Run the command for a dependency
+      #
+      # app - The application configuration for the dependency
+      # source - The dependency source enumerator for the dependency
+      # dependency - An application dependency
+      #
+      # Returns whether the command succeeded for the dependency
+      def run_dependency(app, source, dependency)
+        raise "run_for_dependency must be implemented by a command"
+      end
+    end
+  end
+end

--- a/lib/licensed/commands/list.rb
+++ b/lib/licensed/commands/list.rb
@@ -8,15 +8,16 @@ module Licensed
 
       protected
 
-      # Run the command for a dependency.  List the dependency in the reporter
+      # Listing dependencies requires not extra work.
       #
       # app - The application configuration for the dependency
       # source - The dependency source enumerator for the dependency
       # dependency - An application dependency
+      # report - A report hash for the command to provide extra data for the report output.
       #
-      # Returns true
-      def run_dependency(app, source, dependency)
-        reporter.report_dependency(dependency) { true }
+      # Returns true.
+      def evaluate_dependency(app, source, dependency, report)
+        true
       end
     end
   end

--- a/lib/licensed/commands/list.rb
+++ b/lib/licensed/commands/list.rb
@@ -8,7 +8,7 @@ module Licensed
 
       protected
 
-      # Listing dependencies requires not extra work.
+      # Listing dependencies requires no extra work.
       #
       # app - The application configuration for the dependency
       # source - The dependency source enumerator for the dependency

--- a/lib/licensed/commands/list.rb
+++ b/lib/licensed/commands/list.rb
@@ -1,37 +1,22 @@
 # frozen_string_literal: true
 module Licensed
   module Commands
-    class List
-      attr_reader :config
-      attr_reader :reporter
-
-      def initialize(config, reporter = Licensed::Reporters::ListReporter.new)
-        @config = config
-        @reporter = reporter
+    class List < Command
+      def initialize(config:, reporter: Licensed::Reporters::ListReporter.new)
+        super(config: config, reporter: reporter)
       end
 
-      def run
-        reporter.report_run do
-          config.apps.each { |app| list_app_dependencies(app) }
-        end
+      protected
 
-        true
-      end
-
-      def list_app_dependencies(app)
-        reporter.report_app(app) do
-          Dir.chdir app.source_path do
-            app.sources.each { |source| list_source_dependencies(source) }
-          end
-        end
-      end
-
-      def list_source_dependencies(source)
-        reporter.report_source(source) do
-          source.dependencies
-                .sort_by { |dependency| dependency.name }
-                .each { |dependency| reporter.report_dependency(dependency) {} }
-        end
+      # Run the command for a dependency.  List the dependency in the reporter
+      #
+      # app - The application configuration for the dependency
+      # source - The dependency source enumerator for the dependency
+      # dependency - An application dependency
+      #
+      # Returns true
+      def run_dependency(app, source, dependency)
+        reporter.report_dependency(dependency) { true }
       end
     end
   end

--- a/lib/licensed/commands/status.rb
+++ b/lib/licensed/commands/status.rb
@@ -3,40 +3,24 @@ require "yaml"
 
 module Licensed
   module Commands
-    class Status
-      attr_reader :config
-      attr_reader :reporter
-
-      def initialize(config, reporter = Licensed::Reporters::StatusReporter.new)
-        @config = config
-        @reporter = reporter
+    class Status < Command
+      def initialize(config:, reporter: Licensed::Reporters::StatusReporter.new)
+        super(config: config, reporter: reporter)
       end
 
-      def allowed_or_reviewed?(app, dependency)
-        app.allowed?(dependency) || app.reviewed?(dependency)
-      end
+      protected
 
-      def run
-        reporter.report_run do
-          config.apps.map { |app| verify_app(app) }.all?
-        end
-      end
-
-      def verify_app(app)
-        reporter.report_app(app) do
-          Dir.chdir app.source_path do
-            app.sources.map { |source| verify_source(app, source) }.all?
-          end
-        end
-      end
-
-      def verify_source(app, source)
-        reporter.report_source(source) do
-          source.dependencies.map { |dependency| verify_dependency(app, source, dependency) }.all?
-        end
-      end
-
-      def verify_dependency(app, source, dependency)
+      # Run the command for a dependency.
+      # Verifies that a cached record exists, is up to date and
+      # has license data that complies with the licensed configuration.
+      #
+      # app - The application configuration for the dependency
+      # source - The dependency source enumerator for the dependency
+      # dependency - An application dependency
+      #
+      # Returns whether the dependency has a cached record that is compliant
+      # with the licensed configuration.
+      def run_dependency(app, source, dependency)
         reporter.report_dependency(dependency) do |report|
           filename = app.cache_path.join(source.class.type, "#{dependency.name}.#{DependencyRecord::EXTENSION}")
           cached_record = cached_record(filename)
@@ -55,6 +39,10 @@ module Licensed
 
           errors.empty?
         end
+      end
+
+      def allowed_or_reviewed?(app, dependency)
+        app.allowed?(dependency) || app.reviewed?(dependency)
       end
 
       def cached_record(filename)

--- a/lib/licensed/commands/status.rb
+++ b/lib/licensed/commands/status.rb
@@ -10,35 +10,33 @@ module Licensed
 
       protected
 
-      # Run the command for a dependency.
       # Verifies that a cached record exists, is up to date and
       # has license data that complies with the licensed configuration.
       #
       # app - The application configuration for the dependency
       # source - The dependency source enumerator for the dependency
       # dependency - An application dependency
+      # report - A report hash for the command to provide extra data for the report output.
       #
       # Returns whether the dependency has a cached record that is compliant
       # with the licensed configuration.
-      def run_dependency(app, source, dependency)
-        reporter.report_dependency(dependency) do |report|
-          filename = app.cache_path.join(source.class.type, "#{dependency.name}.#{DependencyRecord::EXTENSION}")
-          cached_record = cached_record(filename)
+      def evaluate_dependency(app, source, dependency, report)
+        filename = app.cache_path.join(source.class.type, "#{dependency.name}.#{DependencyRecord::EXTENSION}")
+        cached_record = cached_record(filename)
 
-          errors = []
-          if cached_record.nil?
-            errors << "cached dependency record not found"
-          else
-            errors << "cached dependency record out of date" if cached_record["version"] != dependency.version
-            errors << "missing license text" if cached_record.licenses.empty?
-            errors << "license needs reviewed: #{cached_record["license"]}" unless allowed_or_reviewed?(app, cached_record)
-          end
-
-          report["errors"] = errors
-          report["filename"] = filename
-
-          errors.empty?
+        errors = []
+        if cached_record.nil?
+          errors << "cached dependency record not found"
+        else
+          errors << "cached dependency record out of date" if cached_record["version"] != dependency.version
+          errors << "missing license text" if cached_record.licenses.empty?
+          errors << "license needs reviewed: #{cached_record["license"]}" unless allowed_or_reviewed?(app, cached_record)
         end
+
+        report["errors"] = errors
+        report["filename"] = filename
+
+        errors.empty?
       end
 
       def allowed_or_reviewed?(app, dependency)

--- a/test/commands/cache_test.rb
+++ b/test/commands/cache_test.rb
@@ -5,7 +5,7 @@ describe Licensed::Commands::Cache do
   let(:reporter) { TestReporter.new }
   let(:config) { Licensed::Configuration.new }
   let(:source) { TestSource.new(config) }
-  let(:generator) { Licensed::Commands::Cache.new(config, reporter) }
+  let(:generator) { Licensed::Commands::Cache.new(config: config, reporter: reporter) }
   let(:fixtures) { File.expand_path("../../fixtures", __FILE__) }
 
   before do

--- a/test/commands/command_test.rb
+++ b/test/commands/command_test.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+require "test_helper"
+
+describe Licensed::Commands::Command do
+  let(:apps) {
+    [
+      {
+        "name" => "app1",
+        "source_path" => Dir.pwd
+      },
+      {
+        "name" => "app2",
+        "source_path" => Dir.pwd
+      }
+    ]
+  }
+  let(:configuration) { Licensed::Configuration.new("apps" => apps, "sources" => { "test" => true }) }
+  let(:command) { TestCommand.new(config: configuration, reporter: TestReporter.new) }
+
+  it "runs a command for all dependencies in the configuration" do
+    command.run
+    command.config.apps.each do |app|
+      app_results = command.reporter.results[app["name"]]
+      assert app_results
+      source_results = app_results["test"]
+      assert source_results
+      assert source_results["dependency"]
+    end
+  end
+
+  it "fails if any of the dependencies fail the command" do
+    refute command.run(fail: "app2")
+  end
+
+  it "succeeds if all of the dependencies succeed the command" do
+    assert command.run
+  end
+end

--- a/test/commands/list_test.rb
+++ b/test/commands/list_test.rb
@@ -5,7 +5,7 @@ describe Licensed::Commands::List do
   let(:reporter) { TestReporter.new }
   let(:config) { Licensed::Configuration.new }
   let(:source) { TestSource.new(config) }
-  let(:command) { Licensed::Commands::List.new(config, reporter) }
+  let(:command) { Licensed::Commands::List.new(config: config, reporter: reporter) }
   let(:fixtures) { File.expand_path("../../fixtures", __FILE__) }
 
   before do

--- a/test/commands/status_test.rb
+++ b/test/commands/status_test.rb
@@ -5,7 +5,7 @@ describe Licensed::Commands::Status do
   let(:reporter) { TestReporter.new }
   let(:config) { Licensed::Configuration.new }
   let(:source) { TestSource.new(config) }
-  let(:verifier) { Licensed::Commands::Status.new(config, reporter) }
+  let(:verifier) { Licensed::Commands::Status.new(config: config, reporter: reporter) }
 
   before do
     config.apps.each do |app|
@@ -13,7 +13,7 @@ describe Licensed::Commands::Status do
       app.sources << source
     end
 
-    Licensed::Commands::Cache.new(config.dup, reporter).run(force: true)
+    Licensed::Commands::Cache.new(config: config.dup, reporter: reporter).run(force: true)
   end
 
   after do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,19 @@ require "minitest/autorun"
 require "byebug"
 require "licensed"
 require "English"
+require "test_helpers/test_command"
 require "test_helpers/test_shell"
 require "test_helpers/test_reporter"
 require "test_helpers/test_source"
+
+def each_source(&block)
+  Licensed::Sources::Source.sources.each do |source_class|
+    # don't run tests meant for actual dependency enumerators on the test source
+    next if source_class == TestSource
+
+    # if a specific source type is set via ENV, skip other source types
+    next if ENV["SOURCE"] && source_class.type != ENV["SOURCE"].downcase
+
+    block.call(source_class)
+  end
+end

--- a/test/test_helpers/test_command.rb
+++ b/test/test_helpers/test_command.rb
@@ -2,10 +2,8 @@
 class TestCommand < Licensed::Commands::Command
   protected
 
-  def run_dependency(app, source, dependency)
-    reporter.report_dependency(dependency) do |report|
-      next true unless options[:fail]
-      options[:fail] != app["name"]
-    end
+  def evaluate_dependency(app, source, dependency, report)
+    return true unless options[:fail]
+    options[:fail] != app["name"]
   end
 end

--- a/test/test_helpers/test_command.rb
+++ b/test/test_helpers/test_command.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+class TestCommand < Licensed::Commands::Command
+  protected
+
+  def run_dependency(app, source, dependency)
+    reporter.report_dependency(dependency) do |report|
+      next true unless options[:fail]
+      options[:fail] != app["name"]
+    end
+  end
+end

--- a/test/test_helpers/test_source.rb
+++ b/test/test_helpers/test_source.rb
@@ -29,15 +29,3 @@ class TestSource < Licensed::Sources::Source
     ]
   end
 end
-
-def each_source(&block)
-  Licensed::Sources::Source.sources.each do |source_class|
-    # don't run tests meant for actual dependency enumerators on the test source
-    next if source_class == TestSource
-
-    # if a specific source type is set via ENV, skip other source types
-    next if ENV["SOURCE"] && source_class.type != ENV["SOURCE"].downcase
-
-    block.call(source_class)
-  end
-end


### PR DESCRIPTION
This PR simplifies each command implementation by defining a base class that implements the pattern currently present in each command class.

`run > app > source > dependency`

Defining a base class allows each command implementation to focus only on the interesting logic required to complete each command.  All of the plumbing and glue code needed to evaluate each dependency, return a result, and make sure that reporting is called is handled by the base class.

This DRYs up command classes nicely and makes it easier to implement logic in the future that should affect all commands.

I've added docs detailing existing commands as well as the basics on how to implement a new command.