### PR TITLE
Catch and report shell errors during command execution

### DIFF
--- a/lib/licensed/commands/cache.rb
+++ b/lib/licensed/commands/cache.rb
@@ -32,11 +32,11 @@ module Licensed
       def evaluate_dependency(app, source, dependency, report)
         filename = app.cache_path.join(source.class.type, "#{dependency.name}.#{DependencyRecord::EXTENSION}")
         cached_record = Licensed::DependencyRecord.read(filename)
-        report["cached"] = options[:force] || save_dependency_record?(dependency, cached_record)
-        if report["cached"]
+        if options[:force] || save_dependency_record?(dependency, cached_record)
           # use the cached license value if the license text wasn't updated
           dependency.record["license"] = cached_record["license"] if dependency.record.matches?(cached_record)
           dependency.record.save(filename)
+          report["cached"] = true
         end
 
         true

--- a/lib/licensed/commands/cache.rb
+++ b/lib/licensed/commands/cache.rb
@@ -17,7 +17,7 @@ module Licensed
       # Returns whether the command succeeded for the application.
       def run_app(app)
         result = super
-        clear_stale_cached_records(app)
+        clear_stale_cached_records(app) if result
         result
       end
 

--- a/lib/licensed/commands/command.rb
+++ b/lib/licensed/commands/command.rb
@@ -37,9 +37,14 @@ module Licensed
       #
       # Returns whether the command succeeded for the application.
       def run_app(app)
-        reporter.report_app(app) do
+        reporter.report_app(app) do |report|
           Dir.chdir app.source_path do
-            app.sources.map { |source| run_source(app, source) }.all?
+            begin
+              app.sources.map { |source| run_source(app, source) }.all?
+            rescue Licensed::Shell::Error => err
+              report.errors << err.message
+              false
+            end
           end
         end
       end
@@ -51,8 +56,13 @@ module Licensed
       #
       # Returns whether the command succeeded for the dependency source enumerator
       def run_source(app, source)
-        reporter.report_source(source) do
-          source.dependencies.map { |dependency| run_dependency(app, source, dependency) }.all?
+        reporter.report_source(source) do |report|
+          begin
+            source.dependencies.map { |dependency| run_dependency(app, source, dependency) }.all?
+          rescue Licensed::Shell::Error => err
+            report.errors << err.message
+            false
+          end
         end
       end
 
@@ -65,7 +75,12 @@ module Licensed
       # Returns whether the command succeeded for the dependency
       def run_dependency(app, source, dependency)
         reporter.report_dependency(dependency) do |report|
-          evaluate_dependency(app, source, dependency, report)
+          begin
+            evaluate_dependency(app, source, dependency, report)
+          rescue Licensed::Shell::Error => err
+            report.errors << err.message
+            false
+          end
         end
       end
 

--- a/lib/licensed/commands/command.rb
+++ b/lib/licensed/commands/command.rb
@@ -19,7 +19,7 @@ module Licensed
       def run(**options)
         @options = options
         begin
-          result = reporter.report_run do
+          result = reporter.report_run(self) do
             config.apps.map { |app| run_app(app) }.all?
           end
         ensure

--- a/lib/licensed/commands/status.rb
+++ b/lib/licensed/commands/status.rb
@@ -22,21 +22,18 @@ module Licensed
       # with the licensed configuration.
       def evaluate_dependency(app, source, dependency, report)
         filename = app.cache_path.join(source.class.type, "#{dependency.name}.#{DependencyRecord::EXTENSION}")
-        cached_record = cached_record(filename)
-
-        errors = []
-        if cached_record.nil?
-          errors << "cached dependency record not found"
-        else
-          errors << "cached dependency record out of date" if cached_record["version"] != dependency.version
-          errors << "missing license text" if cached_record.licenses.empty?
-          errors << "license needs reviewed: #{cached_record["license"]}" unless allowed_or_reviewed?(app, cached_record)
-        end
-
-        report["errors"] = errors
         report["filename"] = filename
 
-        errors.empty?
+        cached_record = cached_record(filename)
+        if cached_record.nil?
+          report.errors << "cached dependency record not found"
+        else
+          report.errors << "cached dependency record out of date" if cached_record["version"] != dependency.version
+          report.errors << "missing license text" if cached_record.licenses.empty?
+          report.errors << "license needs reviewed: #{cached_record["license"]}" unless allowed_or_reviewed?(app, cached_record)
+        end
+
+        report.errors.empty?
       end
 
       def allowed_or_reviewed?(app, dependency)

