### PR TITLE
Run pip in parallel for packages from requirements.txt to improve performance

### DIFF
--- a/lib/licensed/sources/pip.rb
+++ b/lib/licensed/sources/pip.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
-require "json"
+
 require "English"
+require "json"
+require "parallel"
 
 module Licensed
   module Sources
@@ -14,7 +16,7 @@ module Licensed
       end
 
       def enumerate_dependencies
-        packages_from_requirements_txt.map do |package_name|
+        Parallel.map(packages_from_requirements_txt, in_threads: Parallel.processor_count) do |package_name|
           package = package_info(package_name)
           location = File.join(package["Location"], package["Name"].gsub("-", "_") +  "-" + package["Version"] + ".dist-info")
           Dependency.new(


### PR DESCRIPTION
Continuation of #204 - it looks like the difference for `pip` source is even greater:

2.6.0:
 - 56.279191s
 - 59.861275s
 - 54.958267s

2.6.0 + parallel (threads):
 - 16.790002s
 - 18.095694s
 - 18.228944s

Not all sources can benefit from the parallel run, but in the case of `pip` (and `pipenv`) as the script is executed for every package the improvement is noticeable.