### PR TITLE
Release v 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## 2.2.0 - 2019-05-11
+
+### Added
+- Content hash versioning strategy for go and manifest sources (https://github.com/github/licensed/pull/164)
+
+### Fixed
+- Python source handles urls and package names with "-" in requirements.txt (:tada: @krzysztof-pawlik-gat https://github.com/github/licensed/pull/165)
+
 ## 2.1.0 - 2019-04-16
 
 ### Added
@@ -154,4 +162,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Initial release :tada:
 
-[Unreleased]: https://github.com/github/licensed/compare/2.0.1...HEAD
+[Unreleased]: https://github.com/github/licensed/compare/2.2.0...HEAD

--- a/lib/licensed/version.rb
+++ b/lib/licensed/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Licensed
-  VERSION = "2.1.0".freeze
+  VERSION = "2.2.0".freeze
 
   def self.previous_major_versions
     major_version = Gem::Version.new(Licensed::VERSION).segments.first


### PR DESCRIPTION
## 2.2.0 - 2019-05-11

### Added
- Content hash versioning strategy for go and manifest sources (https://github.com/github/licensed/pull/164)

### Fixed
- Python source handles urls and package names with "-" in requirements.txt (:tada: @krzysztof-pawlik-gat https://github.com/github/licensed/pull/165)