### PR TITLE
Find gradle dependency licenses via new dependency subclass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,5 +93,10 @@ matrix:
       script: ./script/test git_submodule
       env: NAME="git_submodule"
 
+    - language: java
+      before_script: ./test/fixtures/gradle/gradlew --quiet --version
+      script: ./script/test gradle
+      env: NAME="gradle"
+
 notifications:
   disable: true

--- a/lib/licensed/commands/cache.rb
+++ b/lib/licensed/commands/cache.rb
@@ -79,13 +79,11 @@ module Licensed
       #
       # Returns nothing
       def clear_stale_cached_records(app, source)
-        source.with_latest_licenses do
-          names = source.dependencies.map { |dependency| File.join(source.class.type, dependency.name) }
-          Dir.glob(app.cache_path.join(source.class.type, "**/*.#{DependencyRecord::EXTENSION}")).each do |file|
-            file_path = Pathname.new(file)
-            relative_path = file_path.relative_path_from(app.cache_path).to_s
-            FileUtils.rm(file) unless names.include?(relative_path.chomp(".#{DependencyRecord::EXTENSION}"))
-          end
+        names = source.dependencies.map { |dependency| File.join(source.class.type, dependency.name) }
+        Dir.glob(app.cache_path.join(source.class.type, "**/*.#{DependencyRecord::EXTENSION}")).each do |file|
+          file_path = Pathname.new(file)
+          relative_path = file_path.relative_path_from(app.cache_path).to_s
+          FileUtils.rm(file) unless names.include?(relative_path.chomp(".#{DependencyRecord::EXTENSION}"))
         end
       end
     end

--- a/lib/licensed/sources/gradle.rb
+++ b/lib/licensed/sources/gradle.rb
@@ -43,12 +43,6 @@ module Licensed
         end
       end
 
-      def with_latest_licenses
-        download_and_cache_licenses do
-          yield
-        end
-      end
-
       private
 
       def download_licenses_from_csv

--- a/lib/licensed/sources/gradle.rb
+++ b/lib/licensed/sources/gradle.rb
@@ -9,9 +9,9 @@ module Licensed
   module Sources
     class Gradle < Source
 
-      DEFAULT_CONFIGURATIONS   = ["runtime", "runtimeClasspath"]
-      GRADLE_LICENSES_PATH     = ".gradle-licenses"
-      GRADLE_LICENSES_CSV_NAME = "licenses.csv"
+      DEFAULT_CONFIGURATIONS   = ["runtime", "runtimeClasspath"].freeze
+      GRADLE_LICENSES_PATH     = ".gradle-licenses".freeze
+      GRADLE_LICENSES_CSV_NAME = "licenses.csv".freeze
 
       class Dependency < Licensed::Dependency
         class << self
@@ -98,38 +98,38 @@ module Licensed
       end
 
       def gradle_file
-        <<-EOF
-plugins {
-    id "com.github.jk1.dependency-license-report" version "1.4"
-}
+        <<~EOF
+          plugins {
+              id "com.github.jk1.dependency-license-report" version "1.4"
+          }
 
-import com.github.jk1.license.render.CsvReportRenderer
-import com.github.jk1.license.filter.LicenseBundleNormalizer
+          import com.github.jk1.license.render.CsvReportRenderer
+          import com.github.jk1.license.filter.LicenseBundleNormalizer
 
-final configs = #{configurations.inspect}
+          final configs = #{configurations.inspect}
 
-apply from: "build.gradle"
+          apply from: "build.gradle"
 
-licenseReport {
-    configurations = configs
-    outputDir = "$projectDir/#{GRADLE_LICENSES_PATH}"
-    renderers = [new CsvReportRenderer()]
-    filters = [new LicenseBundleNormalizer()]
-}
+          licenseReport {
+              configurations = configs
+              outputDir = "$projectDir/#{GRADLE_LICENSES_PATH}"
+              renderers = [new CsvReportRenderer()]
+              filters = [new LicenseBundleNormalizer()]
+          }
 
-task printDependencies {
-    doLast {
-        def dependencies = []
-        configs.each {
-            configurations[it].resolvedConfiguration.resolvedArtifacts.each { artifact ->
-                def id = artifact.moduleVersion.id
-                dependencies << "  { \\"group\\": \\"${id.group}\\", \\"name\\": \\"${id.name}\\", \\"version\\": \\"${id.version}\\" }"
-            }
-        }
-        println "[\\n${dependencies.join(", ")}\\n]"
-    }
-}
-EOF
+          task printDependencies {
+              doLast {
+                  def dependencies = []
+                  configs.each {
+                      configurations[it].resolvedConfiguration.resolvedArtifacts.each { artifact ->
+                          def id = artifact.moduleVersion.id
+                          dependencies << "  { \\"group\\": \\"${id.group}\\", \\"name\\": \\"${id.name}\\", \\"version\\": \\"${id.version}\\" }"
+                      }
+                  }
+                  println "[\\n${dependencies.join(", ")}\\n]"
+              }
+          }
+        EOF
       end
     end
   end

