### PR TITLE
Add tests for non-source files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,12 @@ matrix:
       script: bundle exec rake rubocop build
       env: NAME="Lint and Build"
 
+    # non-source tests
+    - language: ruby
+      rvm: 2.4.0
+      script: ./script/test core
+      env: NAME="Core"
+
     # go 1.7 tests
     - language: go
       go: "1.7.x"

--- a/Rakefile
+++ b/Rakefile
@@ -47,6 +47,20 @@ namespace :test do
       t.test_files = FileList["test/commands/*_test.rb", "test/sources/#{source}_test.rb"]
     end
   end
+
+  namespace :core do
+    task :env do
+      ENV["SOURCE"] = ""
+    end
+  end
+
+  Rake::TestTask.new(:core => "test:core:env") do |t|
+    t.description = "Run non-source tests"
+    t.libs << "test"
+    t.libs << "lib"
+    t.test_files = FileList["test/**/*_test.rb"].exclude("test/fixtures/**/*_test.rb")
+                                                .exclude("test/sources/*_test.rb")
+  end
 end
 
 Rake::TestTask.new(:test) do |t|

--- a/Rakefile
+++ b/Rakefile
@@ -54,7 +54,7 @@ namespace :test do
     end
   end
 
-  Rake::TestTask.new(:core => "test:core:env") do |t|
+  Rake::TestTask.new(core: "test:core:env") do |t|
     t.description = "Run non-source tests"
     t.libs << "test"
     t.libs << "lib"

--- a/test/sources/helpers/content_versioning_test.rb
+++ b/test/sources/helpers/content_versioning_test.rb
@@ -59,8 +59,17 @@ describe Licensed::Sources::ContentVersioning do
     end
 
     it "handles files not tracked by git" do
-      Dir.chdir File.expand_path("../../../bin", fixtures) do
-        assert_nil helper.git_version(Dir["*"])
+      dir = File.expand_path("../../../bin", fixtures)
+      tmp = File.join(dir, "tmp")
+
+      begin
+        Dir.mkdir dir unless File.exist?(dir)
+        FileUtils.touch tmp
+        Dir.chdir dir do
+          assert_nil helper.git_version(Dir["*"])
+        end
+      ensure
+        File.unlink(tmp) if tmp && File.exist?(tmp)
       end
     end
 


### PR DESCRIPTION
Adding a rake task and CI check for all of the non-`Licensed::Sources` files in the project