### PR TITLE
update licensee requirement

### DIFF
--- a/licensed.gemspec
+++ b/licensed.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.3.0"
 
-  spec.add_dependency "licensee", "~> 9.0"
+  spec.add_dependency "licensee", "~> 9.10"
   spec.add_dependency "thor", "~> 0.19"
   spec.add_dependency "pathname-common_prefix", "~> 0.0.1"
   spec.add_dependency "tomlrb", "~> 1.2"


### PR DESCRIPTION
closes https://github.com/github/licensed/issues/141

The issue occurred because the target project is using an older version of licensee, where `Licensee::Projects::FSProject#dir_path` does not yet exist.  That method was added in v9.9.3, which I'm using `~> 9.10` as an even number.  The most recent version of licensee is 9.11.0.