### PR TITLE
Add composer source for PHP

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -208,3 +208,25 @@ jobs:
       run: script/source-setup/pipenv
     - name: Run tests
       run: script/test pipenv
+
+  composer:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php: [ '5.6', '7.1', '7.2', '7.3' ]
+    steps:
+    - uses: actions/checkout@master
+    - name: Setup php
+      uses: nanasess/setup-php@v1.0.2
+      with:
+        php-version: ${{ matrix.php }}
+    - name: Set up Ruby
+      uses: actions/setup-ruby@v1
+      with:
+        version: 2.6.x
+    - name: Bootstrap
+      run: script/bootstrap
+    - name: Set up fixtures
+      run: script/source-setup/composer
+    - name: Run tests
+      run: script/test composer

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ test/fixtures/git_submodule/*
 test/fixtures/pip/venv
 test/fixtures/pipenv/Pipfile.lock
 !test/fixtures/migrations/**/*
+test/fixtures/composer/**/*
+!test/fixtures/composer/composer.json
 
 vendor/licenses
 .licenses

--- a/README.md
+++ b/README.md
@@ -79,16 +79,17 @@ See the [configuration file documentation](./docs/configuration.md) for more det
 ### Sources
 
 Dependencies will be automatically detected for all of the following sources by default.
-1. [Bower (bower)](./docs/sources/bower.md)
-2. [Bundler](./docs/sources/bundler.md)
-3. [Cabal (cabal)](./docs/sources/cabal.md)
-4. [Go (go)](./docs/sources/go.md)
-5. [Go Dep (dep)](./docs/sources/dep.md)
-6. [Manifest lists (manifests)](./docs/sources/manifests.md)
-7. [NPM (npm)](./docs/sources/npm.md)
-8. [Pip (pip)](./docs/sources/pip.md)
-9. [Pipenv (pipenv)](./docs/sources/pipenv.md)
-10. [Git Submodules (git_submodule)](./docs/sources/git_submodule.md)
+1. [Bower](./docs/sources/bower.md)
+1. [Bundler](./docs/sources/bundler.md)
+1. [Cabal](./docs/sources/cabal.md)
+1. [Composer](./docs/sources/composer.md)
+1. [Go](./docs/sources/go.md)
+1. [Go Dep (dep)](./docs/sources/dep.md)
+1. [Manifest lists (manifests)](./docs/sources/manifests.md)
+1. [NPM](./docs/sources/npm.md)
+1. [Pip](./docs/sources/pip.md)
+1. [Pipenv](./docs/sources/pipenv.md)
+1. [Git Submodules (git_submodule)](./docs/sources/git_submodule.md)
 
 You can disable any of them in the configuration file:
 

--- a/docs/sources/composer.md
+++ b/docs/sources/composer.md
@@ -1,0 +1,14 @@
+# Composer
+
+The composer source will detect dependencies when php is available, a `composer.lock` file is found at an apps `source_path`, and a composer application file is found.
+
+It enumerates dependencies and metadata by parsing `composer.lock` files for for dependency metadata and running `php <composer application file> show --format json --path` to obtain local dependency paths on disk.
+
+### Composer application file
+
+The default composer application file location is `<repository root>/composer.phar`.  To specify a custom composer file location, use the `composer.application_path` configuration setting.
+
+```yml
+composer:
+  application_path: "/path/to/composer"
+```

--- a/lib/licensed/sources.rb
+++ b/lib/licensed/sources.rb
@@ -5,6 +5,7 @@ module Licensed
     require "licensed/sources/bower"
     require "licensed/sources/bundler"
     require "licensed/sources/cabal"
+    require "licensed/sources/composer"
     require "licensed/sources/dep"
     require "licensed/sources/git_submodule"
     require "licensed/sources/go"

--- a/lib/licensed/sources/composer.rb
+++ b/lib/licensed/sources/composer.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+require "json"
+
+module Licensed
+  module Sources
+    class Composer < Source
+      DEFAULT_COMPOSER_APPLICATON_PATH = "composer.phar"
+
+      def enabled?
+        return false unless Licensed::Shell.tool_available?("php")
+        File.exist?(composer_lock) && File.exist?(composer_application_path)
+      end
+
+      def enumerate_dependencies
+        packages.map do |package|
+          Dependency.new(
+            name: package["name"],
+            version: package["version"],
+            path: package_paths[package["name"]],
+            metadata: {
+              "type"     => Composer.type,
+              "name"     => package["name"],
+              "summary"  => package["description"],
+              "homepage" => package["homepage"]
+            }
+          )
+        end
+      end
+
+      def packages
+        JSON.parse(File.read(composer_lock))["packages"]
+      end
+
+      # Returns the output from running `php composer.phar` to get package metadata
+      def package_paths
+        return @package_paths if defined?(@package_paths)
+
+        @package_paths = begin
+          output = Licensed::Shell.execute("php", composer_application_path, "show", "--format", "json", "--path", allow_failure: true)
+          return {} if output.to_s.empty?
+
+          path_json = JSON.parse(output)
+          return {} unless path_json["installed"]
+
+          path_json["installed"].each_with_object({}) do |package, hsh|
+            hsh[package["name"]] = package["path"]
+          end
+        end
+      end
+
+      def composer_application_path
+        setting = @config.dig("composer", "application_path") || DEFAULT_COMPOSER_APPLICATON_PATH
+        File.expand_path(setting, @config.pwd)
+      end
+
+      def composer_lock
+        @config.pwd.join("composer.lock")
+      end
+    end
+  end
+end

