### PR TITLE
Handle dependency errors invidually

### DIFF
--- a/lib/licensed/commands/command.rb
+++ b/lib/licensed/commands/command.rb
@@ -75,6 +75,11 @@ module Licensed
       # Returns whether the command succeeded for the dependency
       def run_dependency(app, source, dependency)
         reporter.report_dependency(dependency) do |report|
+          if dependency.errors?
+            report.errors.concat(dependency.errors)
+            return false
+          end
+
           begin
             evaluate_dependency(app, source, dependency, report)
           rescue Licensed::Shell::Error => err

--- a/lib/licensed/shell.rb
+++ b/lib/licensed/shell.rb
@@ -3,16 +3,14 @@ require "open3"
 
 module Licensed
   module Shell
-    # Executes a command, returning its standard output on success. On failure,
-    # it raises an exception that contains the error output, unless
-    # `allow_failure` is true, in which case it returns an empty string.
+    # Executes a command, returning its standard output on success.
+    # On failure it raises an exception that contains the error output, unless
+    # `allow_failure` is true.
     def self.execute(cmd, *args, allow_failure: false, env: {})
       stdout, stderr, status = Open3.capture3(env, cmd, *args)
 
-      if status.success?
+      if status.success? || allow_failure
         stdout.strip
-      elsif allow_failure
-        ""
       else
         raise Error.new([cmd, *args], status.exitstatus, stderr)
       end
@@ -38,11 +36,11 @@ module Licensed
         super()
         @cmd = cmd
         @exitstatus = status
-        @output = stderr.to_s.strip
+        @stderr = stderr.to_s.strip
       end
 
       def message
-        extra = @output.empty?? "" : "#{@output.gsub(/^/, "        ")}"
+        extra = @stderr.empty?? "" : "#{@stderr.gsub(/^/, "        ")}"
         "'#{escape_cmd}' exited with status #{@exitstatus}\n#{extra}"
       end
 

--- a/lib/licensed/sources/bundler.rb
+++ b/lib/licensed/sources/bundler.rb
@@ -7,12 +7,41 @@ end
 module Licensed
   module Sources
     class Bundler < Source
+      class MissingSpecification < Gem::BasicSpecification
+        attr_reader :name, :requirement
+        alias_method :version, :requirement
+        def initialize(name:, requirement:)
+          @name = name
+          @requirement = requirement
+        end
+
+        def dependencies
+          []
+        end
+
+        def source
+          nil
+        end
+
+        def platform; end
+        def gem_dir; end
+        def gems_dir
+          Gem.dir
+        end
+        def summary; end
+        def homepage; end
+
+        def error
+          "could not find #{name} (#{requirement}) in any sources"
+        end
+      end
+
       GEMFILES = %w{Gemfile gems.rb}.freeze
       DEFAULT_WITHOUT_GROUPS = %i{development test}
 
       def enabled?
         # running a ruby-packer-built licensed exe when ruby isn't available
-        # could lead to errors if the host ruby doesn't executable's ruby
+        # could lead to errors if the host ruby doesn't exist
         return false if ruby_packer? && !Licensed::Shell.tool_available?("ruby")
         defined?(::Bundler) && lockfile_path && lockfile_path.exist?
       end
@@ -20,10 +49,12 @@ module Licensed
       def enumerate_dependencies
         with_local_configuration do
           specs.map do |spec|
