### PR TITLE
Pipenv source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ test/fixtures/cabal/*
 test/fixtures/git_submodule/*
 !test/fixtures/git_submodule/README
 test/fixtures/pip/venv
+test/fixtures/pipenv/Pipfile.lock
 !test/fixtures/migrations/**/*
 
 vendor/licenses

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,6 +79,15 @@ matrix:
       script: ./script/test pip
       env: NAME="pip"
 
+    - language: python
+      python:
+        - "2.7"
+      before_script:
+        - pip install pipenv
+        - ./script/source-setup/pipenv
+      script: ./script/test pipenv
+      env: NAME="pipenv"
+
     # python 3.6 tests
     - language: python
       python:
@@ -86,6 +95,15 @@ matrix:
       before_script: ./script/source-setup/pip
       script: ./script/test pip
       env: NAME="pip"
+
+    - language: python
+      python:
+        - "3.6"
+      before_script:
+        - pip install pipenv
+        - ./script/source-setup/pipenv
+      script: ./script/test pipenv
+      env: NAME="pipenv"
 
     - language: ruby
       rvm: 2.4.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,16 +73,14 @@ matrix:
 
     # python 2.7 tests
     - language: python
-      python:
-        - "2.7"
+      python: 2.7
       before_script: ./script/source-setup/pip
       script: ./script/test pip
       env: NAME="pip"
 
     # python 3.6 tests
     - language: python
-      python:
-        - "3.6"
+      python: 3.6
       before_script: ./script/source-setup/pip
       script: ./script/test pip
       env: NAME="pip"

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,15 +79,6 @@ matrix:
       script: ./script/test pip
       env: NAME="pip"
 
-    - language: python
-      python:
-        - "2.7"
-      before_script:
-        - pip install pipenv
-        - ./script/source-setup/pipenv
-      script: ./script/test pipenv
-      env: NAME="pipenv"
-
     # python 3.6 tests
     - language: python
       python:
@@ -97,8 +88,7 @@ matrix:
       env: NAME="pip"
 
     - language: python
-      python:
-        - "3.6"
+      python: 3.6
       before_script:
         - pip install pipenv
         - ./script/source-setup/pipenv

--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ Dependencies will be automatically detected for all of the following sources by 
 6. [Manifest lists (manifests)](./docs/sources/manifests.md)
 7. [NPM (npm)](./docs/sources/npm.md)
 8. [Pip (pip)](./docs/sources/pip.md)
-9. [Git Submodules (git_submodule)](./docs/sources/git_submodule.md)
+9. [Pipenv (pipenv)](./docs/sources/pipenv.md)
+10. [Git Submodules (git_submodule)](./docs/sources/git_submodule.md)
 
 You can disable any of them in the configuration file:
 

--- a/docs/sources/pipenv.md
+++ b/docs/sources/pipenv.md
@@ -1,0 +1,5 @@
+# Pipenv
+
+The pipenv source uses `pipenv` CLI command to enumerate dependencies and properties.
+
+Be sure to run `pipenv update` (or `pipenv sync`) before running `licensed` so all required packages are properly installed.

--- a/lib/licensed/dependency.rb
+++ b/lib/licensed/dependency.rb
@@ -83,11 +83,15 @@ module Licensed
          .grep(LEGAL_FILES_PATTERN)
          .select { |path| File.file?(path) }
          .sort # sorted by the path
-         .map { |path| { "sources" => normalize_source_path(path), "text" => File.read(path).rstrip } }
+         .map { |path| { "sources" => normalize_source_path(path), "text" => read_file_with_encoding_check(path) } }
          .select { |notice| notice["text"].length > 0 } # files with content only
     end
 
     private
+
+    def read_file_with_encoding_check(file_path)
+      File.read(file_path).encode("UTF-16", invalid: :replace, replace: "?").encode("UTF-8").rstrip
+    end
 
     # Returns the sources for a group of license file contents
     #

--- a/lib/licensed/sources.rb
+++ b/lib/licensed/sources.rb
@@ -11,6 +11,7 @@ module Licensed
     require "licensed/sources/manifest"
     require "licensed/sources/npm"
     require "licensed/sources/pip"
+    require "licensed/sources/pipenv"
     require "licensed/sources/gradle"
   end
 end

--- a/lib/licensed/sources/pipenv.rb
+++ b/lib/licensed/sources/pipenv.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Licensed
+  module Sources
+    class Pipenv < Source
+      def enabled?
+        Licensed::Shell.tool_available?("pipenv") && File.exist?(@config.pwd.join("Pipfile.lock"))
+      end
+
+      def enumerate_dependencies
+        pakages_from_pipfile_lock.map do |package_name|
+          package = package_info(package_name)
+          location = File.join(package["Location"], package["Name"].gsub("-", "_") +  "-" + package["Version"] + ".dist-info")
+          Dependency.new(
+            name: package["Name"],
+            version: package["Version"],
+            path: location,
+            metadata: {
+              "type"        => Pipenv.type,
+              "summary"     => package["Summary"],
+              "homepage"    => package["Home-page"]
+            }
+          )
+        end
+      end
+
+      private
+
+      def pakages_from_pipfile_lock
+        Licensed::Shell.execute("pipenv", "run", "pip", "list")
+            .lines
+            .drop(2)  # Header
+            .map { |line| line.strip.split.first.strip }
+      end
+
+      def package_info(package_name)
+        p_info = Licensed::Shell.execute("pipenv", "run", "pip", "--disable-pip-version-check", "show", package_name).lines
+        p_info.each_with_object(Hash.new(0)) { |pkg, a|
+          k, v = pkg.split(":", 2)
+          next if k.nil? || k.empty?
+          a[k.strip] = v&.strip
+        }
+      end
+    end
+  end
+end

