### PR TITLE
Handle source errors

### DIFF
--- a/docs/adding_a_new_source.md
+++ b/docs/adding_a_new_source.md
@@ -68,8 +68,26 @@ Creating a new `Licensed::Dependency` object requires name, version, and path ar
          - A short description of the dependencies purpose.
       2. homepage
          - The dependency's homepage.
+6. errors (optional)
+  - Any errors found when loading dependency information.
 
 #### Finding licenses
 
 In some cases, license content will be in a parent directory of the specified location.  For instance, this can happen with Golang packages
 that share a license file, e.g. `github.com/go/pkg/1` and `github.com/go/pkg/2` might share a license at `github.com/go/pkg`.  In this case, create a `Licensed::Dependency` with the optional `search_root` property, which denotes the root of the directory hierarchy that should be searched.  Directories will be examined in order from the given license location to the `search_root` location to prefer license files with more specificity, i.e. `github.com/go/pkg/1` will be searched before `github.com/go/pkg`.
+
+#### Handling errors when enumerating dependencies
+
+External tools have their own error handling which, if left unhandled, can cause dependency enumeration as a whole to fail either for an individual dependency source or for licensed as a whole.  These errors should be gracefully handled to allow for the best possible user experience.
+
+##### Handling errors related to a specific dependency
+
+`Licensed::Dependency#initialize` will already set errors related to `nil` or empty `path:` arguments, as well as paths that don't exist.  Additional errors can be set to a dependency using the `errors:` argument, e.g. `Licensed::Dependency.new(errors: ["error"])`.
+
+When a dependency contains errors, all errors will be reported to the user and `Licensed::Command::Command#evaluate_dependency` will be not be called.
+
+##### Handling errors related to source evaluation
+
+When an error occurs related to a specific source, raise a `Licensed::Sources::Source::Error` with an informative message.  The error will be caught and reported to the user, and further evaluation of the source will be halted.
+
+As an example, this could be useful if a source is enabled but incorrectly configured.

--- a/lib/licensed/commands/command.rb
+++ b/lib/licensed/commands/command.rb
@@ -62,6 +62,9 @@ module Licensed
           rescue Licensed::Shell::Error => err
             report.errors << err.message
             false
+          rescue Licensed::Sources::Source::Error => err
+            report.errors << err.message
+            false
           end
         end
       end

--- a/lib/licensed/sources/bundler.rb
+++ b/lib/licensed/sources/bundler.rb
@@ -95,8 +95,8 @@ module Licensed
         results.merge recursive_specs(dependency_specs, results)
       end
 
-      # Returns the specs for dependencies that pass the checks in `include?`
-      # Raises an error if the specification isn't found
+      # Returns the specs for dependencies that pass the checks in `include?`.
+      # Returns a `MissingSpecification` if a gem specification isn't found.
       def specs_for_dependencies(dependencies, source)
         included_dependencies = dependencies.select { |d| include?(d, source) }
         included_dependencies.map do |dep|
@@ -104,8 +104,7 @@ module Licensed
         end
       end
 
-      # Returns a Gem::Specification for the provided gem argument.  If a
-      # Gem::Specification isn't found, an error will be raised.
+      # Returns a Gem::Specification for the provided gem argument.
       def gem_spec(dependency)
         return unless dependency
 

--- a/lib/licensed/sources/manifest.rb
+++ b/lib/licensed/sources/manifest.rb
@@ -110,7 +110,7 @@ module Licensed
       def verify_configured_dependencies!
         # verify that dependencies are configured
         if configured_dependencies.empty?
-          raise "The manifest \"dependencies\" cannot be empty!"
+          raise Source::Error.new("The manifest \"dependencies\" cannot be empty!")
         end
 
         # verify all included files match a single configured dependency
@@ -128,7 +128,7 @@ module Licensed
         end
 
         errors.compact!
-        raise errors.join($/) unless errors.empty?
+        raise Source::Error.new(errors.join($/)) if errors.any?
       end
 
       # Returns the project dependencies specified from the licensed configuration

--- a/lib/licensed/sources/source.rb
+++ b/lib/licensed/sources/source.rb
@@ -9,6 +9,8 @@ module Licensed
         end
       end
 
+      class Error < StandardError; end
+
       class << self
         attr_reader :sources
         def inherited(klass)

--- a/test/sources/manifest_test.rb
+++ b/test/sources/manifest_test.rb
@@ -140,7 +140,7 @@ describe Licensed::Sources::Manifest do
       it "raises an error if the \"dependencies\" setting is empty" do
         config["manifest"]["dependencies"] = {}
 
-        err = assert_raises RuntimeError do
+        err = assert_raises Licensed::Sources::Source::Error do
           source.manifest
         end
 
@@ -153,7 +153,7 @@ describe Licensed::Sources::Manifest do
           "manifest_test_2" => "**/*"
         }
 
-        err = assert_raises RuntimeError do
+        err = assert_raises Licensed::Sources::Source::Error do
           source.manifest
         end
         assert err.message.include?("matched multiple configured dependencies: manifest_test, manifest_test_2")
@@ -164,7 +164,7 @@ describe Licensed::Sources::Manifest do
           "manifest_test" => "!**/nested/*"
         }
 
-        err = assert_raises RuntimeError do
+        err = assert_raises Licensed::Sources::Source::Error do
           source.manifest
         end
         assert err.message.include?("nested.c did not match a configured dependency")

--- a/test/test_helpers/test_command.rb
+++ b/test/test_helpers/test_command.rb
@@ -3,27 +3,17 @@ class TestCommand < Licensed::Commands::Command
   protected
 
   def run_source(app, source)
-    if options[:raise] == "#{app["name"]}.#{source.class.type}"
-      raise Licensed::Shell::Error.new([options[:raise]], 0, nil)
-    end
-
+    return options[:source_proc].call(app, source) if options[:source_proc]
     super
   end
 
   def run_dependency(app, source, dependency)
-    if options[:raise] == "#{app["name"]}.#{source.class.type}.#{dependency.name}"
-      raise Licensed::Shell::Error.new([options[:raise]], 0, nil)
-    end
-
+    return options[:dependency_proc].call(app, source, dependency) if options[:dependency_proc]
     super
   end
 
   def evaluate_dependency(app, source, dependency, report)
-    if options[:raise] == "#{app["name"]}.#{source.class.type}.#{dependency.name}.evaluate"
-      raise Licensed::Shell::Error.new([options[:raise]], 0, nil)
-    end
-
-    return true unless options[:fail]
-    options[:fail] != app["name"]
+    return options[:evaluate_proc].call(app, source, dependency) if options[:evaluate_proc]
+    true
   end
 end


### PR DESCRIPTION
This PR follows up on https://github.com/github/licensed/pull/135 to handle errors found when evaluating a source as a whole.

In comparison to https://github.com/github/licensed/pull/135 which handles errors related to specific dependencies, this PR seeks to provide a way to report errors related to a source as a whole.  A new error class is created that can be raised to provide information about what happened.  The error will be caught and gracefully handled by the command infrastructure.

This is useful when a source is not configured properly, as shown in this PR where the error is raised when a manifest loaded from the licensed configuration file is invalid.

As part of this PR I've also updated docs to mention the various ways of handling errors when enumerating dependencies.