### PR TITLE
Cleanup some test code

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -44,11 +44,7 @@ namespace :test do
       t.description = "Run #{source} tests"
       t.libs << "test"
       t.libs << "lib"
-
-      # use negative lookahead to exclude all source tests except
-      # the tests for `source`
-      t.test_files = FileList["test/**/*_test.rb"].exclude(/test\/sources\/(?!#{source}).*?_test.rb/,
-                                                           "test/fixtures/**/*_test.rb")
+      t.test_files = FileList["test/commands/*_test.rb", "test/sources/#{source}_test.rb"]
     end
   end
 end

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -16,8 +16,12 @@ describe "licensed" do
     end
 
     it "exits 1 when a config file isn't found" do
-      _, _, status = Open3.capture3 "bundle exec exe/licensed cache"
-      refute status.success?
+      Dir.mktmpdir do |dir|
+        Dir.chdir dir do
+          _, _, status = Open3.capture3 "bundle exec exe/licensed cache"
+          refute status.success?
+        end
+      end
     end
 
     it "accepts a path to a config file" do
@@ -36,8 +40,12 @@ describe "licensed" do
     end
 
     it "exits 1 when a config file isn't found" do
-      _, _, status = Open3.capture3 "bundle exec exe/licensed status"
-      refute status.success?
+      Dir.mktmpdir do |dir|
+        Dir.chdir dir do
+          _, _, status = Open3.capture3 "bundle exec exe/licensed status"
+          refute status.success?
+        end
+      end
     end
 
     it "accepts a path to a config file" do
@@ -56,8 +64,12 @@ describe "licensed" do
     end
 
     it "exits 1 when a config file isn't found" do
-      _, _, status = Open3.capture3 "bundle exec exe/licensed list"
-      refute status.success?
+      Dir.mktmpdir do |dir|
+        Dir.chdir dir do
+          _, _, status = Open3.capture3 "bundle exec exe/licensed list"
+          refute status.success?
+        end
+      end
     end
 
     it "accepts a path to a config file" do

--- a/test/commands/cache_test.rb
+++ b/test/commands/cache_test.rb
@@ -2,8 +2,9 @@
 require "test_helper"
 
 describe Licensed::Commands::Cache do
+  let(:cache_path) { Dir.mktmpdir }
   let(:reporter) { TestReporter.new }
-  let(:config) { Licensed::Configuration.new }
+  let(:config) { Licensed::Configuration.new("cache_path" => cache_path) }
   let(:source) { TestSource.new(config) }
   let(:generator) { Licensed::Commands::Cache.new(config: config, reporter: reporter) }
   let(:fixtures) { File.expand_path("../../fixtures", __FILE__) }
@@ -181,7 +182,7 @@ describe Licensed::Commands::Cache do
   end
 
   describe "with app.source_path" do
-    let(:config) { Licensed::Configuration.new("source_path" => fixtures) }
+    let(:config) { Licensed::Configuration.new("source_path" => fixtures, "cache_path" => cache_path) }
 
     it "changes the current directory to app.source_path while running" do
       generator.run
@@ -190,7 +191,7 @@ describe Licensed::Commands::Cache do
   end
 
   describe "with explicit dependency file path" do
-    let(:source) { TestSource.new(config, "dependency/path", "name" => "dependency") }
+    let(:source) { TestSource.new(config, "dependency/path", "name" => "dependency", "cache_path" => cache_path) }
 
     it "caches metadata at the given file path" do
       generator.run

--- a/test/commands/status_test.rb
+++ b/test/commands/status_test.rb
@@ -2,8 +2,9 @@
 require "test_helper"
 
 describe Licensed::Commands::Status do
+  let(:cache_path) { Dir.mktmpdir }
   let(:reporter) { TestReporter.new }
-  let(:config) { Licensed::Configuration.new }
+  let(:config) { Licensed::Configuration.new("cache_path" => cache_path) }
   let(:source) { TestSource.new(config) }
   let(:verifier) { Licensed::Commands::Status.new(config: config, reporter: reporter) }
 
@@ -152,7 +153,7 @@ describe Licensed::Commands::Status do
 
   describe "with app.source_path" do
     let(:fixtures) { File.expand_path("../../fixtures/npm", __FILE__) }
-    let(:config) { Licensed::Configuration.new("source_path" => fixtures) }
+    let(:config) { Licensed::Configuration.new("source_path" => fixtures, "cache_path" => cache_path) }
 
     it "changes the current directory to app.source_path while running" do
       verifier.run
@@ -161,7 +162,7 @@ describe Licensed::Commands::Status do
   end
 
   describe "with explicit dependency file path" do
-    let(:source) { TestSource.new(config, "dependency/path", "name" => "dependency") }
+    let(:source) { TestSource.new(config, "dependency/path", "name" => "dependency", "cache_path" => cache_path) }
 
     it "verifies content at explicit path" do
       filename = config.cache_path.join("test/dependency/path.#{Licensed::DependencyRecord::EXTENSION}")

--- a/test/fixtures/command/bower.yml
+++ b/test/fixtures/command/bower.yml
@@ -1,2 +1,3 @@
 expected_dependency: jquery
 source_path: test/fixtures/bower
+cache_path: test/fixtures/bower/.licenses

--- a/test/fixtures/command/bundler.yml
+++ b/test/fixtures/command/bundler.yml
@@ -1,2 +1,3 @@
 expected_dependency: semantic
 source_path: test/fixtures/bundler
+cache_path: test/fixtures/bundler/.licenses

--- a/test/fixtures/command/cabal.yml
+++ b/test/fixtures/command/cabal.yml
@@ -1,5 +1,6 @@
 expected_dependency: zlib
 source_path: test/fixtures/cabal
+cache_path: test/fixtures/cabal/.licenses
 cabal:
   ghc_package_db:
     - global

--- a/test/fixtures/command/dep.yml
+++ b/test/fixtures/command/dep.yml
@@ -1,4 +1,5 @@
 expected_dependency: github.com/gorilla/context
 source_path: test/fixtures/go/src/test
+cache_path: test/fixtures/go/.licenses
 dep:
   allow_ignored: true

--- a/test/fixtures/command/git_submodule.yml
+++ b/test/fixtures/command/git_submodule.yml
@@ -1,2 +1,3 @@
 expected_dependency: submodule
 source_path: test/fixtures/git_submodule/project
+cache_path: test/fixtures/git_submodule/.licenses

--- a/test/fixtures/command/go.yml
+++ b/test/fixtures/command/go.yml
@@ -1,4 +1,5 @@
 expected_dependency: github.com/gorilla/context
+cache_path: test/fixtures/go/.licenses
 go:
   GOPATH: test/fixtures/go
 

--- a/test/fixtures/command/manifest.yml
+++ b/test/fixtures/command/manifest.yml
@@ -1,4 +1,5 @@
 expected_dependency: manifest_test
 source_path: test/fixtures/manifest
+cache_path: test/fixtures/manifest/.licenses
 manifest:
   path: test/fixtures/manifest/manifest.yml

--- a/test/fixtures/command/npm.yml
+++ b/test/fixtures/command/npm.yml
@@ -1,2 +1,3 @@
 expected_dependency: autoprefixer
 source_path: test/fixtures/npm
+cache_path: test/fixtures/npm/.licenses

--- a/test/fixtures/command/pip.yml
+++ b/test/fixtures/command/pip.yml
@@ -1,4 +1,5 @@
 expected_dependency: Jinja2
 source_path: test/fixtures/pip
+cache_path: test/fixtures/pip/.licenses
 python:
   virtual_env_dir: test/fixtures/pip/venv


### PR DESCRIPTION
This PR cleans up test code a little bit by

- reducing the scope of tests run from `script test <source>` or `bundle exec rake test:<source>`
- moving away from using the repository root's `.licenses` folder as a cache path in tests that exercise caching logic
   - this might make it easier to cache and verify licensed's own dependency metadata in the future