--- a/lib/licensed/reporters/cache_reporter.rb
+++ b/lib/licensed/reporters/cache_reporter.rb
@@ -30,17 +30,16 @@ module Licensed
           errored_reports = report.all_reports.select { |report| report.errors.any? }.to_a
           if errored_reports.any?
             shell.newline
-            shell.newline
             shell.error "  * Errors:"
             errored_reports.each do |report|
               display_metadata = report.map { |k, v| "#{k}: #{v}" }.join(", ")
 
-              shell.newline
               shell.error "    * #{report.name}"
               shell.error "    #{display_metadata}" unless display_metadata.empty?
               report.errors.each do |error|
-               shell.error "    - #{error}"
+                shell.error "      - #{error}"
               end
+              shell.newline
             end
           else
             shell.confirm "  * #{report.reports.size} #{source.class.type} dependencies"

--- a/lib/licensed/reporters/list_reporter.rb
+++ b/lib/licensed/reporters/list_reporter.rb
@@ -31,17 +31,16 @@ module Licensed
           errored_reports = report.all_reports.select { |report| report.errors.any? }.to_a
           if errored_reports.any?
             shell.newline
-            shell.newline
             shell.error "  * Errors:"
             errored_reports.each do |report|
               display_metadata = report.map { |k, v| "#{k}: #{v}" }.join(", ")
 
-              shell.newline
               shell.error "    * #{report.name}"
               shell.error "    #{display_metadata}" unless display_metadata.empty?
               report.errors.each do |error|
-               shell.error "    - #{error}"
+                shell.error "      - #{error}"
               end
+              shell.newline
             end
           else
             shell.confirm "  * #{report.reports.size} #{source.class.type} dependencies"

--- a/lib/licensed/reporters/status_reporter.rb
+++ b/lib/licensed/reporters/status_reporter.rb
@@ -14,34 +14,30 @@ module Licensed
 
           result = yield report
 
-          dependencies_count = report.sum { |_, dependency_reports| dependency_reports.size }
-          error_data = report.flat_map do |source_type, dependency_reports|
-            dependency_reports.reject { |_, data| data["errors"].nil? || data["errors"].empty? }
-                              .map { |name, data| data.merge("source" => source_type, "dependency" => name) }
-          end
+          all_reports = report.all_reports
+          errored_reports = all_reports.select { |report| report.errors.any? }.to_a
 
-          error_count = error_data.flat_map { |data| data["errors"] }.size
+          dependency_count = all_reports.select { |report| report.target.is_a?(Licensed::Dependency) }.size
+          error_count = errored_reports.sum { |report| report.errors.size }
+
           if error_count > 0
             shell.newline
             shell.newline
             shell.error "Errors:"
-            error_data.each do |data|
-              display_name = [data["source"], data["dependency"]].join(".")
-              display_metadata = data.reject { |k, _| k == "errors" || k == "source" || k == "dependency" }
-                                     .map { |k, v| "#{k}: #{v}" }
-                                     .join(", ")
+            errored_reports.each do |report|
+              display_metadata = report.map { |k, v| "#{k}: #{v}" }.join(", ")
 
               shell.newline
-              shell.error "* #{display_name}"
+              shell.error "* #{report.name}"
               shell.error "  #{display_metadata}" unless display_metadata.empty?
-              data["errors"].each do |error|
+              report.errors.each do |error|
                shell.error "    - #{error}"
               end
             end
           end
 
           shell.newline
-          shell.info "#{dependencies_count} dependencies checked, #{error_count} errors found."
+          shell.info "#{dependency_count} dependencies checked, #{error_count} errors found."
 
           result
         end
@@ -58,7 +54,7 @@ module Licensed
         super do |report|
           result = yield report
 
-          if report["errors"].nil? || report["errors"].empty?
+          if report.errors.empty?
             shell.confirm(".", false)
           else
             shell.error("F", false)

--- a/lib/licensed/reporters/status_reporter.rb
+++ b/lib/licensed/reporters/status_reporter.rb
@@ -22,17 +22,16 @@ module Licensed
 
           if error_count > 0
             shell.newline
-            shell.newline
             shell.error "Errors:"
             errored_reports.each do |report|
               display_metadata = report.map { |k, v| "#{k}: #{v}" }.join(", ")
 
-              shell.newline
               shell.error "* #{report.name}"
               shell.error "  #{display_metadata}" unless display_metadata.empty?
               report.errors.each do |error|
-               shell.error "    - #{error}"
+                shell.error "    - #{error}"
               end
