### PR TITLE
Fix warnings reporting

### DIFF
--- a/lib/licensed/reporters/cache_reporter.rb
+++ b/lib/licensed/reporters/cache_reporter.rb
@@ -30,14 +30,14 @@ module Licensed
           warning_reports = report.all_reports.select { |report| report.warnings.any? }.to_a
           if warning_reports.any?
             shell.newline
-            shell.warning "  * Warnings:"
+            shell.warn "  * Warnings:"
             warning_reports.each do |report|
               display_metadata = report.map { |k, v| "#{k}: #{v}" }.join(", ")
 
-              shell.warning "    * #{report.name}"
-              shell.warning "    #{display_metadata}" unless display_metadata.empty?
-              report.warning.each do |warning|
-                shell.warning "      - #{warning}"
+              shell.warn "    * #{report.name}"
+              shell.warn "    #{display_metadata}" unless display_metadata.empty?
+              report.warnings.each do |warning|
+                shell.warn "      - #{warning}"
               end
               shell.newline
             end

--- a/test/reporters/cache_reporter_test.rb
+++ b/test/reporters/cache_reporter_test.rb
@@ -94,6 +94,31 @@ describe Licensed::Reporters::CacheReporter do
       end
     end
 
+    it "reports warnings during the source run" do
+      reporter.report_run(command) do
+        reporter.report_app(app) do |app_report|
+          reporter.report_source(source) do |source_report|
+            reporter.report_dependency(dependency) do |dependency_report|
+              dependency_report.warnings << "dependency warning"
+            end
+          end
+        end
+
+        assert_includes shell.messages,
+                        {
+                           message: "      - dependency warning",
+                           newline: true,
+                           style: :warn
+                        }
+        assert_includes shell.messages,
+                        {
+                           message: "  * 1 #{source.class.type} dependencies",
+                           newline: true,
+                           style: :confirm
+                        }
+      end
+    end
+
     it "reports errors during the source run" do
       reporter.report_run(command) do
         reporter.report_app(app) do |app_report|


### PR DESCRIPTION
I'm pretty confused on this one TBH, I had caught and fixed this as part of https://github.com/github/licensed/pull/144 but I guess never committed or pushed those changes?

Anyway, this is the fix, again, for a crash when warnings are found during `licensed cache`.