### PR TITLE
Relax thor dependency

### DIFF
--- a/licensed.gemspec
+++ b/licensed.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.3.0"
 
   spec.add_dependency "licensee", "~> 9.10"
-  spec.add_dependency "thor", "~> 0.19"
+  spec.add_dependency "thor", "~> 0.19", "< 2.0"
   spec.add_dependency "pathname-common_prefix", "~> 0.0.1"
   spec.add_dependency "tomlrb", "~> 1.2"
   spec.add_dependency "bundler", ">= 1.10"


### PR DESCRIPTION
I used < 2.0 because that's what Rails uses. Happy to make the high end more strict as long as we can support 0.20+. Thanks!

---

Rails 6.0 Railties requires thor set to
`s.add_dependency "thor", ">= 0.20.3", "< 2.0"` and currently licensed
won't allow anything higher than 0.19.x. See
https://github.com/rails/rails/blob/master/railties/railties.gemspec#L40

This PR relaxes the thor dependency so that licensed can be used with
applications running or upgrading to Rails 6+.

cc/ @jonabc 