### PR TITLE
Load license key from bundler specification `loaded_from` as fallback

### DIFF
--- a/test/fixtures/bundler/Gemfile
+++ b/test/fixtures/bundler/Gemfile
@@ -28,3 +28,6 @@ gem "pathed-gem-fixture", path: "pathed-gem-fixture"
 # verify https://github.com/github/licensed/issues/71
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 gem "mini_racer"
+
+# verify https://github.com/github/licensed/issues/153
+gem "aws-sdk-core", "3.39.0"

--- a/test/sources/bundler_test.rb
+++ b/test/sources/bundler_test.rb
@@ -213,7 +213,7 @@ if Licensed::Shell.tool_available?("bundle")
           dep = source.dependencies.find { |d| d.name == "aws-sdk-core" }
           assert dep
           assert_equal "3.39.0", dep.version
-          refute_equal "none", dep.license_key
+          assert_equal "apache-2.0", dep.license_key
         end
       end
     end

--- a/test/sources/bundler_test.rb
+++ b/test/sources/bundler_test.rb
@@ -207,6 +207,15 @@ if Licensed::Shell.tool_available?("bundle")
           end
         end
       end
+
+      it "finds license metadata when gems are shipped without a gemspec" do
+        Dir.chdir(fixtures) do
+          dep = source.dependencies.find { |d| d.name == "aws-sdk-core" }
+          assert dep
+          assert_equal "3.39.0", dep.version
+          refute_equal "none", dep.license_key
+        end
+      end
     end
 
     describe "bundler_exe" do


### PR DESCRIPTION
Closes https://github.com/github/licensed/issues/153

This PR defines a subclass to the base `Licensed::Dependency` for bundler sources that accepts an additional `loaded_from` argument.  The `loaded_from` argument is given by the bundler specification object and used to create a `PackageManagerFile` if the base `Licensee::Projects::FsProject` implementation doesn't find one from the already available files at `spec.gem_dir`