+              shell.newline
             end
           end
 

--- a/lib/licensed/shell.rb
+++ b/lib/licensed/shell.rb
@@ -33,17 +33,17 @@ module Licensed
     end
 
     class Error < RuntimeError
+      attr_reader :cmd, :status, :stderr
       def initialize(cmd, status, stderr)
         super()
         @cmd = cmd
         @exitstatus = status
-        @output = stderr
+        @output = stderr.to_s.strip
       end
 
       def message
-        output = @output.to_s.strip
-        extra = output.empty?? "" : "\n#{output.gsub(/^/, "    ")}"
-        "command exited with status #{@exitstatus}\n  #{escape_cmd}#{extra}"
+        extra = @output.empty?? "" : "#{@output.gsub(/^/, "        ")}"
+        "'#{escape_cmd}' exited with status #{@exitstatus}\n#{extra}"
       end
 
       def escape_cmd

--- a/test/commands/cache_test.rb
+++ b/test/commands/cache_test.rb
@@ -130,18 +130,14 @@ describe Licensed::Commands::Cache do
 
   it "does not include ignored dependencies in dependency counts" do
     generator.run
-    count = reporter.results.flat_map { |_, source_results| source_results.values }
-                            .reduce(&:merge)
-                            .size
+    count = reporter.report.all_reports.size
 
     FileUtils.mkdir_p config.cache_path.join("test")
     File.write config.cache_path.join("test/dependency.#{Licensed::DependencyRecord::EXTENSION}"), ""
     config.ignore "type" => "test", "name" => "dependency"
 
     generator.run
-    ignored_count = reporter.results.flat_map { |_, source_results| source_results.values }
-                                    .reduce(&:merge)
-                                    .size
+    ignored_count = reporter.report.all_reports.size
     assert_equal count - 1, ignored_count
   end
 

--- a/test/commands/command_test.rb
+++ b/test/commands/command_test.rb
@@ -37,4 +37,34 @@ describe Licensed::Commands::Command do
   it "succeeds if all of the dependencies succeed the command" do
     assert command.run
   end
+
+  it "catches shell errors thrown when evaluating an app" do
+    app_name = apps.first["name"]
+    source_name = "#{app_name}.test"
+    refute command.run(raise: source_name)
+
+    report = command.reporter.report.all_reports.find { |report| report.name == app_name }
+    assert report
+    assert_includes report.errors, "command exited with status 0\n  #{source_name}"
+  end
+
+  it "catches shell errors thrown when evaluating a source" do
+    source_name = "#{apps.first["name"]}.test"
+    dependency_name = "#{source_name}.dependency"
+    refute command.run(raise: dependency_name)
+
+    report = command.reporter.report.all_reports.find { |report| report.name == source_name }
+    assert report
+    assert_includes report.errors, "command exited with status 0\n  #{dependency_name}"
+  end
+
+  it "catches shell errors thrown when evaluating a dependency" do
+    dependency_name = "#{apps.first["name"]}.test.dependency"
+    dependency_evaluation_name = "#{dependency_name}.evaluate"
+    refute command.run(raise: dependency_evaluation_name)
+
+    report = command.reporter.report.all_reports.find { |report| report.name == dependency_name }
+    assert report
+    assert_includes report.errors, "command exited with status 0\n  #{dependency_evaluation_name}"
+  end
 end

--- a/test/commands/command_test.rb
+++ b/test/commands/command_test.rb
@@ -20,11 +20,13 @@ describe Licensed::Commands::Command do
   it "runs a command for all dependencies in the configuration" do
     command.run
     command.config.apps.each do |app|
-      app_results = command.reporter.results[app["name"]]
-      assert app_results
-      source_results = app_results["test"]
-      assert source_results
-      assert source_results["dependency"]
+      app_report = command.reporter.report.reports.find { |report| report.name == app["name"] }
+      assert app_report
+
+      source_report = app_report.reports.find { |report| report.name == "#{app["name"]}.#{TestSource.type}" }
+      assert source_report
+
+      assert source_report.reports.find { |report| report.name == "#{app["name"]}.#{TestSource.type}.dependency" }
     end
   end
 

--- a/test/commands/command_test.rb
+++ b/test/commands/command_test.rb
@@ -45,7 +45,7 @@ describe Licensed::Commands::Command do
 
     report = command.reporter.report.all_reports.find { |report| report.name == app_name }
     assert report
-    assert_includes report.errors, "command exited with status 0\n  #{source_name}"
+    assert_includes report.errors, "'app1.test' exited with status 0\n"
   end
 
   it "catches shell errors thrown when evaluating a source" do
