### PR TITLE
Report warning when caching a dependency with a path that doesn't exist

### DIFF
--- a/lib/licensed/commands/cache.rb
+++ b/lib/licensed/commands/cache.rb
@@ -41,6 +41,10 @@ module Licensed
           report["cached"] = true
         end
 
+        if !dependency.exist?
+          report.warnings << "expected dependency path #{dependency.path} does not exist"
+        end
+
         true
       end
 

--- a/lib/licensed/reporters/cache_reporter.rb
+++ b/lib/licensed/reporters/cache_reporter.rb
@@ -27,6 +27,22 @@ module Licensed
           shell.info "  #{source.class.type}"
           result = yield report
 
+          warning_reports = report.all_reports.select { |report| report.warnings.any? }.to_a
+          if warning_reports.any?
+            shell.newline
+            shell.warning "  * Warnings:"
+            warning_reports.each do |report|
+              display_metadata = report.map { |k, v| "#{k}: #{v}" }.join(", ")
+
+              shell.warning "    * #{report.name}"
+              shell.warning "    #{display_metadata}" unless display_metadata.empty?
+              report.warning.each do |warning|
+                shell.warning "      - #{warning}"
+              end
+              shell.newline
+            end
+          end
+
           errored_reports = report.all_reports.select { |report| report.errors.any? }.to_a
           if errored_reports.any?
             shell.newline

--- a/lib/licensed/reporters/reporter.rb
+++ b/lib/licensed/reporters/reporter.rb
@@ -19,6 +19,10 @@ module Licensed
           @errors ||= []
         end
 
+        def warnings
+          @warnings ||= []
+        end
+
         def all_reports
           result = []
           result << self

--- a/test/commands/cache_test.rb
+++ b/test/commands/cache_test.rb
@@ -141,6 +141,14 @@ describe Licensed::Commands::Cache do
     assert_equal count - 1, ignored_count
   end
 
+  it "reports a warning when a dependency doesn't exist" do
+    config.apps.first["test"] = { "path" => File.join(Dir.pwd, "non-existant") }
+    generator.run
+    report = reporter.report.all_reports.find { |r| r.name&.include?("dependency") }
+    refute_empty report.warnings
+    assert report.warnings.any? { |w| w =~ /expected dependency path .*? does not exist/ }
+  end
+
   describe "with multiple apps" do
     let(:apps) do
       [

--- a/test/dependency_test.rb
+++ b/test/dependency_test.rb
@@ -28,12 +28,6 @@ describe Licensed::Dependency do
         dep = Licensed::Dependency.new(name: "test", version: "1.0", path: nil)
         assert_includes dep.errors, "dependency path not found"
       end
-
-      it "sets an error if path does not exist" do
-        path = File.join(Dir.pwd, "fake-path")
-        dep = Licensed::Dependency.new(name: "test", version: "1.0", path: path)
-        assert_includes dep.errors, "expected dependency path #{path} does not exist"
-      end
     end
   end
 

--- a/test/dependency_test.rb
+++ b/test/dependency_test.rb
@@ -271,7 +271,7 @@ describe Licensed::Dependency do
     end
   end
 
-  describe "error" do
+  describe "error?" do
     it "returns true if a dependency has an error" do
       dep = Licensed::Dependency.new(name: "test", version: "1.0", path: Dir.pwd, errors: ["error"])
       assert dep.errors?
@@ -280,6 +280,30 @@ describe Licensed::Dependency do
     it "returns false if a dependency does not have an error" do
       dep = Licensed::Dependency.new(name: "test", version: "1.0", path: Dir.pwd)
       refute dep.errors?
+    end
+  end
+
+  describe "path" do
+    it "returns the configured dependency path" do
+      dep = Licensed::Dependency.new(name: "test", version: "1.0", path: Dir.pwd)
+      assert_equal Dir.pwd, dep.path.to_s
+    end
+  end
+
+  describe "exist?" do
+    it "returns true if the configured dependency path exists" do
+      dep = Licensed::Dependency.new(name: "test", version: "1.0", path: Dir.pwd)
+      assert dep.exist?
+    end
+
+    it "returns true if the configured search root exists" do
+      dep = Licensed::Dependency.new(name: "test", version: "1.0", path: File.join(Dir.pwd, "non-exist"), search_root: Dir.pwd)
+      assert dep.exist?
+    end
+
+    it "returns false if neither the search root or configured path exists" do
+      dep = Licensed::Dependency.new(name: "test", version: "1.0", path: File.join(Dir.pwd, "non-exist"))
+      refute dep.exist?
     end
   end
 end

--- a/test/sources/dep_test.rb
+++ b/test/sources/dep_test.rb
@@ -60,28 +60,5 @@ describe Licensed::Sources::Dep do
         end
       end
     end
-
-    describe "with unavailable packages" do
-      let(:root) { Dir.mktmpdir }
-      let(:fixtures) { File.join(root, "test") }
-
-      before do
-        FileUtils.mkdir_p fixtures
-        FileUtils.cp_r File.expand_path("../../fixtures/go/src/test", __FILE__), root
-        FileUtils.rm_rf File.join(fixtures, "vendor/github.com")
-      end
-
-      after do
-        FileUtils.rm_rf fixtures
-      end
-
-      it "sets an error message" do
-        Dir.chdir fixtures do
-          dep = source.dependencies.find { |d| d.name == "github.com/gorilla/context" }
-          assert dep
-          assert dep.errors.any? { |e| e =~ /expected dependency path .* does not exist/ }
-        end
-      end
-    end
   end
 end


### PR DESCRIPTION
closes https://github.com/github/licensed/issues/143

This PR adds warnings to licensed command reports, and sets a warning if a dependency path isn't found when caching a dependency record.

If a dependency path doesn't exist on the local disk, this used to raise an error, however this can be a fairly common case for gems included by default in a ruby installation and shouldn't stop the remainder of a dependencies found metadata from being recorded.