### PR TITLE
Release 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## 2.0.1 - 2019-02-14
+
+### Changes
+- Dependency paths that don't exist on the local disk are reported as warnings
+- Cache, status and list output is sorted by app name, source type and dependency name
+- Bumped `licensee` gem requirement
+
 ## 2.0.0 - 2019-02-09
 
 **This is a major release and includes breaking changes to the configuration and cached record file formats**
@@ -133,4 +140,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Initial release :tada:
 
-[Unreleased]: https://github.com/github/licensed/compare/2.0.0...HEAD
+[Unreleased]: https://github.com/github/licensed/compare/2.0.1...HEAD

--- a/lib/licensed/version.rb
+++ b/lib/licensed/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Licensed
-  VERSION = "2.0.0".freeze
+  VERSION = "2.0.1".freeze
 
   def self.previous_major_versions
     major_version = Gem::Version.new(Licensed::VERSION).segments.first


### PR DESCRIPTION
## 2.0.1 - 2019-02-14

### Changes
- Dependency paths that don't exist on the local disk are reported as warnings
- Cache, status and list output is sorted by app name, source type and dependency name
- Bumped `licensee` gem requirement