--- a/lib/licensed/sources/gradle.rb
+++ b/lib/licensed/sources/gradle.rb
@@ -69,12 +69,7 @@ module Licensed
 
           url = self.class.url_for(self)
           license_data = self.class.retrieve_license(url)
-
-          FileUtils.mkdir_p(File.join(@path, name))
-          file = File.join(@path, name, "LICENSE")
-          File.write(file, license_data)
-          file_parts = { dir: File.dirname(file), name: File.basename(file) }
-          Array(Licensee::ProjectFiles::LicenseFile.new(license_data, file_parts))
+          Array(Licensee::ProjectFiles::LicenseFile.new(license_data, { uri: url }))
         end
       end
 

--- a/lib/licensed/sources/gradle.rb
+++ b/lib/licensed/sources/gradle.rb
@@ -68,7 +68,7 @@ module Licensed
 
         # Returns a Licensee::ProjectFiles::LicenseFile for the dependency
         def project_files
-          self.class.load_csv(dir_path, @executable, @configurations)
+          self.class.load_csv(path, @executable, @configurations)
 
           url = self.class.url_for(self)
           license_data = self.class.retrieve_license(url)

--- a/lib/licensed/sources/gradle.rb
+++ b/lib/licensed/sources/gradle.rb
@@ -121,7 +121,7 @@ module Licensed
 
       def self.gradle_command(*args, path:, executable:, configurations:)
         Dir.chdir(path) do
-          Tempfile.open(["license-", ".gradle"], path) do |f|
+          Tempfile.create(["license-", ".gradle"], path) do |f|
             f.write gradle_file(configurations)
             f.close
             Licensed::Shell.execute(executable, "-q", "-b", f.path, *args)

--- a/lib/licensed/sources/gradle.rb
+++ b/lib/licensed/sources/gradle.rb
@@ -4,7 +4,7 @@ require "csv"
 require "uri"
 require "json"
 require "net/http"
-require 'fileutils'
+require "fileutils"
 
 module Licensed
   module Sources

--- a/lib/licensed/sources/source.rb
+++ b/lib/licensed/sources/source.rb
@@ -58,11 +58,6 @@ module Licensed
         config.ignored?("type" => self.class.type, "name" => dependency.name)
       end
 
-      # Callback for updating the source tree if needed
-      def with_latest_licenses
-        yield
-      end
-
       private
 
       # Returns a cached list of dependencies

--- a/licensed.gemspec
+++ b/licensed.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.8"
+  spec.add_development_dependency "mocha", "~> 1.0"
   spec.add_development_dependency "rubocop", "~> 0.49"
   spec.add_development_dependency "rubocop-github", "~> 0.6"
   spec.add_development_dependency "byebug", "~> 10.0.0"

--- a/test/sources/gradle_test.rb
+++ b/test/sources/gradle_test.rb
@@ -5,6 +5,7 @@ require "fileutils"
 
 if Licensed::Shell.tool_available?("gradle")
   describe Licensed::Sources::Gradle do
+    let(:fixtures) { File.expand_path("../../fixtures/gradle", __FILE__) }
     let(:config) { Licensed::Configuration.new }
     let(:source) { Licensed::Sources::Gradle.new(config) }
 
@@ -18,7 +19,7 @@ if Licensed::Shell.tool_available?("gradle")
         end
       end
 
-      it "is false no npm configs exist" do
+      it "is false if build.gradle does not exist" do
         Dir.chdir(Dir.tmpdir) do
           refute source.enabled?
         end
@@ -26,14 +27,13 @@ if Licensed::Shell.tool_available?("gradle")
     end
 
     describe "dependencies" do
-      let(:fixtures) { File.expand_path("../../fixtures/gradle", __FILE__) }
-
       it "includes declared dependencies" do
         Dir.chdir fixtures do
           dep = source.dependencies.detect { |d| d.name == "io.netty:netty-all" }
           assert dep
           assert_equal "gradle", dep.record["type"]
           assert_equal "4.1.33.Final", dep.version
+          # add assertion for dep.path being expected url
         end
       end
 
@@ -43,18 +43,19 @@ if Licensed::Shell.tool_available?("gradle")
         end
       end
     end
+  end
 
-    describe "update_licenses_cache" do
-      let(:fixtures) { File.expand_path("../../fixtures/gradle", __FILE__) }
+  describe Licensed::Sources::Gradle::Dependency do
+    let(:fixtures) { File.expand_path("../../fixtures/gradle", __FILE__) }
+    let(:config) { Licensed::Configuration.new }
+    let(:source) { Licensed::Sources::Gradle.new(config) }
 
