### PR TITLE
Run pipenv in parallel for discovered packages to improve performance.

### DIFF
--- a/lib/licensed/sources/pipenv.rb
+++ b/lib/licensed/sources/pipenv.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "parallel"
+
 module Licensed
   module Sources
     class Pipenv < Source
@@ -8,7 +10,7 @@ module Licensed
       end
 
       def enumerate_dependencies
-        pakages_from_pipfile_lock.map do |package_name|
+        Parallel.map(pakages_from_pipfile_lock, in_threads: Parallel.processor_count) do |package_name|
           package = package_info(package_name)
           location = File.join(package["Location"], package["Name"].gsub("-", "_") +  "-" + package["Version"] + ".dist-info")
           Dependency.new(

--- a/licensed.gemspec
+++ b/licensed.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "tomlrb", "~> 1.2"
   spec.add_dependency "bundler", ">= 1.10"
   spec.add_dependency "ruby-xxHash", "~> 0.4"
+  spec.add_dependency "parallel", ">= 0.18.0"
 
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.8"


### PR DESCRIPTION
Running `pipenv` in parallel significantly improved the performance of `pipenv` source, on my 8 core (4 cores + ht) machine running `./script/test pipenv` takes:

2.5.0:
 - 25.979721s
 - 25.930273s
 - 26.492875s

2.5.0 + parallel (threads):
 - 8.658091s
 - 8.751204s
 - 8.751976s
