### PR TITLE
Add Mix source

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Test
 
-on: 
+on:
   push:
     branches:
     - "*"
@@ -230,3 +230,26 @@ jobs:
       run: script/source-setup/composer
     - name: Run tests
       run: script/test composer
+
+  mix:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        otp: [21.x, 22.x]
+        elixir: [1.8.x, 1.9.x]
+    steps:
+    - uses: actions/checkout@master
+    - uses: actions/setup-elixir@v1.0.0
+      with:
+        otp-version: ${{matrix.otp}}
+        elixir-version: ${{matrix.elixir}}
+    - name: Set up Ruby
+      uses: actions/setup-ruby@v1
+      with:
+        version: 2.6.x
+    - name: Bootstrap
+      run: script/bootstrap
+    - name: Set up fixtures
+      run: script/source-setup/mix
+    - name: Run tests
+      run: script/test mix

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ test/fixtures/pipenv/Pipfile.lock
 !test/fixtures/migrations/**/*
 test/fixtures/composer/**/*
 !test/fixtures/composer/composer.json
+test/fixtures/mix/_build
+test/fixtures/mix/deps
+test/fixtures/mix/mix.lock
 
 vendor/licenses
 .licenses

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Dependencies will be automatically detected for all of the following sources by 
 1. [Pip](./docs/sources/pip.md)
 1. [Pipenv](./docs/sources/pipenv.md)
 1. [Git Submodules (git_submodule)](./docs/sources/git_submodule.md)
+1. [Mix](./docs/sources/mix.md)
 
 You can disable any of them in the configuration file:
 

--- a/docs/sources/mix.md
+++ b/docs/sources/mix.md
@@ -19,3 +19,5 @@ Be sure to re-run this command whenever your `mix.exs` dependencies change to up
 ## Limitations
 
 Because `mix deps.get` does not generate `mix.lock` entries for `:path` dependencies (nor are they stored in `deps/`), license information is not extracted from them.
+
+If you need to extract license information from dependencies from another local directory (that is a Git repository), consider using a `:git` dependency with a file path in your `mix.exs`.