-      it "downloads the project licenses" do
-        Dir.chdir fixtures do
-          source.with_latest_licenses do
-            packages = Dir.entries(File.join(fixtures, ".gradle-licenses"))
-            directory = packages.select { |p| p == "io.netty:netty-all" }
-            assert_match /Apache License/, File.read(File.join(fixtures, ".gradle-licenses", directory, "LICENSE"))
-          end
-        end
+    it "returns the dependency license" do
+      Dir.chdir fixtures do
+        dep = source.dependencies.detect { |d| d.name == "io.netty:netty-all" }
+        assert dep
+        assert_equal "apache-2.0", dep.license
+        assert dep.record.licenses.any? { |r| r["source"] == dep.path && r["text"] =~ /Apache License/ }
       end
     end
   end

--- a/test/sources/gradle_test.rb
+++ b/test/sources/gradle_test.rb
@@ -9,21 +9,6 @@ describe Licensed::Sources::Gradle do
   let(:source) { Licensed::Sources::Gradle.new(config) }
 
   describe "enabled?" do
-    it "is false if neither gradlew or gradle are available" do
-      begin
-        path, ENV["PATH"] = ENV["PATH"], nil
-
-        Dir.mktmpdir do |dir|
-          Dir.chdir(dir) do
-            File.write "build.gradle", ""
-            refute source.enabled?
-          end
-        end
-      ensure
-        ENV["PATH"] = path
-      end
-    end
-
     it "is true if build.gradle exists and gradle is available" do
       Dir.chdir(fixtures) do
         assert source.enabled?

--- a/test/sources/gradle_test.rb
+++ b/test/sources/gradle_test.rb
@@ -76,4 +76,16 @@ describe Licensed::Sources::Gradle::Dependency do
       refute Pathname.pwd.join(Licensed::Sources::Gradle::GRADLE_LICENSES_PATH).exist?
     end
   end
+
+  it "does not make any network requests when accessing non-license data" do
+    Licensed::Sources::Gradle::Dependency.expects(:retrieve_license).never
+    Licensed::Sources::Gradle::Dependency.expects(:load_csv).never
+
+    Dir.chdir fixtures do
+      dep = source.dependencies.detect { |d| d.name == "io.netty:netty-all" }
+      # accessing non-license dependency data does not make network requests
+      dep.name
+      dep.version
+    end
+  end
 end

--- a/test/sources/gradle_test.rb
+++ b/test/sources/gradle_test.rb
@@ -54,8 +54,8 @@ if Licensed::Shell.tool_available?("gradle")
       Dir.chdir fixtures do
         dep = source.dependencies.detect { |d| d.name == "io.netty:netty-all" }
         assert dep
-        assert_equal "apache-2.0", dep.license
-        assert dep.record.licenses.any? { |r| r["source"] == dep.path && r["text"] =~ /Apache License/ }
+        assert_equal "apache-2.0", dep.license.key
+        assert dep.record.licenses.any? { |r| r["text"] =~ /Apache License/ }
       end
     end
   end

--- a/test/sources/gradle_test.rb
+++ b/test/sources/gradle_test.rb
@@ -65,7 +65,10 @@ describe Licensed::Sources::Gradle::Dependency do
       dep = source.dependencies.detect { |d| d.name == "io.netty:netty-all" }
       assert dep
       assert_equal "apache-2.0", dep.license.key
-      assert dep.record.licenses.any? { |r| r["text"] =~ /Apache License/ }
+
+      license = dep.record.licenses.find { |l| l["text"] =~ /Apache License/ }
+      assert license
+      assert_equal "https://www.apache.org/licenses/LICENSE-2.0", license["sources"]
     end
   end
 end

--- a/test/sources/gradle_test.rb
+++ b/test/sources/gradle_test.rb
@@ -3,60 +3,69 @@ require "test_helper"
 require "tmpdir"
 require "fileutils"
 
-if Licensed::Shell.tool_available?("gradle")
-  describe Licensed::Sources::Gradle do
-    let(:fixtures) { File.expand_path("../../fixtures/gradle", __FILE__) }
-    let(:config) { Licensed::Configuration.new }
-    let(:source) { Licensed::Sources::Gradle.new(config) }
+describe Licensed::Sources::Gradle do
+  let(:fixtures) { File.expand_path("../../fixtures/gradle", __FILE__) }
+  let(:config) { Licensed::Configuration.new }
+  let(:source) { Licensed::Sources::Gradle.new(config) }
 