@@ -55,7 +55,7 @@ describe Licensed::Commands::Command do
 
     report = command.reporter.report.all_reports.find { |report| report.name == source_name }
     assert report
-    assert_includes report.errors, "command exited with status 0\n  #{dependency_name}"
+    assert_includes report.errors, "'app1.test.dependency' exited with status 0\n"
   end
 
   it "catches shell errors thrown when evaluating a dependency" do
@@ -65,6 +65,6 @@ describe Licensed::Commands::Command do
 
     report = command.reporter.report.all_reports.find { |report| report.name == dependency_name }
     assert report
-    assert_includes report.errors, "command exited with status 0\n  #{dependency_evaluation_name}"
+    assert_includes report.errors, "'app1.test.dependency.evaluate' exited with status 0\n"
   end
 end

--- a/test/reporters/cache_reporter_test.rb
+++ b/test/reporters/cache_reporter_test.rb
@@ -8,30 +8,31 @@ describe Licensed::Reporters::CacheReporter do
   let(:config) { Licensed::Configuration.new }
   let(:source) { TestSource.new(config) }
   let(:dependency) { source.dependencies.first }
+  let(:command) { TestCommand.new(config: config, reporter: reporter) }
 
   describe "#report_app" do
     it "runs a block" do
       success = false
-      reporter.report_run do
+      reporter.report_run(command) do
         reporter.report_app(app) { success = true }
       end
       assert success
     end
 
     it "returns the result of the block" do
-      reporter.report_run do
+      reporter.report_run(command) do
         assert_equal 1, reporter.report_app(app) { 1 }
       end
     end
 
     it "provides a report hash to the block" do
-      reporter.report_run do
+      reporter.report_run(command) do
         reporter.report_app(app) { |report| refute_nil report }
       end
     end
 
     it "prints an informative message to the shell" do
-      reporter.report_run do
+      reporter.report_run(command) do
         reporter.report_app(app) {}
 
         assert_includes shell.messages,
@@ -47,7 +48,7 @@ describe Licensed::Reporters::CacheReporter do
   describe "#report_source" do
     it "runs a block" do
       success = false
-      reporter.report_run do
+      reporter.report_run(command) do
         reporter.report_app(app) do
           reporter.report_source(source) { success = true }
         end
@@ -57,7 +58,7 @@ describe Licensed::Reporters::CacheReporter do
     end
 
     it "returns the result of the block" do
-      reporter.report_run do
+      reporter.report_run(command) do
         reporter.report_app(app) do
           assert_equal 1, reporter.report_source(source) { 1 }
         end
@@ -65,7 +66,7 @@ describe Licensed::Reporters::CacheReporter do
     end
 
     it "provides a report hash to the block" do
-      reporter.report_run do
+      reporter.report_run(command) do
         reporter.report_app(app) do
           reporter.report_source(source) { |report| refute_nil report }
         end
@@ -73,7 +74,7 @@ describe Licensed::Reporters::CacheReporter do
     end
 
     it "prints informative messages to the shell" do
-      reporter.report_run do
+      reporter.report_run(command) do
         reporter.report_app(app) do
           reporter.report_source(source) {}
           assert_includes shell.messages,
@@ -97,7 +98,7 @@ describe Licensed::Reporters::CacheReporter do
   describe "#report_dependency" do
     it "runs a block" do
       success = false
-      reporter.report_run do
+      reporter.report_run(command) do
         reporter.report_app(app) do
           reporter.report_source(source) do
             reporter.report_dependency(dependency) { success = true }
@@ -109,7 +110,7 @@ describe Licensed::Reporters::CacheReporter do
     end
 
     it "returns the result of the block" do
-      reporter.report_run do
+      reporter.report_run(command) do
         reporter.report_app(app) do
           reporter.report_source(source) do
             assert_equal 1, reporter.report_dependency(dependency) { 1 }
@@ -119,7 +120,7 @@ describe Licensed::Reporters::CacheReporter do
     end
 
     it "provides a report hash to the block" do
-      reporter.report_run do
+      reporter.report_run(command) do
         reporter.report_app(app) do
           reporter.report_source(source) do
             reporter.report_dependency(dependency) { |report| refute_nil report }
@@ -129,7 +130,7 @@ describe Licensed::Reporters::CacheReporter do
     end
 
     it "prints an informative messages for a cached dependency to the shell" do
