### PR TITLE
Clean up CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,12 +51,21 @@ jobs:
 
   cabal:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ghc: [ '8.2.2', '8.6.5' ]
+        cabal: [ '2.0', '3.0' ]
     steps:
     - uses: actions/checkout@master
     - name: Set up Ruby
       uses: actions/setup-ruby@v1
       with:
         version: 2.6.x
+    - name: Setup Haskell
+      uses: actions/setup-haskell@v1
+      with:
+        ghc-version: ${{ matrix.ghc }}
+        cabal-version: ${{ matrix.cabal }}
     - name: Bootstrap
       run: script/bootstrap
     - name: Set up fixtures

--- a/lib/licensed/sources/mix.rb
+++ b/lib/licensed/sources/mix.rb
@@ -8,7 +8,7 @@ module Licensed
 
       # Returns whether a mix.lock is present
       def enabled?
-        File.exists?(lockfile_path)
+        File.exist?(lockfile_path)
       end
 
       def enumerate_dependencies

--- a/script/source-setup/cabal
+++ b/script/source-setup/cabal
@@ -16,4 +16,4 @@ if [ "$1" == "-f" ]; then
   find . -not -regex "\.*" -and -not -path "*app*" -print0 | xargs -0 rm -rf
 fi
 
-cabal new-build || (cabal update && cabal install)
+(cabal new-update && cabal new-build) || (cabal update && cabal install)

--- a/test/fixtures/cabal/app.cabal
+++ b/test/fixtures/cabal/app.cabal
@@ -9,11 +9,11 @@ cabal-version:       >=1.10
 
 library
   hs-source-dirs:      .
-  build-depends:       zlib == 0.6.2
+  build-depends:       fused-effects == 0.5.0.1
   default-language:    Haskell2010
 
 executable app
   hs-source-dirs:      app
   main-is:             Main.hs
-  build-depends:       base, Glob == 0.9.2
+  build-depends:       base, semilattices == 0.0.0.4
   default-language:    Haskell2010

--- a/test/fixtures/cabal/app.cabal
+++ b/test/fixtures/cabal/app.cabal
@@ -9,7 +9,7 @@ cabal-version:       >=1.10
 
 library
   hs-source-dirs:      .
-  build-depends:       fused-effects == 0.5.0.1
+  build-depends:       fused-effects == 0.4.0.0
   default-language:    Haskell2010
 
 executable app

--- a/test/fixtures/command/cabal.yml
+++ b/test/fixtures/command/cabal.yml
@@ -1,4 +1,4 @@
-expected_dependency: zlib
+expected_dependency: fused-effects
 source_path: test/fixtures/cabal
 cache_path: test/fixtures/cabal/.licenses
 cabal:

--- a/test/fixtures/command/cabal.yml
+++ b/test/fixtures/command/cabal.yml
@@ -4,5 +4,6 @@ cache_path: test/fixtures/cabal/.licenses
 cabal:
   ghc_package_db:
     - global
+    - user
     - test/fixtures/cabal/dist-newstyle/packagedb/ghc-<ghc_version>
     - ~/.cabal/store/ghc-<ghc_version>/package.db

--- a/test/sources/cabal_test.rb
+++ b/test/sources/cabal_test.rb
@@ -23,10 +23,11 @@ if Licensed::Shell.tool_available?("ghc")
     end
 
     describe "dependencies" do
+      let(:cabal_db) { "~/.cabal/store/ghc-<ghc_version>/package.db" }
       let(:local_db) { File.join(fixtures, "dist-newstyle/packagedb/ghc-<ghc_version>") }
 
       it "finds indirect dependencies" do
-        config["cabal"] = { "ghc_package_db" => ["global", "user", local_db] }
+        config["cabal"] = { "ghc_package_db" => ["global", "user", local_db, cabal_db] }
         Dir.chdir(fixtures) do
           dep = source.dependencies.detect { |d| d.name == "bytestring" }
           assert dep
@@ -37,7 +38,7 @@ if Licensed::Shell.tool_available?("ghc")
       end
 
       it "finds direct dependencies" do
-        config["cabal"] = { "ghc_package_db" => ["global", "user", local_db] }
+        config["cabal"] = { "ghc_package_db" => ["global", "user", local_db, cabal_db] }
         Dir.chdir(fixtures) do
           dep = source.dependencies.detect { |d| d.name == "zlib" }
           assert dep
@@ -48,7 +49,7 @@ if Licensed::Shell.tool_available?("ghc")
       end
 
       it "finds dependencies for executables" do
