### PR TITLE
Environment command updates

### DIFF
--- a/lib/licensed/commands/environment.rb
+++ b/lib/licensed/commands/environment.rb
@@ -37,11 +37,11 @@ module Licensed
 
       def create_reporter(options)
         case options[:format]
-          when "json"
-            Licensed::Reporters::JsonReporter.new
-          else
-            Licensed::Reporters::YamlReporter.new
-          end
+        when "json"
+          Licensed::Reporters::JsonReporter.new
+        else
+          Licensed::Reporters::YamlReporter.new
+        end
       end
 
       protected

--- a/lib/licensed/commands/environment.rb
+++ b/lib/licensed/commands/environment.rb
@@ -10,21 +10,21 @@ module Licensed
           @config = config
         end
 
+        def enabled_source_types
+          config.sources.select { |s| s.enabled? }.map { |s| s.class.type }
+        end
+
         def to_h
-          out = config.to_h.merge(
-            # override data for any calculated properties
-            "cache_path" => config.cache_path,
+          {
+            "name" => config["name"],
             "source_path" => config.source_path,
-            "sources" => config.sources.map { |s| s.class.type },
+            "cache_path" => config.cache_path,
+            "sources" => enabled_source_types,
+            "allowed" => config["allowed"],
+            "ignored" => config["ignored"],
+            "reviewed" => config["reviewed"],
             "version_strategy" => self.version_strategy
-          )
-
-          # don't report sub-apps
-          out.delete("apps")
-          # root is provided as a key on the top-level object
-          out.delete("root")
-
-          out
+          }
         end
       end
 

--- a/lib/licensed/commands/environment.rb
+++ b/lib/licensed/commands/environment.rb
@@ -13,8 +13,8 @@ module Licensed
         def to_h
           out = config.to_h.merge(
             # override data for any calculated properties
-            "cache_path" => config.cache_path.to_s,
-            "source_path" => config.source_path.to_s,
+            "cache_path" => config.cache_path,
+            "source_path" => config.source_path,
             "sources" => config.sources.map { |s| s.class.type },
             "version_strategy" => self.version_strategy
           )
@@ -30,7 +30,7 @@ module Licensed
 
       def run(**options)
         super do |report|
-          report["root"] = config.root.to_s
+          report["root"] = config.root
           report["git_repo"] = Licensed::Git.git_repo?
         end
       end

--- a/lib/licensed/reporters/yaml_reporter.rb
+++ b/lib/licensed/reporters/yaml_reporter.rb
@@ -7,7 +7,7 @@ module Licensed
           result = yield report
 
           report["apps"] = report.reports.map(&:to_h) if report.reports.any?
-          shell.info report.to_h.to_yaml
+          shell.info sanitize(report.to_h).to_yaml
 
           result
         end
@@ -26,6 +26,21 @@ module Licensed
           result = yield report
           report["dependencies"] = report.reports.map(&:to_h) if report.reports.any?
           result
+        end
+      end
+
+      def sanitize(object)
+        case object
+        when String, TrueClass, FalseClass, Numeric
+          object
+        when Array
+          object.compact.map { |item| sanitize(item) }
+        when Hash
+          object.reject { |_, v| v.nil? }
+                .map { |k, v| [k.to_s, sanitize(v)] }
+                .to_h
+        else
+          object.to_s
         end
       end
     end

--- a/test/commands/environment_test.rb
+++ b/test/commands/environment_test.rb
@@ -28,7 +28,7 @@ describe Licensed::Commands::Environment do
       command.run
 
       report = reporter.report
-      assert_equal config.root.to_s, report["root"]
+      assert_equal config.root, report["root"]
       assert_equal Licensed::Git.git_repo?, report["git_repo"]
     end
 

--- a/test/reporters/yaml_reporter_test.rb
+++ b/test/reporters/yaml_reporter_test.rb
@@ -40,6 +40,47 @@ describe Licensed::Reporters::JsonReporter do
                          style: :info
                       }
     end
+
+    it "sanitizes data to print using primitive types" do
+      reporter.report_run(command) do |report|
+        report[:key] = :value
+        report[:path] = Pathname.pwd
+        report[:hash] = {
+          array: [1, :symbol, true, false],
+          hash: {
+            key: :value
+          }
+        }
+        report[:array] = [
+          { key: :value },
+          [1, :symbol, true, false],
+          :symbol
+        ]
+      end
+
+      expected_object = {
+        "key" => "value",
+        "path" => Pathname.pwd.to_s,
+        "hash" => {
+          "array" => [1, "symbol", true, false],
+          "hash" => {
+            "key" => "value"
+          }
+        },
+        "array" => [
+          { "key" => "value" },
+          [1, "symbol", true, false],
+          "symbol"
+        ]
+      }
+
+      assert_includes shell.messages,
+                      {
+                         message: expected_object.to_yaml,
+                         newline: true,
+                         style: :info
+                      }
+    end
   end
 
   describe "#report_app" do


### PR DESCRIPTION
This PR updates the `licensed env` command to more strictly control the output.

I don't have a good scenario to understand how/why the full configuration should be output, or understand whether additional information from enabled sources would be useful either.  That would fall into using the command to debug a licensed configuration, but depending on the use case there might be a better way to fill that need.

In the meantime it made sense to limit the output to a wellknown set of data.  At the same time I fixed the yaml reporter to sanitize input to string content to avoid custom type information from being included in the output.