+            error = spec.error if spec.respond_to?(:error)
             Licensed::Dependency.new(
               name: spec.name,
               version: spec.version.to_s,
               path: spec.gem_dir,
+              errors: Array(error),
               metadata: {
                 "type"     => Bundler.type,
                 "summary"  => spec.summary,
@@ -69,7 +100,7 @@ module Licensed
       def specs_for_dependencies(dependencies, source)
         included_dependencies = dependencies.select { |d| include?(d, source) }
         included_dependencies.map do |dep|
-          gem_spec(dep) || raise("Unable to find a specification for #{dep.name} (#{dep.requirement}) in any sources")
+          gem_spec(dep) || MissingSpecification.new(name: dep.name, requirement: dep.requirement)
         end
       end
 
@@ -138,6 +169,8 @@ module Licensed
         # use `gem specification` with a clean ENV to get gem specification YAML
         yaml = ::Bundler.with_original_env { Licensed::Shell.execute(*ruby_command_args("gem", "specification", name)) }
         Gem::Specification.from_yaml(yaml)
+      rescue Licensed::Shell::Error
+        # return nil
       end
 
       # Build the bundler definition

--- a/lib/licensed/sources/dep.rb
+++ b/lib/licensed/sources/dep.rb
@@ -13,11 +13,6 @@ module Licensed
           package_dir = @config.pwd.join("vendor", package[:name])
           search_root = @config.pwd.join("vendor", package[:project])
 
-          unless package_dir.exist?
-            next if @config.ignored?("type" => Dep.type, "name" => package[:name])
-            raise "couldn't find package for #{package[:name]}"
-          end
-
           Dependency.new(
             name: package[:name],
             version: package[:version],

--- a/lib/licensed/sources/npm.rb
+++ b/lib/licensed/sources/npm.rb
@@ -15,7 +15,6 @@ module Licensed
       def enumerate_dependencies
         packages.map do |name, package|
           path = package["path"]
-          fail "couldn't locate #{name} under node_modules/" unless path
           Dependency.new(
             name: name,
             version: package["version"],
@@ -33,7 +32,6 @@ module Licensed
       def packages
         root_dependencies = JSON.parse(package_metadata_command)["dependencies"]
         recursive_dependencies(root_dependencies).each_with_object({}) do |(name, results), hsh|
-          next if @config.ignored?("type" => NPM.type, "name" => name)
           results.uniq! { |package| package["version"] }
           if results.size == 1
             hsh[name] = results[0]
@@ -58,13 +56,7 @@ module Licensed
 
       # Returns the output from running `npm list` to get package metadata
       def package_metadata_command
-        npm_list_command("--json", "--production", "--long")
-      end
-
-      # Executes an `npm list` command with the provided args and returns the
-      # output from stdout
-      def npm_list_command(*args)
-        Licensed::Shell.execute("npm", "list", *args)
+        Licensed::Shell.execute("npm", "list", "--json", "--production", "--long", allow_failure: true)
       end
     end
   end

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 
 describe "licensed" do
   let (:root) { File.expand_path("../../", __FILE__) }
-  let (:config_path) { File.join(root, "test/fixtures/command/bundler.yml") }
+  let (:config_path) { File.join(root, "test/fixtures/cli/.licensed.yml") }
 
   before do
     Dir.chdir root

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 
 describe "licensed" do
   let (:root) { File.expand_path("../../", __FILE__) }
-  let (:config_path) { File.join(root, "test/fixtures/config/.licensed.yml") }
+  let (:config_path) { File.join(root, "test/fixtures/command/bundler.yml") }
 
   before do
     Dir.chdir root

--- a/test/commands/command_test.rb
+++ b/test/commands/command_test.rb
@@ -67,4 +67,13 @@ describe Licensed::Commands::Command do
     assert report
     assert_includes report.errors, "'app1.test.dependency.evaluate' exited with status 0\n"
   end
+
+  it "reports errors found on a dependency" do
+    dependency_name = "#{apps.first["name"]}.test.dependency"
+    configuration.apps.first["test"] = { "path" => nil }
+    refute command.run
+    report = command.reporter.report.all_reports.find { |report| report.name == dependency_name }
+    assert report
+    assert_includes report.errors, "dependency path not found"
+  end
 end

--- a/test/dependency_test.rb
+++ b/test/dependency_test.rb
@@ -3,21 +3,49 @@ require "test_helper"
 require "tmpdir"
 
 describe Licensed::Dependency do
+  let(:error) { nil }
+
   def mkproject(&block)
     Dir.mktmpdir do |dir|
       Dir.chdir dir do
-        yield Licensed::Dependency.new(name: "test", version: "1.0", path: dir)
+        yield Licensed::Dependency.new(name: "test", version: "1.0", path: dir, errors: [error])
       end
     end
   end
 
-  it "raises an error if the path argument is not an absolute path" do
-    assert_raises ArgumentError do
-      Licensed::Dependency.new(name: "test", version: "1.0", path: ".")
+  describe "initialize" do
+    it "raises an error if the path argument is not an absolute path" do
+      assert_raises ArgumentError do
+        Licensed::Dependency.new(name: "test", version: "1.0", path: ".")
+      end
+    end
+
+    describe "with an error" do
+      it "sets an error if path is nil or empty" do
+        dep = Licensed::Dependency.new(name: "test", version: "1.0", path: "")
+        assert_includes dep.errors, "dependency path not found"
+
+        dep = Licensed::Dependency.new(name: "test", version: "1.0", path: nil)
+        assert_includes dep.errors, "dependency path not found"
+      end
+
+      it "sets an error if path does not exist" do
+        path = File.join(Dir.pwd, "fake-path")
+        dep = Licensed::Dependency.new(name: "test", version: "1.0", path: path)
+        assert_includes dep.errors, "expected dependency path #{path} does not exist"
+      end
     end
   end
 
   describe "record" do
+    describe "with a dependency error" do
+      let(:error) { "error" }
+
+      it "returns nil" do
+        mkproject { |dep| assert_nil dep.record }
+      end
+    end
+
     it "returns a Licensed::DependencyRecord object with dependency data" do
       mkproject do |dependency|
         File.write "LICENSE", Licensee::License.find("mit").text
@@ -39,6 +67,14 @@ describe Licensed::Dependency do
   end
 
   describe "license_key" do
+    describe "with a dependency error" do
+      let(:error) { "error" }
+
+      it "returns none" do
+        mkproject { |dependency| assert_equal "none", dependency.license_key }
+      end
+    end
+
     it "gets license from license file" do
       mkproject do |dependency|
         File.write "LICENSE", Licensee::License.find("mit").text
@@ -110,10 +146,18 @@ describe Licensed::Dependency do
   end
 
   describe "license_contents" do
+    describe "with a dependency error" do
+      let(:error) { "error" }
+
+      it "returns an empty list" do
+        mkproject { |dependency| assert_empty dependency.license_contents }
+      end
+    end
+
     it "gets license content from license file" do
       mkproject do |dependency|
         File.write "LICENSE", Licensee::License.find("mit").text
-        assert_includes dependency.record.licenses,
+        assert_includes dependency.license_contents,
                         { "sources" => "LICENSE", "text" => Licensee::License.find("mit").text }
       end
     end
@@ -121,14 +165,14 @@ describe Licensed::Dependency do
     it "does not get license content from package manager file" do
       mkproject do |dependency|
         File.write "project.gemspec", "s.license = 'mit'"
-        assert_empty dependency.record.licenses
+        assert_empty dependency.license_contents
       end
     end
 
     it "gets license from readme" do
       mkproject do |dependency|
         File.write "README.md", "# License\n" + Licensee::License.find("mit").text
-        assert_includes dependency.record.licenses,
+        assert_includes dependency.license_contents,
                         { "sources" => "README.md", "text" => Licensee::License.find("mit").text.rstrip }
       end
     end
@@ -137,7 +181,7 @@ describe Licensed::Dependency do
       mkproject do |dependency|
         File.write "project.gemspec", "foo"
         File.write "README.md", "# License\n" + Licensee::License.find("mit").text
-        assert_includes dependency.record.licenses,
+        assert_includes dependency.license_contents,
                         { "sources" => "README.md", "text" => Licensee::License.find("mit").text.rstrip }
       end
     end
@@ -147,9 +191,9 @@ describe Licensed::Dependency do
         File.write "LICENSE", Licensee::License.find("mit").text
         File.write "LICENSE.md", Licensee::License.find("bsd-3-clause").text
 
-        assert_includes dependency.record.licenses,
+        assert_includes dependency.license_contents,
                         { "sources" => "LICENSE", "text" => Licensee::License.find("mit").text }
-        assert_includes dependency.record.licenses,
+        assert_includes dependency.license_contents,
                         { "sources" => "LICENSE.md", "text" => Licensee::License.find("bsd-3-clause").text }
       end
     end
@@ -159,9 +203,9 @@ describe Licensed::Dependency do
         File.write "LICENSE", Licensee::License.find("mit").text
         File.write "README.md", "# License\n" + Licensee::License.find("bsd-3-clause").text
 
-        assert_includes dependency.record.licenses,
+        assert_includes dependency.license_contents,
                         { "sources" => "LICENSE", "text" => Licensee::License.find("mit").text }
-        assert_includes dependency.record.licenses,
+        assert_includes dependency.license_contents,
                         { "sources" => "README.md", "text" => Licensee::License.find("bsd-3-clause").text.rstrip }
       end
     end
@@ -175,7 +219,7 @@ describe Licensed::Dependency do
           Dir.chdir "dependency" do
             dep = Licensed::Dependency.new(name: "test", version: "1.0", path: Dir.pwd, search_root: File.expand_path(".."))
             source = Pathname.new(dir).basename.join("LICENSE").to_path
-            assert_includes dep.record.licenses,
+            assert_includes dep.license_contents,
                             { "sources" => source, "text" => "license" }
           end
         end
@@ -187,24 +231,32 @@ describe Licensed::Dependency do
         File.write "LICENSE", Licensee::License.find("mit").text
         File.write "LICENSE.md", Licensee::License.find("mit").text
 
-        assert_includes dependency.record.licenses,
+        assert_includes dependency.license_contents,
                         { "sources" => "LICENSE, LICENSE.md", "text" => Licensee::License.find("mit").text }
       end
     end
   end
 
   describe "notice_contents" do
+    describe "with a dependency error" do
+      let(:error) { "error" }
+
+      it "returns an empty list" do
+        mkproject { |dependency| assert_empty dependency.notice_contents }
+      end
+    end
+
     it "extracts legal notices" do
       mkproject do |dependency|
         File.write "AUTHORS", "authors"
         File.write "NOTICE", "notice"
         File.write "LEGAL", "legal"
 
-        assert_includes dependency.record.notices,
+        assert_includes dependency.notice_contents,
                         { "sources" => "AUTHORS", "text" => "authors" }
-        assert_includes dependency.record.notices,
+        assert_includes dependency.notice_contents,
                         { "sources" => "NOTICE", "text" => "notice" }
-        assert_includes dependency.record.notices,
+        assert_includes dependency.notice_contents,
                         { "sources" => "LEGAL", "text" => "legal" }
       end
     end
@@ -215,13 +267,25 @@ describe Licensed::Dependency do
         File.write "NOTICE", ""
         File.write "LEGAL", "legal"
 
-        refute_includes dependency.record.notices,
+        refute_includes dependency.notice_contents,
                         { "sources" => "AUTHORS", "text" => "authors" }
-        refute_includes dependency.record.notices,
+        refute_includes dependency.notice_contents,
                         { "sources" => "NOTICE", "text" => "notice" }
-        assert_includes dependency.record.notices,
+        assert_includes dependency.notice_contents,
                         { "sources" => "LEGAL", "text" => "legal" }
       end
+    end
+  end
+
+  describe "error" do
+    it "returns true if a dependency has an error" do
+      dep = Licensed::Dependency.new(name: "test", version: "1.0", path: Dir.pwd, errors: ["error"])
+      assert dep.errors?
+    end
+
+    it "returns false if a dependency does not have an error" do
+      dep = Licensed::Dependency.new(name: "test", version: "1.0", path: Dir.pwd)
+      refute dep.errors?
     end
   end
 end

--- a/test/fixtures/cli/.licensed.yml
+++ b/test/fixtures/cli/.licensed.yml
@@ -1,0 +1,5 @@
+name: cli-test
+ignored:
+  bundler:
+    # in CI, bundler is set up pretty wonky and isn't found at the expected location
+    - "bundler"

--- a/test/sources/bundler_test.rb
+++ b/test/sources/bundler_test.rb
@@ -148,7 +148,6 @@ if Licensed::Shell.tool_available?("bundle")
         end
       end
 
-
       describe "with excluded groups in the configuration" do
         let(:config) { Licensed::Configuration.new("bundler" => { "without" => "exclude" }) }
 
@@ -193,6 +192,19 @@ if Licensed::Shell.tool_available?("bundle")
         fixtures = File.expand_path("../../fixtures/bundler", __FILE__)
         Dir.chdir(fixtures) do
           assert_nil source.dependencies.find { |d| d.name == "licensed" }
+        end
+      end
+
+      it "sets an error when dependencies are missing" do
+        Dir.mktmpdir do |dir|
+          FileUtils.cp_r(fixtures, dir)
+          dir = File.join(dir, "bundler")
+          FileUtils.rm_rf(File.join(dir, "vendor"))
+          Dir.chdir(dir) do
+            dep = source.dependencies.find { |d| d.name == "semantic" }
+            assert dep
+            assert_includes dep.errors, "could not find semantic (= 1.6.0) in any sources"
+          end
         end
       end
     end

--- a/test/sources/dep_test.rb
+++ b/test/sources/dep_test.rb
@@ -75,20 +75,11 @@ describe Licensed::Sources::Dep do
         FileUtils.rm_rf fixtures
       end
 
-      it "do not raise an error if ignored" do
-        config.ignore("type" => "dep", "name" => "github.com/gorilla/context")
-        config.ignore("type" => "dep", "name" => "github.com/davecgh/go-spew/spew")
-
+      it "sets an error message" do
         Dir.chdir fixtures do
-          source.dependencies
-        end
-      end
-
-      it "raises an error" do
-        Dir.chdir fixtures do
-          assert_raises RuntimeError do
-            source.dependencies
-          end
+          dep = source.dependencies.find { |d| d.name == "github.com/gorilla/context" }
+          assert dep
+          assert dep.errors.any? { |e| e =~ /expected dependency path .* does not exist/ }
         end
       end
     end

--- a/test/sources/npm_test.rb
+++ b/test/sources/npm_test.rb
@@ -58,13 +58,13 @@ if Licensed::Shell.tool_available?("npm")
         end
       end
 
-      it "raises when dependencies are missing" do
+      it "sets an error when dependencies are missing" do
         Dir.mktmpdir do |dir|
           FileUtils.cp(File.join(fixtures, "package.json"), File.join(dir, "package.json"))
           Dir.chdir(dir) do
-            error = assert_raises(Licensed::Shell::Error) { source.dependencies }
-            assert_includes error.message, "'npm list --json --production --long' exited with status 1"
-            assert_includes error.message, "npm ERR! missing: autoprefixer@"
+            dep = source.dependencies.find { |d| d.name == "autoprefixer" }
+            assert dep
+            assert_includes dep.errors, "dependency path not found"
           end
         end
       end

--- a/test/sources/source_test.rb
+++ b/test/sources/source_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require "test_helper"
+require "tmpdir"
+require "fileutils"
+
+describe Licensed::Sources::Source do
+  let(:config) { Licensed::Configuration.new }
+  let(:source) { TestSource.new(config) }
+
+  describe "dependencies" do
+    it "returns dependencies from the source" do
+      dep = source.dependencies.first
+      assert dep
+      assert dep.name == "dependency"
+    end
+
+    it "does not return ignored dependencies" do
+      config.ignore("type" => "test", "name" => "dependency")
+      assert_empty source.dependencies
+    end
+  end
+end

--- a/test/test_helpers/test_source.rb
+++ b/test/test_helpers/test_source.rb
@@ -16,11 +16,12 @@ class TestSource < Licensed::Sources::Source
   end
 
   def enumerate_dependencies
+    dependency_config = config["test"] || {}
     [
       Licensed::Dependency.new(
         name: @name,
         version: "1.0",
-        path: Dir.pwd,
+        path: dependency_config.fetch("path", Dir.pwd),
         metadata: {
           "type"     => TestSource.type,
           "dir"      => Dir.pwd


### PR DESCRIPTION
This PR adds handling for errors encountered when pulling information for individual dependencies.  This change, along with https://github.com/github/licensed/pull/133, aims to reduce the majority of source and dependency specific errors encountered when enumerating dependencies from crashing an entire licensed command run.

An `errors` attribute is added to `Licensed::Dependency` which is then picked up in `Licensed::Commands::Command#run_dependency` and transferred to the command's reporter for output similar to any other failure that might be displayed for a dependency.

If a dependency has errors, all of its methods will return empty or nil data.  Additionally, it will not be evaluated by the commands and will be considered to have failed.

Some common error cases relating to paths are picked up automatically when creating a new dependency
- a nil or empty `path` argument
- a `path` argument that doesn't exist on disk

Any other errors are returned from the various CLI and framework tools can be passed in directly.

Specific comments on implementation inline.