### PR TITLE
Don't leave file open after evaluating pip requirements txt

### DIFF
--- a/lib/licensed/source/pip.rb
+++ b/lib/licensed/source/pip.rb
@@ -38,9 +38,10 @@ module Licensed
       private
 
       def packages_from_requirements_txt
-        File.open(@config.pwd.join("requirements.txt")).map do |line|
-          line.strip.match(PACKAGE_REGEX) { |match| match.captures.first }
-        end.compact
+        File.read(@config.pwd.join("requirements.txt"))
+            .lines
+            .map { |line| line.strip.match(PACKAGE_REGEX) { |match| match.captures.first } }
+            .compact
       end
 
       def package_info(package_name)


### PR DESCRIPTION
Noticed this after merging https://github.com/github/licensed/pull/139 (note: the usage of `File.open` predates that PR)

`File.open` returns a file object that needs to be manually closed, which never happened.  The alternatives were to
1. Close the file object
2. Use `File.open` with a block, which will automatically close the file at the end of the block
3. Use `File.read` since all we care about is the contents of the file

Using the third option as it's the most straightforward.  Also by aligning operations I was able to reasonably fit the `map` statement on a single line, removing the need for a `do end` block