### PR TITLE
pin rubocop to 0.66

### DIFF
--- a/licensed.gemspec
+++ b/licensed.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.8"
   spec.add_development_dependency "mocha", "~> 1.0"
-  spec.add_development_dependency "rubocop", "~> 0.49"
+  spec.add_development_dependency "rubocop", "~> 0.49", "< 0.67"
   spec.add_development_dependency "rubocop-github", "~> 0.6"
   spec.add_development_dependency "byebug", "~> 10.0.0"
 end


### PR DESCRIPTION
rubocop-github hasn't yet updated for https://github.com/rubocop-hq/rubocop/issues/6637 which is breaking CI https://travis-ci.org/github/licensed/jobs/515777310#L568.  Pinning the rubocop version to something that works until rubocop-github is updated.