--- a/docs/sources/mix.md
+++ b/docs/sources/mix.md
@@ -1,0 +1,17 @@
+# Mix
+
+The mix source will detect `mix.lock` lockfiles, and parse their contents to enumerate dependencies.
+
+The `mix` CLI tool itself isn't used to extract dependency data, and no project compilation occurs during license extraction, but your dependencies should be present in your project `deps/` directory, as is conventional with Elixir projects.a
+
+## Installing Dependencies
+
+Your project should contain a `deps/ directory containing the dependency sources. You can download your dependencies (which are defined in `mix.exs`) using `mix`:
+
+```
+mix deps.get
+```
+
+This will create your `mix.lock` lockfile if needed.
+
+Be sure to re-run this command whenever your `mix.exs` dependencies change to update your lockfile and dependency sources.

--- a/docs/sources/mix.md
+++ b/docs/sources/mix.md
@@ -2,11 +2,11 @@
 
 The mix source will detect `mix.lock` lockfiles, and parse their contents to enumerate dependencies.
 
-The `mix` CLI tool itself isn't used to extract dependency data, and no project compilation occurs during license extraction, but your dependencies should be present in your project `deps/` directory, as is conventional with Elixir projects.a
+The `mix` CLI tool itself isn't used to extract dependency data, and no project compilation occurs during license extraction, but your dependencies should be present in your project `deps/` directory, as is conventional with Elixir projects.
 
 ## Installing Dependencies
 
-Your project should contain a `deps/ directory containing the dependency sources. You can download your dependencies (which are defined in `mix.exs`) using `mix`:
+Your project should contain a `deps/` directory containing the dependency sources. You can download your dependencies (which are defined in `mix.exs`) using `mix`:
 
 ```
 mix deps.get

--- a/docs/sources/mix.md
+++ b/docs/sources/mix.md
@@ -15,3 +15,7 @@ mix deps.get
 This will create your `mix.lock` lockfile if needed.
 
 Be sure to re-run this command whenever your `mix.exs` dependencies change to update your lockfile and dependency sources.
+
+## Limitations
+
+Because `mix deps.get` does not generate `mix.lock` entries for `:path` dependencies (nor are they stored in `deps/`), license information is not extracted from them.

--- a/lib/licensed/sources.rb
+++ b/lib/licensed/sources.rb
@@ -14,5 +14,6 @@ module Licensed
     require "licensed/sources/pip"
     require "licensed/sources/pipenv"
     require "licensed/sources/gradle"
+    require "licensed/sources/mix"
   end
 end

--- a/lib/licensed/sources/mix.rb
+++ b/lib/licensed/sources/mix.rb
@@ -13,17 +13,12 @@ module Licensed
       end
 
       def enumerate_dependencies
-        parsed_dependencies
-      end
-
-      private
-
-      # Returns a memoized Array of Dependency instances.
-      def parsed_dependencies
         find_packages.map do |name, lock_info|
           convert_package_to_dependency(name, lock_info)
         end
       end
+
+      private
 
       # Returns the parsed mix.lock information as a Hash.
       def find_packages

--- a/lib/licensed/sources/mix.rb
+++ b/lib/licensed/sources/mix.rb
@@ -146,22 +146,22 @@ module Licensed
           if match
             data = SCM_PATTERN[match[:scm]].match(match[:contents])
             if data
-              package_entry(match, data)
+              valid_package_entry(match, data)
             else
-              raise ParseError, "Could not extract #{match[:scm]} data from mix.lock line: #{line}"
+              invalid_package_entry(match, line)
             end
           else
-            raise ParseError, "Unknown mix.lock line format: #{line}"
+            raise Licensed::Sources::Source::Error, "Unknown mix.lock line format: #{line}"
           end
         end
 
-        # Format the package information.
+        # Format a valid package entry.
         #
         # match - A MatchData containing name and scm information.
         # data  - A MatchData containing version and repo information.
         #
         # Returns a Hash representing the package.
-        def package_entry(match, data)
+        def valid_package_entry(match, data)
           {
             name: match[:name],
             version: data[:version],
@@ -169,6 +169,23 @@ module Licensed
               "scm" => match[:scm],
               "repo" => data[:repo]
             }
+          }
+        end
+
+        # Format an invalid package entry.
+        #
+        # match - A MatchData containing name and scm information.
+        # line  - The line from mix.lock that could not be parsed, as a String.
+        #
+        # Returns a Hash representing the package, with error information.
+        def invalid_package_entry(match, line)
+          {
+            name: match[:name],
+            version: nil,
+            metadata: {
+              "scm" => match[:scm]
+            },
+            error: "Could not extract data from mix.lock line: #{line}"
           }
         end
       end

--- a/lib/licensed/sources/mix.rb
+++ b/lib/licensed/sources/mix.rb
@@ -1,0 +1,400 @@
+# frozen_string_literal: true
+require "strscan"
+
+module Licensed
+  module Sources
+    class Mix < Source
+
+      LOCKFILE = "mix.lock"
+
+      def enabled?
+        File.exists?(LOCKFILE) && mix?
+      end
+
+      def enumerate_dependencies
+        parsed_dependencies
+      end
+
+      # Returns whether the mix CLI tool is available
+      def mix?
+        @mix ||= Licensed::Shell.tool_available?("mix")
+      end
+
+      private
+
+      # Returns a memoized Array of Dependency instances.
+      def parsed_dependencies
+        @parsed_dependencies ||= find_packages.map do |name, lock_info|
+          convert_package_to_dependency(name, lock_info)
+        end
+      end
+
+      # Returns the parsed mix.lock information as a Hash.
+      def find_packages
+        lockfile = File.read(LOCKFILE)
+        LockfileParser.run(lockfile)
+      end
+
+      # Converts a raw package representation to a dependency.
+      #
+      # name      - The name of the package as a String.
+      # lock_info - The parsed lockfile data for the package as an Array.
+      #
+      # Returns a Dependency, or raises an ArgumentError if unsuccessful.
+      def convert_package_to_dependency(name, lock_info)
+        package_type = lock_info.first
+        case package_type
+        when "git"
+          git_dependency(name, lock_info)
+        when "hex"
+          hex_dependency(name, lock_info)
+        else
+          raise ArgumentError, "Unknown package type in mix.lock: #{package_type}"
+        end
+      end
+
+      # Generate a Dependency for a Git-based package type.
+      #
+      # name      - The name of the package as a String.
+      # lock_info - The parsed lockfile data for the package as an Array.
+      #
+      # Returns a Dependency (possibly with error information).
+      def git_dependency(name, lock_info)
+        # Example: {:git, "https://example.com/path/to/repo.git", "A-SHA-HERE", []},
+        path, errors = check_dep_path(name)
+        if lock_info.length == 4
+          Dependency.new(
+            name: name,
+            version: lock_info[2],
+            path: path,
+            metadata: {
+              "type" => "git",
+              "repo" => lock_info[1]
+            },
+            errors: errors
+          )
+        else
+          Dependency.new(
+            name: name,
+            path: path,
+            errors: errors << "unknown mix.lock format",
+            metadata: {
+              "type" => "git"
+            }
+          )
+        end
+      end
+
+      # Generate a Dependency for a Hex-based package type.
+      #
+      # name      - The name of the package as a String.
+      # lock_info - The parsed lockfile data for the package as an Array.
+      #
+      # Returns a Dependency (possibly with error information).
+      def hex_dependency(name, lock_info)
+        # Example: {:hex, :pkgname, "1.2.3", "A-DIGEST-HERE", [:mix], [], "hexpm"}
+        path, errors = check_dep_path(name)
+        if lock_info.length == 7
+          Dependency.new(
+            name: name,
+            version: lock_info[2],
+            path: path,
+            metadata: {
+              "type" => "hex",
+              "repo" => lock_info.last
+            },
+            errors: errors
+          )
+        else
+          Dependency.new(
+            name: name,
+            path: path,
+            errors: errors << "unknown mix.lock format",
+            metadata: {
+              "type" => "hex"
+            }
+          )
+        end
+      end
+
+      # Check that the package has been installed in deps/.
+      #
+      # name - The name of the package as a String.
+      #
+      # Returns an Array with two members; the path as a String
+      # and a possible Array of errors.
+      def check_dep_path(name)
+        path = dep_path(name)
+        if File.directory?(path)
+          return [path, []]
+        else
+          return [path, ["Not installed by `mix deps.get` in deps/"]]
+        end
+      end
+
+      # Generate the absolute path to the named package.
+      #
+      # name - The name of the package dependency as a String.
+      #
+      # Returns a String.
+      def dep_path(name)
+        File.absolute_path(File.join(".", "deps", name))
+      end
+
+      class LockfileParser
+        class ParseError < RuntimeError; end
+
+        WS_PATTERN = /\s*/
+        ATOM_CONTENTS_PATTERN = /[A-Za-z][A-Za-z_.0-9]+/
+        SEP_PATTERN = /,\s*/
+
+        # Parses a mix.lock to extract raw package information.
+        #
+        # lock - The mix.lock file contents as a String.
+        #
+        # Returns a Hash of package names to lockfile info, or raises a
+        # ParseError if unsuccessful.
+        def self.run(lock)
+          new(lock).result
+        end
+
+        def initialize(lock)
+          @lock = lock
+          @scanner = StringScanner.new(lock)
+        end
+
+        # Builds the parser result.
+        #
+        # Returns a memoized Hash of package names to lockfile info, or raises a
+        # ParseError if unsuccessful.
+        def result
+          @result ||= parse_toplevel
+        end
+
+        private
+
+        # Parses the toplevel structure in the lockfile.
+        #
+        # Returns a Hash of package names to lockfile info, or
+        # raises a ParseError if unsuccessful.
+        def parse_toplevel
+          start = @scanner.pos
+          if @scanner.scan(/%\{/)
+            data = {}
+            loop do
+              char = @scanner.peek(1)
+              case char
+              when "}"
+                @scanner.pos += 1
+                break
+              when "" # EOS
+                error("unterminated map", @scanner.pos)
+              else
+                @scanner.skip(WS_PATTERN)
+                key = parse_quoted_string
+                if key && @scanner.scan(/:\s+/)
+                  tuple = parse_tuple
+                  data[key] = tuple
+                  @scanner.skip(SEP_PATTERN)
+                end
+              end
+            end
+            data
+          else
+            raise ParseError, "invalid mix.lock"
+          end
+        end
+
+        # Parses a tuple from the current position.
+        #
+        # Returns a String (with quotes removed), or raises a ParseError if unsuccessful.
+        def parse_quoted_string
+          start = @scanner.pos
+          if @scanner.scan(/"/)
+            result = @scanner.scan_until(/"/)
+            unless result
+              raise ParseError, "quoted string not terminated (start at #{start})"
+            end
+            result.chop
+          else
+            error("expected quoted string", start)
+          end
+        end
+
+        # Parses a tuple from the current position.
+        #
+        # Returns an Array, or raises a ParseError if unsuccessful.
+        def parse_tuple
+          start = @scanner.pos
+          if @scanner.scan(/\{/)
+            data = []
+            loop do
+              case @scanner.peek(1)
+              when "}"
+                @scanner.pos += 1
+                break
+              when "" # EOS
+                raise ParseError, "tuple not terminated (start at #{start})"
+              else
+                data << parse_value(:tuple)
+              end
+              @scanner.skip(SEP_PATTERN)
+            end
+            data
+          else
+            error("expected tuple", start)
+          end
+        end
+
+        # Parses an atom from the current position.
+        #
+        # Returns a String, or raises a ParseError if unsuccessful.
+        def parse_atom
+          start = @scanner.pos
+          if @scanner.scan(/:/)
+            @scanner.scan(ATOM_CONTENTS_PATTERN)
+          else
+            error("expected atom", start)
+          end
+        end
+
+        # Parses a list from the current position.
+        #
+        # Returns an Array, or raises a ParseError if unsuccessful.
+        def parse_list
+          start = @scanner.pos
+          if @scanner.scan(/\[/)
+            data = []
+            loop do
+              char = @scanner.peek(1)
+              case @scanner.peek(1)
+              when "]"
+                @scanner.pos += 1
+                break
+              when "" # EOS
+                raise ParseError, "list not terminated (start at #{start})"
+              else
+                data << parse_value(:list)
+              end
+              @scanner.skip(SEP_PATTERN)
+            end
+            # Deal with the edge case where a non-open keyword list is wrapped
+            # in an extra list.
+            if data.length == 1 && data.first.is_a?(Array)
+              data = data.first
+            end
+            data
+          else
+            error("expected list", start)
+          end
+        end
+
+        # Parses a keyword list from the current position.
+        #
+        # Returns a Hash (with String keys).
+        def parse_keyword_list
+          data = {}
+          loop do
+            name = parse_keyword_name
+            value = parse_value(:keyword_list)
+            data[name] = value
+            unless @scanner.peek(1) == ","
+              break
+            end
+            @scanner.skip(SEP_PATTERN)
+          end
+          data
+        end
+
+        # Parses a keyword list from the current position.
+        #
+        # Returns a String or raises a ParseError if unsuccessful.
+        def parse_keyword_name
+          before_name = @scanner.pos
+          name = @scanner.scan(ATOM_CONTENTS_PATTERN)
+          unless name
+            error("expected keyword", before_name)
+          end
+
+          after_name = @scanner.pos
+          if @scanner.scan(/:/)
+            @scanner.skip(WS_PATTERN)
+            name
+          else
+            error("keyword #{name.inspect} not an atom", after_name)
+          end
+        end
+
+        # Parses atoms, quoted strings, keyword lists, lists, and tuples from
+        # the current position.
+        #
+        # context - The surrounding context of the value as a Symbol, used to
+        #           deal with edge cases around parsing keyword lists.
+        #
+        # Returns a String or raises a ParseError if unsuccessful.
+        def parse_value(context)
+          start = @scanner.pos
+          char = @scanner.peek(1)
+          case char
+          when ":"
+            parse_atom
+          when "'", "\""
+            parse_quoted_string
+          when /[a-z]/
+            if context == :keyword_list
+              # Open keyword lists can't be nested, this should be true, false, or
+              # nil.
+              parse_special_atom
+            else
+              parse_keyword_list
+            end
+          when /\[/
+            parse_list
+          when /\{/
+            parse_tuple
+          else
+            error("unknown value", start)
+          end
+        end
+
+        # Parse special atoms true, false, and nil.
+        #
+        # Returns true, false, or nil (or raises a ParseError if none of these
+        # could be parsed).
+        def parse_special_atom
+          start = @scanner.pos
+          case @scanner.scan(/true|false|nil/)
+          when "true"
+            true
+          when "false"
+            false
+          when "nil"
+            nil
+          else
+            error("expected true, false, or nil", start)
+          end
+        end
+
+        # Raise a ParseError with position and subsequent input.
+        #
+        # message  - the error message as a String.
+        # position - the parser byte position to report as an Integer.
+        def error(message, position)
+          raise ParseError, error_message(message, position)
+        end
+
+        # Format an error message with position and subsequent input.
+        #
+        # text     - the text that will serve as the prefix for the exception
+        #            message, as a String.
+        # position - the parser byte position to report as an Integer.
+        #
+        # Returns a String.
+        def error_message(text, position)
+          preview = @lock[position, 10]
+          "#{text} at position #{position} near #{preview.inspect}"
+        end
+      end
+    end
+  end
+end

--- a/lib/licensed/sources/mix.rb
+++ b/lib/licensed/sources/mix.rb
@@ -7,17 +7,13 @@ module Licensed
 
       LOCKFILE = "mix.lock"
 
+      # Returns whether a mix.lock is present
       def enabled?
-        File.exists?(LOCKFILE) && mix?
+        File.exists?(LOCKFILE)
       end
 
       def enumerate_dependencies
         parsed_dependencies
-      end
-
-      # Returns whether the mix CLI tool is available
-      def mix?
-        @mix ||= Licensed::Shell.tool_available?("mix")
       end
 
       private

--- a/lib/licensed/sources/mix.rb
+++ b/lib/licensed/sources/mix.rb
@@ -317,7 +317,7 @@ module Licensed
             @scanner.skip(WS_PATTERN)
             name
           else
-            error("keyword #{name.inspect} not an atom", after_name)
+            error("keyword #{name.inspect} is not an atom", after_name)
           end
         end
 

--- a/script/source-setup/mix
+++ b/script/source-setup/mix
@@ -16,4 +16,4 @@ if [ "$1" == "-f" ]; then
   mix clean || true
 fi
 
-# mix do deps.get, deps.compile
+mix deps.get

--- a/script/source-setup/mix
+++ b/script/source-setup/mix
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+if [ -z "$(which mix)" ]; then
+  echo "A local mix installation is required for elixir development." >&2
+  exit 127
+fi
+
+# setup test fixtures
+BASE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd $BASE_PATH/test/fixtures/mix
+
+if [ "$1" == "-f" ]; then
+  echo "removing old fixture setup..."
+  mix deps.clean --all || true
+  mix clean || true
+fi
+
+# mix do deps.get, deps.compile

--- a/test/fixtures/command/mix.yml
+++ b/test/fixtures/command/mix.yml
@@ -1,0 +1,3 @@
+expected_dependency: phoenix
+source_path: test/fixtures/mix
+cache_path: test/fixtures/mix/.licenses

--- a/test/fixtures/mix/.gitignore
+++ b/test/fixtures/mix/.gitignore
@@ -1,0 +1,24 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+mix-*.tar
+

--- a/test/fixtures/mix/lib/app.ex
+++ b/test/fixtures/mix/lib/app.ex
@@ -1,0 +1,18 @@
+defmodule App do
+  @moduledoc """
+  Documentation for App.
+  """
+
+  @doc """
+  Hello world.
+
+  ## Examples
+
+      iex> App.hello()
+      :world
+
+  """
+  def hello do
+    :world
+  end
+end

--- a/test/fixtures/mix/mix.exs
+++ b/test/fixtures/mix/mix.exs
@@ -23,7 +23,8 @@ defmodule App.MixProject do
     [
       {:plug, "1.8.3"},
       {:phoenix, "1.4.10"},
-      {:mox, "0.5.1", only: [:test]}
+      {:mox, "0.5.1", only: [:test]},
+      {:gen_stage, git: "https://github.com/elixir-lang/gen_stage.git"}
       # {:dep_from_hexpm, "~> 0.3.0"},
       # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
     ]

--- a/test/fixtures/mix/mix.exs
+++ b/test/fixtures/mix/mix.exs
@@ -21,8 +21,9 @@ defmodule App.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:plug, "~> 1.8.3"},
-      {:mox, "~> 0.5.1", only: [:test]}
+      {:plug, "1.8.3"},
+      {:phoenix, "1.4.10"},
+      {:mox, "0.5.1", only: [:test]}
       # {:dep_from_hexpm, "~> 0.3.0"},
       # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
     ]

--- a/test/fixtures/mix/mix.exs
+++ b/test/fixtures/mix/mix.exs
@@ -1,0 +1,30 @@
+defmodule App.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :mix,
+      version: "0.1.0",
+      elixir: "~> 1.9",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  # Run "mix help compile.app" to learn about applications.
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  # Run "mix help deps" to learn about dependencies.
+  defp deps do
+    [
+      {:plug, "~> 1.8.3"},
+      {:mox, "~> 0.5.1", only: [:test]}
+      # {:dep_from_hexpm, "~> 0.3.0"},
+      # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
+    ]
+  end
+end

--- a/test/fixtures/mix/mix.lock
+++ b/test/fixtures/mix/mix.lock
@@ -1,6 +1,0 @@
-%{
-  "mime": {:hex, :mime, "1.3.1", "30ce04ab3175b6ad0bdce0035cba77bba68b813d523d1aac73d9781b4d193cf8", [:mix], [], "hexpm"},
-  "mox": {:hex, :mox, "0.5.1", "f86bb36026aac1e6f924a4b6d024b05e9adbed5c63e8daa069bd66fb3292165b", [:mix], [], "hexpm"},
-  "plug": {:hex, :plug, "1.8.3", "12d5f9796dc72e8ac9614e94bda5e51c4c028d0d428e9297650d09e15a684478", [:mix], [{:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}, {:plug_crypto, "~> 1.0", [hex: :plug_crypto, repo: "hexpm", optional: false]}, {:telemetry, "~> 0.4", [hex: :telemetry, repo: "hexpm", optional: true]}], "hexpm"},
-  "plug_crypto": {:hex, :plug_crypto, "1.0.0", "18e49317d3fa343f24620ed22795ec29d4a5e602d52d1513ccea0b07d8ea7d4d", [:mix], [], "hexpm"},
-}

--- a/test/fixtures/mix/mix.lock
+++ b/test/fixtures/mix/mix.lock
@@ -1,0 +1,6 @@
+%{
+  "mime": {:hex, :mime, "1.3.1", "30ce04ab3175b6ad0bdce0035cba77bba68b813d523d1aac73d9781b4d193cf8", [:mix], [], "hexpm"},
+  "mox": {:hex, :mox, "0.5.1", "f86bb36026aac1e6f924a4b6d024b05e9adbed5c63e8daa069bd66fb3292165b", [:mix], [], "hexpm"},
+  "plug": {:hex, :plug, "1.8.3", "12d5f9796dc72e8ac9614e94bda5e51c4c028d0d428e9297650d09e15a684478", [:mix], [{:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}, {:plug_crypto, "~> 1.0", [hex: :plug_crypto, repo: "hexpm", optional: false]}, {:telemetry, "~> 0.4", [hex: :telemetry, repo: "hexpm", optional: true]}], "hexpm"},
+  "plug_crypto": {:hex, :plug_crypto, "1.0.0", "18e49317d3fa343f24620ed22795ec29d4a5e602d52d1513ccea0b07d8ea7d4d", [:mix], [], "hexpm"},
+}

--- a/test/fixtures/mix/test/app_test.exs
+++ b/test/fixtures/mix/test/app_test.exs
@@ -1,0 +1,8 @@
+defmodule AppTest do
+  use ExUnit.Case
+  doctest App
+
+  test "greets the world" do
+    assert App.hello() == :world
+  end
+end

--- a/test/fixtures/mix/test/test_helper.exs
+++ b/test/fixtures/mix/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/test/sources/mix_test.rb
+++ b/test/sources/mix_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+require "test_helper"
+require "tmpdir"
+
+if Licensed::Shell.tool_available?("mix")
+  describe Licensed::Sources::Mix do
+    let(:fixtures) { File.expand_path("../../fixtures/mix", __FILE__) }
+    let(:config) { Licensed::Configuration.new }
+    let(:source) { Licensed::Sources::Mix.new(config) }
+
+    describe "enabled?" do
+      it "is true if mix.lock exists" do
+        Dir.chdir(fixtures) do
+          assert source.enabled?
+        end
+      end
+
+      it "is false if no mix.lock exists" do
+        Dir.chdir(Dir.tmpdir) do
+          refute source.enabled?
+        end
+      end
+    end
+
+    describe "dependencies" do
+      it "finds indirect dependencies" do
+        Dir.chdir(fixtures) do
+          dep = source.dependencies.detect { |d| d.name == "mime" }
+          path = File.absolute_path(File.join(".", "deps", "mime"))
+          assert dep
+          assert_equal path, dep.path
+          assert_equal "1.3.1", dep.version
+          assert_equal "hex", dep.record["type"]
+          assert_equal "hexpm", dep.record["repo"]
+        end
+      end
+
+      it "finds direct dependencies" do
+        Dir.chdir(fixtures) do
+          dep = source.dependencies.detect { |d| d.name == "phoenix" }
+          path = File.absolute_path(File.join(".", "deps", "phoenix"))
+          assert dep
+          assert_equal path, dep.path
+          assert_equal "1.4.10", dep.version
+          assert_equal "hex", dep.record["type"]
+          assert_equal "hexpm", dep.record["repo"]
+        end
+      end
+    end
+  end
+end

--- a/test/sources/mix_test.rb
+++ b/test/sources/mix_test.rb
@@ -30,7 +30,8 @@ if Licensed::Shell.tool_available?("mix")
           assert dep
           assert_equal path, dep.path
           assert_equal "1.3.1", dep.version
-          assert_equal "hex", dep.record["type"]
+          assert_equal "mix", dep.record["type"]
+          assert_equal "hex", dep.record["scm"]
           assert_equal "hexpm", dep.record["repo"]
         end
       end
@@ -42,7 +43,8 @@ if Licensed::Shell.tool_available?("mix")
           assert dep
           assert_equal path, dep.path
           assert_equal "1.4.10", dep.version
-          assert_equal "hex", dep.record["type"]
+          assert_equal "mix", dep.record["type"]
+          assert_equal "hex", dep.record["scm"]
           assert_equal "hexpm", dep.record["repo"]
         end
       end

--- a/test/sources/mix_test.rb
+++ b/test/sources/mix_test.rb
@@ -31,6 +31,7 @@ if Licensed::Shell.tool_available?("mix")
           assert_equal path, dep.path
           assert_equal "1.3.1", dep.version
           assert_equal "mix", dep.record["type"]
+          # Mix-specific values
           assert_equal "hex", dep.record["scm"]
           assert_equal "hexpm", dep.record["repo"]
         end
@@ -44,8 +45,29 @@ if Licensed::Shell.tool_available?("mix")
           assert_equal path, dep.path
           assert_equal "1.4.10", dep.version
           assert_equal "mix", dep.record["type"]
+          # Mix-specific values
           assert_equal "hex", dep.record["scm"]
           assert_equal "hexpm", dep.record["repo"]
+        end
+      end
+    end
+
+    describe "Mix.SCM types" do
+      it "supports packages from hex" do
+        Dir.chdir(fixtures) do
+          dep = source.dependencies.detect { |d| d.name == "phoenix" }
+          # Mix-specific values
+          assert_equal "hex", dep.record["scm"]
+          assert_equal "hexpm", dep.record["repo"]
+        end
+      end
+
+      it "supports packages from git" do
+        Dir.chdir(fixtures) do
+          dep = source.dependencies.detect { |d| d.name == "gen_stage" }
+          # Mix-specific values
+          assert_equal "git", dep.record["scm"]
+          assert_equal "https://github.com/elixir-lang/gen_stage.git", dep.record["repo"]
         end
       end
     end


### PR DESCRIPTION
Adds a new dependency source enumerator for `mix`, to enumerate Elixir package dependencies.

The source of information is a `mix.lock` file. In the event dependencies are installed (in `deps/`), a lockfile should be present, as the conventional `mix deps.get` command both downloads dependencies and generates the lockfile.

In order for dependencies to be enumerated:

- A `mix.lock` file must be available at the licensed app source path.

Technically speaking, since the `mix` command isn't called by licensed to extract metadata (rather, we parse the limited Elixir data structure that's written into `mix.lock`), an Elixir/Erlang/OTP runtime isn't needed when licensed is run.

cc @jclem 