-      reporter.report_run do
+      reporter.report_run(command) do
         reporter.report_app(app) do
           reporter.report_source(source) do
             reporter.report_dependency(dependency) { |report| report["cached"] = true }
@@ -145,7 +146,7 @@ describe Licensed::Reporters::CacheReporter do
     end
 
     it "prints an informative messages for a skipped dependency to the shell" do
-      reporter.report_run do
+      reporter.report_run(command) do
         reporter.report_app(app) do
           reporter.report_source(source) do
             reporter.report_dependency(dependency) { |report| report["cached"] = false }

--- a/test/reporters/cache_reporter_test.rb
+++ b/test/reporters/cache_reporter_test.rb
@@ -108,13 +108,13 @@ describe Licensed::Reporters::CacheReporter do
         assert_includes shell.messages,
                         {
 
-                           message: "    - source error",
+                           message: "      - source error",
                            newline: true,
                            style: :error
                         }
         assert_includes shell.messages,
                         {
-                           message: "    - dependency error",
+                           message: "      - dependency error",
                            newline: true,
                            style: :error
                         }

--- a/test/reporters/cache_reporter_test.rb
+++ b/test/reporters/cache_reporter_test.rb
@@ -93,6 +93,39 @@ describe Licensed::Reporters::CacheReporter do
         end
       end
     end
+
+    it "reports errors during the source run" do
+      reporter.report_run(command) do
+        reporter.report_app(app) do |app_report|
+          reporter.report_source(source) do |source_report|
+            source_report.errors << "source error"
+            reporter.report_dependency(dependency) do |dependency_report|
+              dependency_report.errors << "dependency error"
+            end
+          end
+        end
+
+        assert_includes shell.messages,
+                        {
+
+                           message: "    - source error",
+                           newline: true,
+                           style: :error
+                        }
+        assert_includes shell.messages,
+                        {
+                           message: "    - dependency error",
+                           newline: true,
+                           style: :error
+                        }
+        refute_includes shell.messages,
+                        {
+                           message: "  * 0 #{source.class.type} dependencies",
+                           newline: true,
+                           style: :confirm
+                        }
+      end
+    end
   end
 
   describe "#report_dependency" do
@@ -155,6 +188,22 @@ describe Licensed::Reporters::CacheReporter do
                                message: "    Using #{dependency.name} (#{dependency.version})",
                                newline: true,
                                style: :info
+                            }
+          end
+        end
+      end
+    end
+
+    it "prints an informative messages for an errored dependency to the shell" do
+      reporter.report_run(command) do
+        reporter.report_app(app) do
+          reporter.report_source(source) do
+            reporter.report_dependency(dependency) { |report| report.errors << "error" }
+            assert_includes shell.messages,
+                            {
+                               message: "    Error #{dependency.name} (#{dependency.version})",
+                               newline: true,
+                               style: :error
                             }
           end
         end

--- a/test/reporters/list_reporter_test.rb
+++ b/test/reporters/list_reporter_test.rb
@@ -93,6 +93,39 @@ describe Licensed::Reporters::ListReporter do
         end
       end
     end
+
+    it "reports errors during the source run" do
+      reporter.report_run(command) do
+        reporter.report_app(app) do |app_report|
+          reporter.report_source(source) do |source_report|
+            source_report.errors << "source error"
+            reporter.report_dependency(dependency) do |dependency_report|
+              dependency_report.errors << "dependency error"
+            end
+          end
+        end
+
+        assert_includes shell.messages,
+                        {
+
+                           message: "    - source error",
+                           newline: true,
+                           style: :error
+                        }
+        assert_includes shell.messages,
+                        {
+                           message: "    - dependency error",
+                           newline: true,
+                           style: :error
+                        }
+        refute_includes shell.messages,
+                        {
+                           message: "  * 0 #{source.class.type} dependencies",
+                           newline: true,
+                           style: :confirm
+                        }
+      end
+    end
   end
 
   describe "#report_dependency" do

--- a/test/reporters/list_reporter_test.rb
+++ b/test/reporters/list_reporter_test.rb
@@ -8,30 +8,31 @@ describe Licensed::Reporters::ListReporter do
   let(:config) { Licensed::Configuration.new }
   let(:source) { TestSource.new(config) }
   let(:dependency) { source.dependencies.first }
+  let(:command) { TestCommand.new(config: config, reporter: reporter) }
 
   describe "#report_app" do
     it "runs a block" do
       success = false
-      reporter.report_run do
+      reporter.report_run(command) do
         reporter.report_app(app) { success = true }
       end
       assert success
     end
 
     it "returns the result of the block" do
