### PR TITLE
Bundler updates

### DIFF
--- a/lib/licensed/sources/bundler.rb
+++ b/lib/licensed/sources/bundler.rb
@@ -212,8 +212,9 @@ module Licensed
             yaml = Licensed::Shell.execute(*ruby_command_args("gem", "specification", name))
             spec = Gem::Specification.from_yaml(yaml)
             # this is horrible, but it will cache the gem_dir using the clean env
-            # so that it can be used outside of this block
-            spec.gem_dir
+            # so that it can be used outside of this block when running from
+            # the ruby packer executable environment
+            spec.gem_dir if ruby_packer?
             spec
           end
         rescue Licensed::Shell::Error

--- a/lib/licensed/sources/bundler.rb
+++ b/lib/licensed/sources/bundler.rb
@@ -151,7 +151,7 @@ module Licensed
         spec = definition.resolve.find { |s| s.satisfies?(dependency) }
 
         # a nil spec should be rare, generally only seen from bundler
-        return matching_spec(dependency) || bundle_exec_gem_spec(dependency.name) if spec.nil?
+        return matching_spec(dependency) || bundle_exec_gem_spec(dependency.name, dependency.requirement) if spec.nil?
 
         # try to find a non-lazy specification that matches `spec`
         # spec.source.specs gives access to specifications with more
@@ -166,7 +166,7 @@ module Licensed
 
         # if the specification file doesn't exist, get the specification using
         # the bundler and gem CLI
-        bundle_exec_gem_spec(dependency.name)
+        bundle_exec_gem_spec(dependency.name, dependency.requirement)
       end
 
       # Returns whether a dependency should be included in the final
@@ -200,7 +200,7 @@ module Licensed
 
       # Load a gem specification from the YAML returned from `gem specification`
       # This is a last resort when licensed can't obtain a specification from other means
-      def bundle_exec_gem_spec(name)
+      def bundle_exec_gem_spec(name, requirement)
         # `gem` must be available to run `gem specification`
         return unless Licensed::Shell.tool_available?("gem")
 
@@ -209,7 +209,7 @@ module Licensed
         begin
           ::Bundler.with_original_env do
             ::Bundler.rubygems.clear_paths
-            yaml = Licensed::Shell.execute(*ruby_command_args("gem", "specification", name))
+            yaml = Licensed::Shell.execute(*ruby_command_args("gem", "specification", name, "-v", requirement.to_s))
             spec = Gem::Specification.from_yaml(yaml)
             # this is horrible, but it will cache the gem_dir using the clean env
             # so that it can be used outside of this block when running from

--- a/test/sources/bundler_test.rb
+++ b/test/sources/bundler_test.rb
@@ -251,19 +251,22 @@ if Licensed::Shell.tool_available?("bundle")
     describe "bundle_exec_gem_spec" do
       it "gets a gem specification for a version" do
         Dir.chdir(fixtures) do
-          assert source.bundle_exec_gem_spec("semantic", "1.6.0")
+          version = source.dependencies.find { |d| d.name == "bundler" }.version
+          assert source.bundle_exec_gem_spec("bundler", version)
         end
       end
 
       it "gets a gem specification for a requirement" do
         Dir.chdir(fixtures) do
-          assert source.bundle_exec_gem_spec("semantic", Gem::Requirement.new("> 1.5.0", "< 2.0"))
+          version = source.dependencies.find { |d| d.name == "bundler" }.version
+          assert source.bundle_exec_gem_spec("bundler", Gem::Requirement.new(">= #{version}"))
         end
       end
 
       it "returns nil if a gem specification isn't found" do
         Dir.chdir(fixtures) do
-          refute source.bundle_exec_gem_spec("semantic", "2.0")
+          version = source.dependencies.find { |d| d.name == "bundler" }.version
+          refute source.bundle_exec_gem_spec("bundler", version.to_f - 1)
         end
       end
     end

--- a/test/sources/bundler_test.rb
+++ b/test/sources/bundler_test.rb
@@ -247,5 +247,25 @@ if Licensed::Shell.tool_available?("bundle")
         end
       end
     end
+
+    describe "bundle_exec_gem_spec" do
+      it "gets a gem specification for a version" do
+        Dir.chdir(fixtures) do
+          assert source.bundle_exec_gem_spec("semantic", "1.6.0")
+        end
+      end
+
+      it "gets a gem specification for a requirement" do
+        Dir.chdir(fixtures) do
+          assert source.bundle_exec_gem_spec("semantic", Gem::Requirement.new("> 1.5.0", "< 2.0"))
+        end
+      end
+
+      it "returns nil if a gem specification isn't found" do
+        Dir.chdir(fixtures) do
+          refute source.bundle_exec_gem_spec("semantic", "2.0")
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Closes https://github.com/github/licensed/issues/172

1. Adds version requirement specification to the `gem specification` call in `Bundler#bundle_exec_gem_spec` to prevent finding an invalid gem specification
2. In `Bundler#bundle_exec_gem_spec`, a found specification's gem directory is only cached when running in a `ruby_packer?` context