-    describe "enabled?" do
-      it "is true if build.gradle exists" do
+  describe "enabled?" do
+    it "is false if neither gradlew or gradle are available" do
+      begin
+        path, ENV["PATH"] = ENV["PATH"], nil
+
         Dir.mktmpdir do |dir|
           Dir.chdir(dir) do
             File.write "build.gradle", ""
-            assert source.enabled?
+            refute source.enabled?
           end
         end
-      end
-
-      it "is false if build.gradle does not exist" do
-        Dir.chdir(Dir.tmpdir) do
-          refute source.enabled?
-        end
+      ensure
+        ENV["PATH"] = path
       end
     end
 
-    describe "dependencies" do
-      it "includes declared dependencies" do
-        Dir.chdir fixtures do
-          dep = source.dependencies.detect { |d| d.name == "io.netty:netty-all" }
-          assert dep
-          assert_equal "gradle", dep.record["type"]
-          assert_equal "4.1.33.Final", dep.version
-          # add assertion for dep.path being expected url
-        end
+    it "is true if build.gradle exists and gradle is available" do
+      Dir.chdir(fixtures) do
+        assert source.enabled?
       end
+    end
 
-      it "does not include test dependencies" do
-        Dir.chdir fixtures do
-          refute source.dependencies.detect { |d| d.name == "org.junit.jupiter:junit-jupiter" }
-        end
+    it "is false if build.gradle does not exist" do
+      Dir.chdir(Dir.tmpdir) do
+        refute source.enabled?
       end
     end
   end
 
-  describe Licensed::Sources::Gradle::Dependency do
-    let(:fixtures) { File.expand_path("../../fixtures/gradle", __FILE__) }
-    let(:config) { Licensed::Configuration.new }
-    let(:source) { Licensed::Sources::Gradle.new(config) }
-
-    it "returns the dependency license" do
+  describe "dependencies" do
+    it "includes declared dependencies" do
       Dir.chdir fixtures do
         dep = source.dependencies.detect { |d| d.name == "io.netty:netty-all" }
         assert dep
-        assert_equal "apache-2.0", dep.license.key
-        assert dep.record.licenses.any? { |r| r["text"] =~ /Apache License/ }
+        assert_equal "gradle", dep.record["type"]
+        assert_equal "4.1.33.Final", dep.version
       end
+    end
+
+    it "does not include test dependencies" do
+      Dir.chdir fixtures do
+        refute source.dependencies.detect { |d| d.name == "org.junit.jupiter:junit-jupiter" }
+      end
+    end
+  end
+end
+
+describe Licensed::Sources::Gradle::Dependency do
+  let(:fixtures) { File.expand_path("../../fixtures/gradle", __FILE__) }
+  let(:config) { Licensed::Configuration.new }
+  let(:source) { Licensed::Sources::Gradle.new(config) }
+
+  it "returns the dependency license" do
+    Dir.chdir fixtures do
+      dep = source.dependencies.detect { |d| d.name == "io.netty:netty-all" }
+      assert dep
+      assert_equal "apache-2.0", dep.license.key
+      assert dep.record.licenses.any? { |r| r["text"] =~ /Apache License/ }
     end
   end
 end

--- a/test/sources/gradle_test.rb
+++ b/test/sources/gradle_test.rb
@@ -52,6 +52,16 @@ describe Licensed::Sources::Gradle do
         refute source.dependencies.detect { |d| d.name == "org.junit.jupiter:junit-jupiter" }
       end
     end
+
+    it "cleans up grade licenses csv content" do
+      Dir.chdir fixtures do
+        dep = source.dependencies.detect { |d| d.name == "io.netty:netty-all" }
+        # load the dependency record which creates temp license-*.gradle files
+        dep.record
+
+        refute Dir.glob(Pathname.pwd.join("license-*.gradle").to_path).any?
+      end
+    end
   end
 end
 
@@ -69,6 +79,16 @@ describe Licensed::Sources::Gradle::Dependency do
       license = dep.record.licenses.find { |l| l["text"] =~ /Apache License/ }
       assert license
       assert_equal "https://www.apache.org/licenses/LICENSE-2.0", license["sources"]
+    end
+  end
+
+  it "cleans up grade licenses csv content" do
+    Dir.chdir fixtures do
+      dep = source.dependencies.detect { |d| d.name == "io.netty:netty-all" }
+      # load the dependency record, pulling license files
+      dep.record
+
+      refute Pathname.pwd.join(Licensed::Sources::Gradle::GRADLE_LICENSES_PATH).exist?
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require "bundler/setup"
 require "minitest/autorun"
+require "mocha/minitest"
 require "byebug"
 require "licensed"
 require "English"


### PR DESCRIPTION
:wave: @dbussink here's what I had in mind about loading dependency license contents using a subclass.  I don't have gradle locally so haven't yet run any tests to see if this actually works, but it hopefully is enough to demonstrate the idea.