### PR TITLE
Fixes for tests to get them compatible with actions

### DIFF
--- a/lib/licensed/sources/cabal.rb
+++ b/lib/licensed/sources/cabal.rb
@@ -131,8 +131,7 @@ module Licensed
       # Returns an array of ghc package DB locations as specified in the app
       # configuration
       def package_db_args
-        return [] unless @config["cabal"]
-        Array(@config["cabal"]["ghc_package_db"]).map do |path|
+        @package_db_args ||= Array(@config.dig("cabal", "ghc_package_db")).map do |path|
           next "--#{path}" if %w(global user).include?(path)
           path = realized_ghc_package_path(path)
           path = File.expand_path(path, @config.root)

--- a/script/source-setup/cabal
+++ b/script/source-setup/cabal
@@ -14,4 +14,5 @@ if [ "$1" == "-f" ]; then
   find . -not -regex "\.*" -and -not -path "*app*" -print0 | xargs -0 rm -rf
 fi
 
+cabal update
 cabal new-build

--- a/test/fixtures/pip/requirements.txt
+++ b/test/fixtures/pip/requirements.txt
@@ -1,6 +1,6 @@
 # This comment should be ignored
 --index-url https://pypi.org/simple
-pandas
+scapy
 Jinja2==2.9.6
 requests>=2.21.0
 tqdm<=4.30.0

--- a/test/sources/cabal_test.rb
+++ b/test/sources/cabal_test.rb
@@ -67,8 +67,8 @@ if Licensed::Shell.tool_available?("ghc")
       end
 
       it "sets an error if a dependency isn't found" do
-        # run test without any ghc package db configuration to avoid finding
-        # dependencies
+        # include only the user database, avoiding using the global cache
+        config["cabal"] = { "ghc_package_db" => ["user"] }
         Dir.chdir(fixtures) do
           dep = source.dependencies.detect { |d| d.name == "zlib" }
           assert dep

--- a/test/sources/pip_test.rb
+++ b/test/sources/pip_test.rb
@@ -27,7 +27,7 @@ if Licensed::Shell.tool_available?("pip")
     describe "dependencies" do
       it "detects dependencies without a version constraint" do
         Dir.chdir fixtures do
-          dep = source.dependencies.detect { |d| d.name == "pandas" }
+          dep = source.dependencies.detect { |d| d.name == "scapy" }
           assert dep
           assert_equal "pip", dep.record["type"]
           assert dep.record["homepage"]


### PR DESCRIPTION
When moving CI checks over to Actions, I found a few tests that were failing due to differences from tool chains available on travis.

- `cabal update` needs to be called when setting up that source
- `pandas` and `setuptools` aren't playing nicely when setup with python 2.x
- cabal test needed to set a package db so that the default `--global` location wasn't used