-        config["cabal"] = { "ghc_package_db" => ["global", "user", local_db] }
+        config["cabal"] = { "ghc_package_db" => ["global", "user", local_db, cabal_db] }
         Dir.chdir(fixtures) do
           dep = source.dependencies.detect { |d| d.name == "Glob" }
           assert dep
@@ -59,7 +60,7 @@ if Licensed::Shell.tool_available?("ghc")
       end
 
       it "does not include the target project" do
-        config["cabal"] = { "ghc_package_db" => ["global", "user", local_db] }
+        config["cabal"] = { "ghc_package_db" => ["global", "user", local_db, cabal_db] }
         Dir.chdir(fixtures) do
           refute source.dependencies.detect { |d| d.name == "app" }
         end

--- a/test/sources/cabal_test.rb
+++ b/test/sources/cabal_test.rb
@@ -40,10 +40,10 @@ if Licensed::Shell.tool_available?("ghc")
       it "finds direct dependencies" do
         config["cabal"] = { "ghc_package_db" => ["global", "user", local_db, cabal_db] }
         Dir.chdir(fixtures) do
-          dep = source.dependencies.detect { |d| d.name == "zlib" }
+          dep = source.dependencies.detect { |d| d.name == "fused-effects" }
           assert dep
           assert_equal "cabal", dep.record["type"]
-          assert_equal "0.6.2", dep.version
+          assert_equal "0.5.0.1", dep.version
           assert dep.record["summary"]
         end
       end
@@ -51,10 +51,10 @@ if Licensed::Shell.tool_available?("ghc")
       it "finds dependencies for executables" do
         config["cabal"] = { "ghc_package_db" => ["global", "user", local_db, cabal_db] }
         Dir.chdir(fixtures) do
-          dep = source.dependencies.detect { |d| d.name == "Glob" }
+          dep = source.dependencies.detect { |d| d.name == "semilattices" }
           assert dep
           assert_equal "cabal", dep.record["type"]
-          assert_equal "0.9.2", dep.version
+          assert_equal "0.0.0.4", dep.version
           assert dep.record["summary"]
         end
       end
@@ -70,7 +70,7 @@ if Licensed::Shell.tool_available?("ghc")
         # look in a location that doesn't contain any packages
         config["cabal"] = { "ghc_package_db" => [Dir.pwd] }
         Dir.chdir(fixtures) do
-          dep = source.dependencies.detect { |d| d.name == "zlib" }
+          dep = source.dependencies.detect { |d| d.name == "fused-effects" }
           assert dep
           assert_includes dep.errors, "package not found"
         end

--- a/test/sources/cabal_test.rb
+++ b/test/sources/cabal_test.rb
@@ -43,7 +43,7 @@ if Licensed::Shell.tool_available?("ghc")
           dep = source.dependencies.detect { |d| d.name == "fused-effects" }
           assert dep
           assert_equal "cabal", dep.record["type"]
-          assert_equal "0.5.0.1", dep.version
+          assert_equal "0.4.0.0", dep.version
           assert dep.record["summary"]
         end
       end

--- a/test/sources/mix_test.rb
+++ b/test/sources/mix_test.rb
@@ -89,9 +89,9 @@ if Licensed::Shell.tool_available?("mix")
         it "returns an entry for a valid package" do
           expectation = [
             {
-              :name => "foo",
-              :version => "1.2.3",
-              :metadata => {"scm" => "hex", "repo" => "hexpm"}
+              name: "foo",
+              version: "1.2.3",
+              metadata: {"scm" => "hex", "repo" => "hexpm"}
             }
           ]
           assert_equal expectation, parse_lockfile_contents(lockfile)
@@ -104,10 +104,10 @@ if Licensed::Shell.tool_available?("mix")
         it "returns an entry for an invalid package" do
           expectation = [
             {
-              :name => "absinthe",
-              :version => nil,
-              :metadata => {"scm" => "hex"},
-              :error => "Could not extract data from mix.lock line: \"absinthe\": {:hex, 1, 2},\n"
+              name: "absinthe",
+              version: nil,
+              metadata: {"scm" => "hex"},
+              error: "Could not extract data from mix.lock line: \"absinthe\": {:hex, 1, 2},\n"
             }
           ]
           assert_equal expectation, parse_lockfile_contents(lockfile)


### PR DESCRIPTION
It looks like CI broke at some point with cabal no longer being found by default in GitHub Actions environments.  That's ok because theres a handy new `@actions/setup-haskell` action to get things back up and running

I'm also including a few linter failures that came up after merging the new `mix` source, where CI wasn't run on the PR because it came from a fork.  I think that's the reason anyway