### PR TITLE
Improve detection of Python packages from pip requirements file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,8 +13,8 @@ Please note that this project is released with a [Contributor Code of Conduct][c
 
 0. [Fork][fork] and clone the repository
 0. Configure and install the dependencies: `script/bootstrap`
-0. Setup test fixtures: `rake setup`
-0. Make sure the tests pass on your machine: `rake test`
+0. Setup test fixtures: `bundle exec rake setup`
+0. Make sure the tests pass on your machine: `bundle exec rake test`
 0. Create a new branch: `git checkout -b my-branch-name`
 0. Make your change, add tests, and make sure the tests still pass
 0. Push to your fork and [submit a pull request][pr]

--- a/lib/licensed/source/pip.rb
+++ b/lib/licensed/source/pip.rb
@@ -42,6 +42,8 @@ module Licensed
         end
       end
 
+      private
+
       # Build the list of packages from a 'requirements.txt'
       def parse_requirements_txt
         File.open(@config.pwd.join("requirements.txt")).map do |line|

--- a/lib/licensed/source/pip.rb
+++ b/lib/licensed/source/pip.rb
@@ -6,7 +6,7 @@ module Licensed
   module Source
     class Pip
       VERSION_OPERATORS = /
-        (\w+)
+        ^(\w+)
         |(\w+)<
         |(\w+)>
         |(\w+)<=
@@ -46,11 +46,11 @@ module Licensed
 
       # Build the list of packages from a 'requirements.txt'
       def parse_requirements_txt
-        File.open(@config.pwd.join("requirements.txt")).map do |line|
+        File.open(@config.pwd.join("requirements.txt")).map { |line|
           line.strip.match(VERSION_OPERATORS) { |match|
-            match.captures.compact
-          }.first
-        end
+            match.captures.first
+          }
+        }.compact
       end
 
       def package_info(package_name)

--- a/lib/licensed/source/pip.rb
+++ b/lib/licensed/source/pip.rb
@@ -22,7 +22,7 @@ module Licensed
       end
 
       def dependencies
