### PR TITLE
Handle bundler array settings for various versions

### DIFF
--- a/lib/licensed/sources/bundler.rb
+++ b/lib/licensed/sources/bundler.rb
@@ -247,7 +247,16 @@ module Licensed
       # Returns the bundle definition groups, removing "without" groups,
       # and including "with" groups
       def groups
-        definition.groups - Array(::Bundler.settings[:without]) + Array(::Bundler.settings[:with]) - exclude_groups
+        @groups ||= definition.groups - bundler_setting_array(:without) + bundler_setting_array(:with) - exclude_groups
+      end
+
+      # Returns a bundler setting as an array.
+      # Depending on the version of bundler, array values are either returned as
+      # a raw string ("a:b:c") or as an array ([:a, :b, :c])
+      def bundler_setting_array(key)
+        setting = ::Bundler.settings[key]
+        setting = setting.split(":").map(&:to_sym) if setting.is_a?(String)
+        Array(setting)
       end
 
       # Returns any groups to exclude specified from both licensed configuration


### PR DESCRIPTION
In running tests on various versions of bundler, I found that the existing implementation didn't work with Bundler `~> 1.15.0`.  Some debugging and it looks like at least in 1.15.4, `::Bundler.settings[:without]` is returned as a string `"a:b:c"` while in later versions it's returned as `[:a, :b, :c]`.

This change adds in a helper method to get `without` and `with` settings working.