-      reporter.report_run do
+      reporter.report_run(command) do
         assert_equal 1, reporter.report_app(app) { 1 }
       end
     end
 
     it "provides a report hash to the block" do
-      reporter.report_run do
+      reporter.report_run(command) do
         reporter.report_app(app) { |report| refute_nil report }
       end
     end
 
     it "prints an informative message to the shell" do
-      reporter.report_run do
+      reporter.report_run(command) do
         reporter.report_app(app) {}
 
         assert_includes shell.messages,
@@ -47,7 +48,7 @@ describe Licensed::Reporters::ListReporter do
   describe "#report_source" do
     it "runs a block" do
       success = false
-      reporter.report_run do
+      reporter.report_run(command) do
         reporter.report_app(app) do
           reporter.report_source(source) { success = true }
         end
@@ -57,7 +58,7 @@ describe Licensed::Reporters::ListReporter do
     end
 
     it "returns the result of the block" do
-      reporter.report_run do
+      reporter.report_run(command) do
         reporter.report_app(app) do
           assert_equal 1, reporter.report_source(source) { 1 }
         end
@@ -65,7 +66,7 @@ describe Licensed::Reporters::ListReporter do
     end
 
     it "provides a report hash to the block" do
-      reporter.report_run do
+      reporter.report_run(command) do
         reporter.report_app(app) do
           reporter.report_source(source) { |report| refute_nil report }
         end
@@ -73,7 +74,7 @@ describe Licensed::Reporters::ListReporter do
     end
 
     it "prints informative messages to the shell" do
-      reporter.report_run do
+      reporter.report_run(command) do
         reporter.report_app(app) do
           reporter.report_source(source) {}
           assert_includes shell.messages,
@@ -97,7 +98,7 @@ describe Licensed::Reporters::ListReporter do
   describe "#report_dependency" do
     it "runs a block" do
       success = false
-      reporter.report_run do
+      reporter.report_run(command) do
         reporter.report_app(app) do
           reporter.report_source(source) do
             reporter.report_dependency(dependency) { success = true }
@@ -109,7 +110,7 @@ describe Licensed::Reporters::ListReporter do
     end
 
     it "returns the result of the block" do
-      reporter.report_run do
+      reporter.report_run(command) do
         reporter.report_app(app) do
           reporter.report_source(source) do
             assert_equal 1, reporter.report_dependency(dependency) { 1 }
@@ -119,7 +120,7 @@ describe Licensed::Reporters::ListReporter do
     end
 
     it "provides a report hash to the block" do
-      reporter.report_run do
+      reporter.report_run(command) do
         reporter.report_app(app) do
           reporter.report_source(source) do
             reporter.report_dependency(dependency) { |report| refute_nil report }
@@ -129,7 +130,7 @@ describe Licensed::Reporters::ListReporter do
     end
 
     it "prints an informative messages for a cached dependency to the shell" do
-      reporter.report_run do
+      reporter.report_run(command) do
         reporter.report_app(app) do
           reporter.report_source(source) do
             reporter.report_dependency(dependency) { |report| report["cached"] = true }

--- a/test/reporters/list_reporter_test.rb
+++ b/test/reporters/list_reporter_test.rb
@@ -108,13 +108,13 @@ describe Licensed::Reporters::ListReporter do
         assert_includes shell.messages,
                         {
 
-                           message: "    - source error",
+                           message: "      - source error",
                            newline: true,
                            style: :error
                         }
         assert_includes shell.messages,
                         {
-                           message: "    - dependency error",
+                           message: "      - dependency error",
                            newline: true,
                            style: :error
                         }

--- a/test/reporters/reporter_test.rb
+++ b/test/reporters/reporter_test.rb
@@ -7,56 +7,62 @@ describe Licensed::Reporters::Reporter do
   let(:config) { Licensed::Configuration.new }
   let(:source) { TestSource.new(config) }
   let(:dependency) { source.dependencies.first }
+  let(:command) { TestCommand.new(config: config, reporter: reporter) }
 
   describe "#report_run" do
     it "runs a block" do
       success = false
-      reporter.report_run { success = true }
+      reporter.report_run(command) { success = true }
       assert success
     end
 
     it "returns the result of the block" do
-      assert_equal 1, reporter.report_run { 1 }
+      assert_equal 1, reporter.report_run(command) { 1 }
     end
 
