### PR TITLE
Fix v2 migration when sources is not explicit set

### DIFF
--- a/lib/licensed/migrations/v2.rb
+++ b/lib/licensed/migrations/v2.rb
@@ -28,7 +28,9 @@ module Licensed
           end
 
           app.sources.each do |source|
-            Dir.chdir app.cache_path.join(source.class.type) do
+            cache_path = app.cache_path.join(source.class.type)
+            next unless File.exist?(cache_path)
+            Dir.chdir cache_path do
               # licensed v1 cached records were stored as .txt files with YAML frontmatter
               Dir["**/*.txt"].each do |file|
                 yaml, licenses, notices = parse_file(file)


### PR DESCRIPTION
The migration code tried to update cached records for all sources, regardless of whether they had any records cached or not, since the migrator doesn't check `Source#enabled?` .  This is a small fix to only change directories to cache paths that exist.