--- a/script/source-setup/composer
+++ b/script/source-setup/composer
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -e
+
+if [ -z "$(which php)" ]; then
+  echo "A local php installation is required for php development." >&2
+  exit 127
+fi
+
+# setup test fixtures
+BASE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd $BASE_PATH/test/fixtures/composer
+
+if [ "$1" == "-f" ]; then
+  find . -not -regex "\.*" -and -not -name "composer\.json" -print0 | xargs -0 rm -rf
+fi
+
+if [ ! -f "composer.phar" ]; then
+  EXPECTED_SIGNATURE="$(curl -s https://composer.github.io/installer.sig)"
+  php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+  ACTUAL_SIGNATURE="$(php -r "echo hash_file('sha384', 'composer-setup.php');")"
+
+  if [ "$EXPECTED_SIGNATURE" != "$ACTUAL_SIGNATURE" ]; then
+    >&2 echo 'ERROR: Invalid installer signature'
+    rm composer-setup.php
+    exit 1
+  fi
+
+  php composer-setup.php
+  RESULT=$?
+  rm composer-setup.php
+
+  if [ $RESULT -ne 0 ]; then
+    >&2 echo 'ERROR: composer.phar installation failed'
+    exit $RESULT
+  fi
+fi
+
+php composer.phar install

--- a/test/fixtures/command/composer.yml
+++ b/test/fixtures/command/composer.yml
@@ -1,0 +1,3 @@
+expected_dependency: monolog/monolog
+source_path: test/fixtures/composer
+cache_path: test/fixtures/composer/.licenses

--- a/test/fixtures/composer/composer.json
+++ b/test/fixtures/composer/composer.json
@@ -1,0 +1,8 @@
+{
+  "require": {
+    "monolog/monolog": "1.24.0"
+  },
+  "require-dev": {
+    "phpunit/php-file-iterator": "1.4.5"
+  }
+}

--- a/test/sources/composer_test.rb
+++ b/test/sources/composer_test.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+require "test_helper"
+require "tmpdir"
+require "fileutils"
+
+if Licensed::Shell.tool_available?("php")
+  describe Licensed::Sources::Composer do
+    let(:config) { Licensed::Configuration.new }
+    let(:fixtures) { File.expand_path("../../fixtures/composer", __FILE__) }
+    let(:source) { Licensed::Sources::Composer.new(config) }
+
+    describe "enabled?" do
+      it "is false if composer.lock does not exists" do
+        Dir.mktmpdir do |dir|
+          Dir.chdir(dir) do
+            File.write "composer.phar", ""
+            refute source.enabled?
+          end
+        end
+      end
+
+      it "is false if composer.phar does not exists" do
+        Dir.mktmpdir do |dir|
+          Dir.chdir(dir) do
+            File.write "composer.lock", ""
+            refute source.enabled?
+          end
+        end
+      end
+
+      it "is true if composer.lock and composer.phar exist" do
+        Dir.mktmpdir do |dir|
+          Dir.chdir(dir) do
+            File.write "composer.lock", ""
+            File.write "composer.phar", ""
+            assert source.enabled?
+          end
+        end
+      end
+    end
+
+    describe "dependencies" do
+      it "includes declared dependencies" do
+        Dir.chdir fixtures do
+          dep = source.dependencies.detect { |d| d.name == "monolog/monolog" }
+          assert dep
+          assert_equal "composer", dep.record["type"]
+          assert_equal "1.24.0", dep.version
+          assert dep.record["homepage"]
+          assert dep.record["summary"]
+          assert dep.path
+        end
+      end
+
+      it "includes nested dependencies" do
+        Dir.chdir fixtures do
+          dep = source.dependencies.detect { |dep| dep.name == "psr/log" }
+          assert dep
+          assert_equal "composer", dep.record["type"]
+          assert_equal "1.1.0", dep.version
+          assert dep.record["homepage"]
+          assert dep.record["summary"]
+          assert dep.path
+        end
+      end
+
+      it "does not include dev dependencies" do
+        Dir.chdir fixtures do
+          refute source.dependencies.detect { |dep| dep.name == "phpunit/php-file-iterator" }
+        end
+      end
+    end
+
+    describe "composer_application_path" do
+      it "defaults to composer.phar" do
+        assert_equal config.pwd.join("composer.phar").to_s, source.composer_application_path
+      end
+
+      it "expands relative paths" do
+        config["composer"] = { "application_path" => "test/composer.phar" }
+        assert_equal config.pwd.join("test/composer.phar").to_s, source.composer_application_path
+      end
+
+      it "expands paths with symbols" do
+        config["composer"] = { "application_path" => "~/composer.phar" }
+        assert_equal File.join(Dir.home, "composer.phar"), source.composer_application_path
+      end
+
+      it "expands absolute paths" do
+        config["composer"] = { "application_path" => "/composer.phar" }
+        assert_equal "/composer.phar", source.composer_application_path
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes https://github.com/github/licensed/issues/152

Adds a new dependency source enumerator for composer to enumerate php package dependencies.

The primary source of information is the `composer.lock` file.  Since `licensed` requires dependencies to be installed locally before it can be run and `php composer.phar install` will autocreate a lockfile, it should be rare to have dependencies installed without a lockfile being present.

In order for dependencies to be enumerated
1. a php runtime needs to be present
2. a `composer.lock` file must be available at the licensed app source path
3. a composer application must be available

The composer application path defaults to `composer.phar`, which is appended to the licensed app source path for a final result of `<repository root>/composer.phar`.  The composer application path can be overridden by adding a `composer.application_path` configuration value to `.licensed.yml`.  The configuration value can be relative to the licensed app source path or an absolute path, and it can contain path directives like `~` or `..`.

**BE WARNED**
I haven't used PHP in about 15 years, and I haven't ever used composer before this.  The implementation seemed relatively straightforward but if there are edge cases that aren't handled I will be asking those that submit issues for help 😆 