-    it "provides a report hash to the block" do
-      reporter.report_run { |report| refute_nil report }
+    it "provides a report to the block" do
+      reporter.report_run(command) do |report|
+        assert report.is_a?(Licensed::Reporters::Reporter::Report)
+        assert_equal command, report.target
+        assert_nil report.name
+      end
     end
   end
 
   describe "#report_app" do
     it "runs a block" do
       success = false
-      reporter.report_run do
+      reporter.report_run(command) do
         reporter.report_app(app) { success = true }
       end
       assert success
     end
 
     it "returns the result of the block" do
-      reporter.report_run do
+      reporter.report_run(command) do
         assert_equal 1, reporter.report_app(app) { 1 }
       end
     end
 
-    it "provides a report hash to the block" do
-      reporter.report_run do
-        reporter.report_app(app) { |report| refute_nil report }
+    it "provides a report to the block" do
+      reporter.report_run(command) do
+        reporter.report_app(app) do |report|
+          assert report.is_a?(Licensed::Reporters::Reporter::Report)
+          assert_equal app, report.target
+          assert_equal app["name"], report.name
+        end
       end
     end
 
     it "stores the app report to the run report" do
-      reporter.report_run do |run_report|
-        reporter.report_app(app) do |app_report|
-          app_report["success"] = true
-        end
-
-        assert run_report[app["name"]]["success"]
+      reporter.report_run(command) do |run_report|
+        reporter.report_app(app) { }
+        assert run_report.reports.find { |report| report.target == app }
       end
     end
 
     it "raises an error for recursive calls" do
-      reporter.report_run do
+      reporter.report_run(command) do
         reporter.report_app(app) do
           assert_raises Licensed::Reporters::Reporter::ReportingError do
             reporter.report_app(app) {}
@@ -75,7 +81,7 @@ describe Licensed::Reporters::Reporter do
   describe "#report_source" do
     it "runs a block" do
       success = false
-      reporter.report_run do
+      reporter.report_run(command) do
         reporter.report_app(app) do
           reporter.report_source(source) { success = true }
         end
@@ -85,35 +91,37 @@ describe Licensed::Reporters::Reporter do
     end
 
     it "returns the result of the block" do
-      reporter.report_run do
+      reporter.report_run(command) do
         reporter.report_app(app) do
           assert_equal 1, reporter.report_source(source) { 1 }
         end
       end
     end
 
-    it "provides a report hash to the block" do
-      reporter.report_run do
+    it "provides a report to the block" do
+      reporter.report_run(command) do
         reporter.report_app(app) do
-          reporter.report_source(source) { |report| refute_nil report }
+          reporter.report_source(source) do |report|
+            assert report.is_a?(Licensed::Reporters::Reporter::Report)
+            assert_equal source, report.target
+            assert_equal "#{app["name"]}.#{source.class.type}", report.name
+          end
         end
       end
     end
 
     it "stores the source report to the app report" do
-      reporter.report_run do
+      reporter.report_run(command) do
         reporter.report_app(app) do |app_report|
-          reporter.report_source(source) do |source_report|
-            source_report["success"] = true
-          end
+          reporter.report_source(source) { }
+          assert app_report.reports.find { |report| report.target == source }
 
-          assert app_report[source.class.type]["success"]
         end
       end
     end
 
     it "raises an error for recursive calls" do
-      reporter.report_run do
+      reporter.report_run(command) do
         reporter.report_app(app) do
           reporter.report_source(source) do
             assert_raises Licensed::Reporters::Reporter::ReportingError do
@@ -134,7 +142,7 @@ describe Licensed::Reporters::Reporter do
   describe "#report_dependency" do
     it "runs a block" do
       success = false
-      reporter.report_run do
+      reporter.report_run(command) do
         reporter.report_app(app) do
           reporter.report_source(source) do
             reporter.report_dependency(dependency) { success = true }
@@ -146,7 +154,7 @@ describe Licensed::Reporters::Reporter do
     end
 
     it "returns the result of the block" do
-      reporter.report_run do
+      reporter.report_run(command) do
         reporter.report_app(app) do
           reporter.report_source(source) do
             assert_equal 1, reporter.report_dependency(dependency) { 1 }
@@ -155,25 +163,26 @@ describe Licensed::Reporters::Reporter do
       end
     end
 
-    it "provides a report hash to the block" do
-      reporter.report_run do
+    it "provides a report to the block" do
+      reporter.report_run(command) do
         reporter.report_app(app) do
           reporter.report_source(source) do