-        @dependencies ||= parse_requirements_txt.map do |package_name|
+        @dependencies ||= packages_from_requirements_txt.map do |package_name|
           package = package_info(package_name)
           location = File.join(package["Location"], package["Name"] +  "-" + package["Version"] + ".dist-info")
           Dependency.new(location, {
@@ -37,8 +37,7 @@ module Licensed
 
       private
 
-      # Build the list of packages from a 'requirements.txt'
-      def parse_requirements_txt
+      def packages_from_requirements_txt
         File.open(@config.pwd.join("requirements.txt")).map do |line|
           line.strip.match(PACKAGE_REGEX) { |match| match.captures.first }
         end.compact

--- a/lib/licensed/source/pip.rb
+++ b/lib/licensed/source/pip.rb
@@ -39,9 +39,9 @@ module Licensed
 
       # Build the list of packages from a 'requirements.txt'
       def parse_requirements_txt
-        File.open(@config.pwd.join("requirements.txt")).map { |line|
+        File.open(@config.pwd.join("requirements.txt")).map do |line|
           line.strip.match(PACKAGE_REGEX) { |match| match.captures.first }
-        }.compact
+        end.compact
       end
 
       def package_info(package_name)

--- a/lib/licensed/source/pip.rb
+++ b/lib/licensed/source/pip.rb
@@ -5,6 +5,16 @@ require "English"
 module Licensed
   module Source
     class Pip
+      VERSION_OPERATORS = /
+        (\w+)
+        |(\w+)<
+        |(\w+)>
+        |(\w+)<=
+        |(\w+)>=
+        |(\w+)==
+        |(\w+)!=
+      /x
+
       def self.type
         "pip"
       end
@@ -33,11 +43,11 @@ module Licensed
       end
 
       # Build the list of packages from a 'requirements.txt'
-      # Assumes that the requirements.txt follow the format pkg=1.0.0 or pkg==1.0.0
       def parse_requirements_txt
         File.open(@config.pwd.join("requirements.txt")).map do |line|
-          p_split = line.split("==")
-          p_split[0]
+          line.strip.match(VERSION_OPERATORS) { |match|
+            match.captures.compact
+          }.first
         end
       end
 

--- a/lib/licensed/source/pip.rb
+++ b/lib/licensed/source/pip.rb
@@ -5,15 +5,8 @@ require "English"
 module Licensed
   module Source
     class Pip
-      VERSION_OPERATORS = /
-        ^(\w+)
-        |(\w+)<
-        |(\w+)>
-        |(\w+)<=
-        |(\w+)>=
-        |(\w+)==
-        |(\w+)!=
-      /x
+      VERSION_OPERATORS = %w(< > <= >= == !=).freeze
+      PACKAGE_REGEX = /^(\w+)(#{VERSION_OPERATORS.join("|")})?/
 
       def self.type
         "pip"
@@ -47,9 +40,7 @@ module Licensed
       # Build the list of packages from a 'requirements.txt'
       def parse_requirements_txt
         File.open(@config.pwd.join("requirements.txt")).map { |line|
-          line.strip.match(VERSION_OPERATORS) { |match|
-            match.captures.first
-          }
+          line.strip.match(PACKAGE_REGEX) { |match| match.captures.first }
         }.compact
       end
 

--- a/lib/licensed/source/pip.rb
+++ b/lib/licensed/source/pip.rb
@@ -36,7 +36,7 @@ module Licensed
       # Assumes that the requirements.txt follow the format pkg=1.0.0 or pkg==1.0.0
       def parse_requirements_txt
         File.open(@config.pwd.join("requirements.txt")).map do |line|
-          p_split = line.split("=")
+          p_split = line.split("==")
           p_split[0]
         end
       end

--- a/licensed.gemspec
+++ b/licensed.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "thor", "~>0.19"
   spec.add_dependency "pathname-common_prefix", "~>0.0.1"
   spec.add_dependency "tomlrb", "~>1.2"
-  spec.add_dependency "bundler", "~> 1.10"
+  spec.add_dependency "bundler", ">= 1.10"
 
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.8"

--- a/licensed.gemspec
+++ b/licensed.gemspec
@@ -24,9 +24,9 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.3.0"
 
   spec.add_dependency "licensee", "~> 9.0"
-  spec.add_dependency "thor", "~>0.19"
-  spec.add_dependency "pathname-common_prefix", "~>0.0.1"
-  spec.add_dependency "tomlrb", "~>1.2"
+  spec.add_dependency "thor", "~> 0.19"
+  spec.add_dependency "pathname-common_prefix", "~> 0.0.1"
+  spec.add_dependency "tomlrb", "~> 1.2"
   spec.add_dependency "bundler", ">= 1.10"
 
   spec.add_development_dependency "rake", "~> 10.0"

--- a/test/fixtures/command/pip.yml
+++ b/test/fixtures/command/pip.yml
@@ -1,4 +1,4 @@
-expected_dependency: MarkupSafe
+expected_dependency: Jinja2
 source_path: test/fixtures/pip
 python:
-  virtual_env_dir: "test/fixtures/pip/venv"
+  virtual_env_dir: test/fixtures/pip/venv

--- a/test/fixtures/pip/requirements.txt
+++ b/test/fixtures/pip/requirements.txt
@@ -1,3 +1,4 @@
+--index-url https://pypi.org/simple
 pandas
 Jinja2==2.9.6
 requests>=2.21.0

--- a/test/fixtures/pip/requirements.txt
+++ b/test/fixtures/pip/requirements.txt
@@ -1,3 +1,4 @@
+# This comment should be ignored
 --index-url https://pypi.org/simple
 pandas
 Jinja2==2.9.6

--- a/test/fixtures/pip/requirements.txt
+++ b/test/fixtures/pip/requirements.txt
@@ -7,3 +7,4 @@ tqdm<=4.30.0
 Pillow>5.4.0
 Scrapy<1.6.0
 numpy!=1.16.1
+boto3>=1.0,<=2.0

--- a/test/fixtures/pip/requirements.txt
+++ b/test/fixtures/pip/requirements.txt
@@ -1,1 +1,7 @@
+pandas
 Jinja2==2.9.6
+requests>=2.21.0
+tqdm<=4.30.0
+Pillow>5.4.0
+Scrapy<1.6.0
+numpy!=1.16.1

--- a/test/fixtures/pip/requirements.txt
+++ b/test/fixtures/pip/requirements.txt
@@ -1,2 +1,1 @@
 Jinja2==2.9.6
-MarkupSafe==1.0

--- a/test/fixtures/pip/requirements.txt
+++ b/test/fixtures/pip/requirements.txt
@@ -7,4 +7,5 @@ tqdm<=4.30.0
 Pillow>5.4.0
 Scrapy<1.6.0
 numpy!=1.16.1
+botocore == 1.12.91
 boto3>=1.0,<=2.0

--- a/test/source/pip_test.rb
+++ b/test/source/pip_test.rb
@@ -25,7 +25,7 @@ if Licensed::Shell.tool_available?("pip")
     end
 
     describe "dependencies" do
-      it "includes direct dependencies" do
+      it "detects dependencies with == version constraint" do
         Dir.chdir fixtures do
           dep = source.dependencies.detect { |d| d["name"] == "Jinja2" }
           assert dep

--- a/test/source/pip_test.rb
+++ b/test/source/pip_test.rb
@@ -34,16 +34,6 @@ if Licensed::Shell.tool_available?("pip")
           assert dep["summary"]
         end
       end
-
-      it "includes indirect dependencies" do
-        Dir.chdir fixtures do
-          dep = source.dependencies.detect { |d| d["name"] == "MarkupSafe" }
-          assert dep
-          assert_equal "pip", dep["type"]
-          assert dep["homepage"]
-          assert dep["summary"]
-        end
-      end
     end
   end
 end

--- a/test/source/pip_test.rb
+++ b/test/source/pip_test.rb
@@ -94,6 +94,16 @@ if Licensed::Shell.tool_available?("pip")
           assert dep["summary"]
         end
       end
+
+      it "detects dependencies with multiple version constraints" do
+        Dir.chdir fixtures do
+          dep = source.dependencies.detect { |d| d["name"] == "boto3" }
+          assert dep
+          assert_equal "pip", dep["type"]
+          assert dep["homepage"]
+          assert dep["summary"]
+        end
+      end
     end
   end
 end

--- a/test/source/pip_test.rb
+++ b/test/source/pip_test.rb
@@ -25,9 +25,69 @@ if Licensed::Shell.tool_available?("pip")
     end
 
     describe "dependencies" do
+      it "detects dependencies without a version constraint" do
+        Dir.chdir fixtures do
+          dep = source.dependencies.detect { |d| d["name"] == "pandas" }
+          assert dep
+          assert_equal "pip", dep["type"]
+          assert dep["homepage"]
+          assert dep["summary"]
+        end
+      end
+
       it "detects dependencies with == version constraint" do
         Dir.chdir fixtures do
           dep = source.dependencies.detect { |d| d["name"] == "Jinja2" }
+          assert dep
+          assert_equal "pip", dep["type"]
+          assert dep["homepage"]
+          assert dep["summary"]
+        end
+      end
+
+      it "detects dependencies with >= version constraint" do
+        Dir.chdir fixtures do
+          dep = source.dependencies.detect { |d| d["name"] == "requests" }
+          assert dep
+          assert_equal "pip", dep["type"]
+          assert dep["homepage"]
+          assert dep["summary"]
+        end
+      end
+
+      it "detects dependencies with <= version constraint" do
+        Dir.chdir fixtures do
+          dep = source.dependencies.detect { |d| d["name"] == "tqdm" }
+          assert dep
+          assert_equal "pip", dep["type"]
+          assert dep["homepage"]
+          assert dep["summary"]
+        end
+      end
+
+      it "detects dependencies with < version constraint" do
+        Dir.chdir fixtures do
+          dep = source.dependencies.detect { |d| d["name"] == "Pillow" }
+          assert dep
+          assert_equal "pip", dep["type"]
+          assert dep["homepage"]
+          assert dep["summary"]
+        end
+      end
+
+      it "detects dependencies with > version constraint" do
+        Dir.chdir fixtures do
+          dep = source.dependencies.detect { |d| d["name"] == "Scrapy" }
+          assert dep
+          assert_equal "pip", dep["type"]
+          assert dep["homepage"]
+          assert dep["summary"]
+        end
+      end
+
+      it "detects dependencies with != version constraint" do
+        Dir.chdir fixtures do
+          dep = source.dependencies.detect { |d| d["name"] == "numpy" }
           assert dep
           assert_equal "pip", dep["type"]
           assert dep["homepage"]

--- a/test/source/pip_test.rb
+++ b/test/source/pip_test.rb
@@ -95,6 +95,16 @@ if Licensed::Shell.tool_available?("pip")
         end
       end
 
+      it "detects dependencies with whitespace between the package name and version operator" do
+        Dir.chdir fixtures do
+          dep = source.dependencies.detect { |d| d["name"] == "botocore" }
+          assert dep
+          assert_equal "pip", dep["type"]
+          assert dep["homepage"]
+          assert dep["summary"]
+        end
+      end
+
       it "detects dependencies with multiple version constraints" do
         Dir.chdir fixtures do
           dep = source.dependencies.detect { |d| d["name"] == "boto3" }


### PR DESCRIPTION
Related to https://github.com/github/licensed/issues/117#issuecomment-451226189

Primary changes include

- Detect dependencies without version constraint
- Detect dependencies with `>` version constraint
- Detect dependencies with `<` version constraint
- Detect dependencies with `>=` version constraint
- Detect dependencies with `<=` version constraint
- Detect dependencies with `!=` version constraint
- Ignore pip options in requirements file

Note that while these changes improve detection, they do not introduce 100% dependency detection. For example, packages can still go undetected in a requirements file when present as [an editable option](https://pip.pypa.io/en/stable/reference/pip_install/#cmdoption-e) or as [an overridden dependency via VCS](https://pip.pypa.io/en/stable/reference/pip_install/#vcs-support).