### PR TITLE
Do not try to package "build" platform

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -57,6 +57,7 @@ end
 
 packages_search = File.expand_path("script/packages/*", __dir__)
 platforms = Dir[packages_search].map { |f| File.basename(f, ".*") }
+                                .reject { |f| f == "build" }
 
 namespace :package do
   platforms.each do |platform|


### PR DESCRIPTION
In https://github.com/github/licensed/pull/160 I moved the `build-rubyc-exe` script into the `script/packages` folder and missed updating the rake packaging tasks to not see this as a valid build platform.

This doesn't break any package builds, but can be confusing when viewing output from `script/package` or `bundle exec rake package`