-            reporter.report_dependency(dependency) { |report| refute_nil report }
+            reporter.report_dependency(dependency) do |report|
+              assert report.is_a?(Licensed::Reporters::Reporter::Report)
+              assert_equal dependency, report.target
+              assert_equal "#{app["name"]}.#{source.class.type}.#{dependency.name}", report.name
+            end
           end
         end
       end
     end
 
     it "stores the dependency report to the source report" do
-      reporter.report_run do
+      reporter.report_run(command) do
         reporter.report_app(app) do
           reporter.report_source(source) do |source_report|
-            reporter.report_dependency(dependency) do |dependency_report|
-              dependency_report["success"] = true
-            end
-
-            assert source_report[dependency.name]["success"]
+            reporter.report_dependency(dependency) { }
+            assert source_report.reports.find { |report| report.target == dependency }
           end
         end
       end

--- a/test/reporters/reporter_test.rb
+++ b/test/reporters/reporter_test.rb
@@ -56,7 +56,7 @@ describe Licensed::Reporters::Reporter do
 
     it "stores the app report to the run report" do
       reporter.report_run(command) do |run_report|
-        reporter.report_app(app) { }
+        reporter.report_app(app) {}
         assert run_report.reports.find { |report| report.target == app }
       end
     end
@@ -113,7 +113,7 @@ describe Licensed::Reporters::Reporter do
     it "stores the source report to the app report" do
       reporter.report_run(command) do
         reporter.report_app(app) do |app_report|
-          reporter.report_source(source) { }
+          reporter.report_source(source) {}
           assert app_report.reports.find { |report| report.target == source }
 
         end
@@ -181,7 +181,7 @@ describe Licensed::Reporters::Reporter do
       reporter.report_run(command) do
         reporter.report_app(app) do
           reporter.report_source(source) do |source_report|
-            reporter.report_dependency(dependency) { }
+            reporter.report_dependency(dependency) {}
             assert source_report.reports.find { |report| report.target == dependency }
           end
         end

--- a/test/sources/npm_test.rb
+++ b/test/sources/npm_test.rb
@@ -63,7 +63,7 @@ if Licensed::Shell.tool_available?("npm")
           FileUtils.cp(File.join(fixtures, "package.json"), File.join(dir, "package.json"))
           Dir.chdir(dir) do
             error = assert_raises(Licensed::Shell::Error) { source.dependencies }
-            assert_includes error.message, "command exited with status 1"
+            assert_includes error.message, "'npm list --json --production --long' exited with status 1"
             assert_includes error.message, "npm ERR! missing: autoprefixer@"
           end
         end

--- a/test/test_helpers/test_command.rb
+++ b/test/test_helpers/test_command.rb
@@ -2,7 +2,27 @@
 class TestCommand < Licensed::Commands::Command
   protected
 
+  def run_source(app, source)
+    if options[:raise] == "#{app["name"]}.#{source.class.type}"
+      raise Licensed::Shell::Error.new([options[:raise]], 0, nil)
+    end
+
+    super
+  end
+
+  def run_dependency(app, source, dependency)
+    if options[:raise] == "#{app["name"]}.#{source.class.type}.#{dependency.name}"
+      raise Licensed::Shell::Error.new([options[:raise]], 0, nil)
+    end
+
+    super
+  end
+
   def evaluate_dependency(app, source, dependency, report)
+    if options[:raise] == "#{app["name"]}.#{source.class.type}.#{dependency.name}.evaluate"
+      raise Licensed::Shell::Error.new([options[:raise]], 0, nil)
+    end
+
     return true unless options[:fail]
     options[:fail] != app["name"]
   end

--- a/test/test_helpers/test_reporter.rb
+++ b/test/test_helpers/test_reporter.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 class TestReporter < Licensed::Reporters::Reporter
-  attr_reader :results
+  attr_reader :report
 
   def initialize
     super TestShell.new
   end
 
   # Make the run report available for tests to examine
-  def report_run
+  def report_run(command)
     super do |report|
-      @results = report
+      @report = report
       yield report
     end
   end


### PR DESCRIPTION
This PR starts work to catch and report external errors during command execution rather than crashing the application.

With this PR, errors raised from failed calls to `Licensed::Shell.execute` will be captured and handled gracefully, showing the error as part of the command report output.

```
➜  licensed git:(catch-errors-to-reporter) ✗ bundle exec licensed cache -c test/fixtures/command/npm.yml
Caching dependency records for npm
  npm

  * Errors:
    * npm.npm
      - 'npm list --json --production --long' exited with status 1
        npm ERR! missing: amdefine@1.0.1, required by source-map@0.4.4
```