### PR TITLE
Don't raise errors on empty dependency paths unless caching records

### DIFF
--- a/lib/licensed/commands/cache.rb
+++ b/lib/licensed/commands/cache.rb
@@ -32,6 +32,11 @@ module Licensed
       #
       # Returns true.
       def evaluate_dependency(app, source, dependency, report)
+        if dependency.path.empty?
+          report.errors << "dependency path not found"
+          return false
+        end
+
         filename = app.cache_path.join(source.class.type, "#{dependency.name}.#{DependencyRecord::EXTENSION}")
         cached_record = Licensed::DependencyRecord.read(filename)
         if options[:force] || save_dependency_record?(dependency, cached_record)

--- a/test/commands/cache_test.rb
+++ b/test/commands/cache_test.rb
@@ -149,6 +149,13 @@ describe Licensed::Commands::Cache do
     assert report.warnings.any? { |w| w =~ /expected dependency path .*? does not exist/ }
   end
 
+  it "reports an error when a dependency's path is empty" do
+    config.apps.first["test"] = { path: nil }
+    generator.run
+    report = reporter.report.all_reports.find { |r| r.name&.include?("dependency") }
+    assert_includes report.errors, "dependency path not found"
+  end
+
   describe "with multiple apps" do
     let(:apps) do
       [

--- a/test/commands/cache_test.rb
+++ b/test/commands/cache_test.rb
@@ -142,7 +142,7 @@ describe Licensed::Commands::Cache do
   end
 
   it "reports a warning when a dependency doesn't exist" do
-    config.apps.first["test"] = { "path" => File.join(Dir.pwd, "non-existant") }
+    config.apps.first["test"] = { path: File.join(Dir.pwd, "non-existant") }
     generator.run
     report = reporter.report.all_reports.find { |r| r.name&.include?("dependency") }
     refute_empty report.warnings

--- a/test/commands/command_test.rb
+++ b/test/commands/command_test.rb
@@ -74,11 +74,11 @@ describe Licensed::Commands::Command do
 
   it "reports errors found on a dependency" do
     dependency_name = "#{apps.first["name"]}.test.dependency"
-    configuration.apps.first["test"] = { "path" => nil }
+    configuration.apps.first["test"] = { errors: ["error"] }
     refute command.run
     report = command.reporter.report.all_reports.find { |report| report.name == dependency_name }
     assert report
-    assert_includes report.errors, "dependency path not found"
+    assert_includes report.errors, "error"
   end
 
   it "catches source errors thrown when evaluating a source" do

--- a/test/dependency_test.rb
+++ b/test/dependency_test.rb
@@ -19,27 +19,9 @@ describe Licensed::Dependency do
         Licensed::Dependency.new(name: "test", version: "1.0", path: ".")
       end
     end
-
-    describe "with an error" do
-      it "sets an error if path is nil or empty" do
-        dep = Licensed::Dependency.new(name: "test", version: "1.0", path: "")
-        assert_includes dep.errors, "dependency path not found"
-
-        dep = Licensed::Dependency.new(name: "test", version: "1.0", path: nil)
-        assert_includes dep.errors, "dependency path not found"
-      end
-    end
   end
 
   describe "record" do
-    describe "with a dependency error" do
-      let(:error) { "error" }
-
-      it "returns nil" do
-        mkproject { |dep| assert_nil dep.record }
-      end
-    end
-
     it "returns a Licensed::DependencyRecord object with dependency data" do
       mkproject do |dependency|
         File.write "LICENSE", Licensee::License.find("mit").text
@@ -61,14 +43,6 @@ describe Licensed::Dependency do
   end
 
   describe "license_key" do
-    describe "with a dependency error" do
-      let(:error) { "error" }
-
-      it "returns none" do
-        mkproject { |dependency| assert_equal "none", dependency.license_key }
-      end
-    end
-
     it "gets license from license file" do
       mkproject do |dependency|
         File.write "LICENSE", Licensee::License.find("mit").text
@@ -140,14 +114,6 @@ describe Licensed::Dependency do
   end
 
   describe "license_contents" do
-    describe "with a dependency error" do
-      let(:error) { "error" }
-
-      it "returns an empty list" do
-        mkproject { |dependency| assert_empty dependency.license_contents }
-      end
-    end
-
     it "gets license content from license file" do
       mkproject do |dependency|
         File.write "LICENSE", Licensee::License.find("mit").text
@@ -232,14 +198,6 @@ describe Licensed::Dependency do
   end
 
   describe "notice_contents" do
-    describe "with a dependency error" do
-      let(:error) { "error" }
-
-      it "returns an empty list" do
-        mkproject { |dependency| assert_empty dependency.notice_contents }
-      end
-    end
-
     it "extracts legal notices" do
       mkproject do |dependency|
         File.write "AUTHORS", "authors"

--- a/test/sources/npm_test.rb
+++ b/test/sources/npm_test.rb
@@ -58,17 +58,6 @@ if Licensed::Shell.tool_available?("npm")
         end
       end
 
-      it "sets an error when dependencies are missing" do
-        Dir.mktmpdir do |dir|
-          FileUtils.cp(File.join(fixtures, "package.json"), File.join(dir, "package.json"))
-          Dir.chdir(dir) do
-            dep = source.dependencies.find { |d| d.name == "autoprefixer" }
-            assert dep
-            assert_includes dep.errors, "dependency path not found"
-          end
-        end
-      end
-
       describe "with multiple instances of a dependency" do
         it "includes version in the dependency name for multiple unique versions" do
           Dir.chdir fixtures do

--- a/test/test_helpers/test_source.rb
+++ b/test/test_helpers/test_source.rb
@@ -3,15 +3,8 @@
 class TestSource < Licensed::Sources::Source
   def initialize(config, name = "dependency", metadata = {})
     super config
-    @dependency_config = {
-      name: name,
-      version: "1.0",
-      path: Dir.pwd,
-      metadata: {
-        "type" => TestSource.type,
-        "dir" => Dir.pwd
-      }.merge(metadata)
-    }.merge(config["test"] || {})
+    @name = name
+    @metadata = metadata
   end
 
   def self.type
@@ -23,6 +16,15 @@ class TestSource < Licensed::Sources::Source
   end
 
   def enumerate_dependencies
-    [Licensed::Dependency.new(**@dependency_config)]
+    dependency_config = {
+      name: @name,
+      version: "1.0",
+      path: Dir.pwd,
+      metadata: {
+        "type" => TestSource.type,
+        "dir" => Dir.pwd
+      }.merge(@metadata)
+    }.merge(config["test"] || {})
+    [Licensed::Dependency.new(**dependency_config)]
   end
 end

--- a/test/test_helpers/test_source.rb
+++ b/test/test_helpers/test_source.rb
@@ -3,8 +3,15 @@
 class TestSource < Licensed::Sources::Source
   def initialize(config, name = "dependency", metadata = {})
     super config
-    @metadata = metadata
-    @name = name
+    @dependency_config = {
+      name: name,
+      version: "1.0",
+      path: Dir.pwd,
+      metadata: {
+        "type" => TestSource.type,
+        "dir" => Dir.pwd
+      }.merge(metadata)
+    }.merge(config["test"] || {})
   end
 
   def self.type
@@ -16,17 +23,6 @@ class TestSource < Licensed::Sources::Source
   end
 
   def enumerate_dependencies
-    dependency_config = config["test"] || {}
-    [
-      Licensed::Dependency.new(
-        name: @name,
-        version: "1.0",
-        path: dependency_config.fetch("path", Dir.pwd),
-        metadata: {
-          "type"     => TestSource.type,
-          "dir"      => Dir.pwd
-        }.merge(@metadata)
-      )
-    ]
+    [Licensed::Dependency.new(**@dependency_config)]
   end
 end


### PR DESCRIPTION
Following https://github.com/github/licensed/pull/144, I think it makes sense to also not raise errors by default when a dependency path is nil or empty, meaning dependency contents weren't found.

This is only really an issue when caching dependency records.  Listing dependencies only needs the name and the version, and verifying cached records relies on the cached data and not on live data.