--- a/script/source-setup/pipenv
+++ b/script/source-setup/pipenv
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+if [ -z "$(which pipenv)" ]; then
+  echo "A local pipenv installation is required for python development." >&2
+  exit 127
+fi
+
+
+# setup test fixtures
+BASE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd $BASE_PATH/test/fixtures/pipenv
+
+# clean up any previous fixture venv that might have been created.
+if [ "$1" == "-f" ]; then
+    echo "removing old fixture setup..."
+    pipenv --rm || true
+fi
+
+# set up a virtualenv and install the packages in the test requirements
+pipenv update

--- a/test/dependency_test.rb
+++ b/test/dependency_test.rb
@@ -227,6 +227,21 @@ describe Licensed::Dependency do
                         { "sources" => "LEGAL", "text" => "legal" }
       end
     end
+
+    it "handles invlaid encodings in legal notices" do
+      mkproject do |dependency|
+        File.write "AUTHORS", [0x20, 0x42, 0x3f, 0x63, 0x6b].pack("ccccc")
+        File.write "NOTICE", "notice"
+        File.write "LEGAL", "legal"
+
+        assert_includes dependency.notice_contents,
+                        { "sources" => "AUTHORS", "text" => " B?ck" }
+        assert_includes dependency.notice_contents,
+                        { "sources" => "NOTICE", "text" => "notice" }
+        assert_includes dependency.notice_contents,
+                        { "sources" => "LEGAL", "text" => "legal" }
+      end
+    end
   end
 
   describe "error?" do

--- a/test/fixtures/pipenv/Pipfile
+++ b/test/fixtures/pipenv/Pipfile
@@ -1,0 +1,11 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+beautifulsoup4 = "==4.7.1"
+dataclasses = {version = "==0.6",markers = "python_version < '3.7.0'"}
+pylint = "==2.3.1"

--- a/test/sources/pipenv_test.rb
+++ b/test/sources/pipenv_test.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+require "test_helper"
+require "tmpdir"
+
+if Licensed::Shell.tool_available?("pipenv")
+  describe Licensed::Sources::Pipenv do
+    let (:fixtures) { File.expand_path("../../fixtures/pipenv", __FILE__) }
+    let (:config)   { Licensed::Configuration.new }
+    let (:source)   { Licensed::Sources::Pipenv.new(config) }
+
+    describe "enabled?" do
+      it "is true if pipenv source is available" do
+        Dir.chdir(fixtures) do
+          assert source.enabled?
+        end
+      end
+
+      it "is false if pipenv source is not available" do
+        Dir.mktmpdir do |dir|
+          Dir.chdir(dir) do
+            refute source.enabled?
+          end
+        end
+      end
+    end
+
+    describe "dependencies" do
+      it "detects top-level dependencies" do
+        Dir.chdir fixtures do
+          dep = source.dependencies.detect { |d| d.name == "pylint" }
+          assert dep
+          assert_equal "pipenv", dep.record["type"]
+          assert dep.record["homepage"]
+          assert dep.record["summary"]
+        end
+      end
+
+      it "detects nested dependencies" do
+        Dir.chdir fixtures do
+          dep = source.dependencies.detect { |d| d.name == "isort" }
+          assert dep
+          assert_equal "pipenv", dep.record["type"]
+          assert dep.record["homepage"]
+          assert dep.record["summary"]
+        end
+      end
+
+      it "detects dependencies with hyphens in package name" do
+        Dir.chdir fixtures do
+          dep = source.dependencies.detect { |d| d.name == "lazy-object-proxy" }
+          assert dep
+          assert_equal "pipenv", dep.record["type"]
+          assert dep.record["homepage"]
+          assert dep.record["summary"]
+        end
+      end
+    end
+  end
+end

--- a/test/sources/pipenv_test.rb
+++ b/test/sources/pipenv_test.rb
@@ -30,6 +30,7 @@ if Licensed::Shell.tool_available?("pipenv")
           dep = source.dependencies.detect { |d| d.name == "pylint" }
           assert dep
           assert_equal "pipenv", dep.record["type"]
+          assert_equal "2.3.1", dep.version
           assert dep.record["homepage"]
           assert dep.record["summary"]
         end
@@ -40,6 +41,7 @@ if Licensed::Shell.tool_available?("pipenv")
           dep = source.dependencies.detect { |d| d.name == "isort" }
           assert dep
           assert_equal "pipenv", dep.record["type"]
+          assert /^4\..*$/.match dep.version
           assert dep.record["homepage"]
           assert dep.record["summary"]
         end
@@ -50,6 +52,7 @@ if Licensed::Shell.tool_available?("pipenv")
           dep = source.dependencies.detect { |d| d.name == "lazy-object-proxy" }
           assert dep
           assert_equal "pipenv", dep.record["type"]
+          assert dep.version
           assert dep.record["homepage"]
           assert dep.record["summary"]
         end


### PR DESCRIPTION
Adding a simple source for `pipenv` -- nice wrapper around `virtualenv` and good, old `pip`.

This merge request contains one non-pipenv related change: a fix for reading & storing notice files that are not UTF-8 encoded.

This will solve issue #117.