### PR TITLE
Print 'license needs review' when license is not allowed

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,13 +62,13 @@ Checking licenses for 3 dependencies
 Warnings:
 
 .licenses/rubygem/bundler.txt:
-  - license needs reviewed: mit.
+  - license needs review: mit.
 
 .licenses/rubygem/licensee.txt:
   - cached license data missing
 
 .licenses/bower/jquery.txt:
-  - license needs reviewed: mit.
+  - license needs review: mit.
   - cached license data out of date
 
 3 dependencies checked, 3 warnings found.

--- a/lib/licensed/command/status.rb
+++ b/lib/licensed/command/status.rb
@@ -39,7 +39,7 @@ module Licensed
                 end
                 warnings << "missing license text" if license.license_text.empty?
                 unless allowed_or_reviewed?(app, license)
-                  warnings << "license needs reviewed: #{license["license"]}."
+                  warnings << "license needs review: #{license["license"]}."
                 end
               else
                 warnings << "cached license data missing"

--- a/test/command/status_test.rb
+++ b/test/command/status_test.rb
@@ -25,13 +25,13 @@ describe Licensed::Command::Status do
 
   it "warns if license is not allowed" do
     out, _ = capture_io { verifier.run }
-    assert_match(/license needs reviewed: mit/, out)
+    assert_match(/license needs review: mit/, out)
   end
 
   it "does not warn if license is allowed" do
     config.allow "mit"
     out, _ = capture_io { verifier.run }
-    refute_match(/license needs reviewed: mit/, out)
+    refute_match(/license needs review: mit/, out)
   end
 
   it "does not warn if dependency is ignored" do


### PR DESCRIPTION
Currently licensed prints like this when a license is not allowed:

```
.licenses/rubygem/bundler.txt:
  - license needs reviewed: mit.
```

It's a very minor detail, but I think it might read better to say "license needs review: mit."?