### PR TITLE
Test version range requirements for indirect dependencies

### DIFF
--- a/test/sources/composer_test.rb
+++ b/test/sources/composer_test.rb
@@ -57,7 +57,8 @@ if Licensed::Shell.tool_available?("php")
           dep = source.dependencies.detect { |dep| dep.name == "psr/log" }
           assert dep
           assert_equal "composer", dep.record["type"]
-          assert_equal "1.1.0", dep.version
+          # psr/log requirement for monolog/monolog is `~1.0`
+          assert Gem::Requirement.new("~> 1.0").satisfied_by?(Gem::Version.new(dep.version))
           assert dep.record["homepage"]
           assert dep.record["summary"]
           assert dep.path

--- a/test/sources/mix_test.rb
+++ b/test/sources/mix_test.rb
@@ -29,7 +29,8 @@ if Licensed::Shell.tool_available?("mix")
           path = File.absolute_path(File.join(".", "deps", "mime"))
           assert dep
           assert_equal path, dep.path
-          assert_equal "1.3.1", dep.version
+          # mime requirement from plug is `~> 1.0`
+          assert Gem::Requirement.new("~> 1.0").satisfied_by?(Gem::Version.new(dep.version))
           assert_equal "mix", dep.record["type"]
           # Mix-specific values
           assert_equal "hex", dep.record["scm"]

--- a/test/sources/pipenv_test.rb
+++ b/test/sources/pipenv_test.rb
@@ -41,7 +41,8 @@ if Licensed::Shell.tool_available?("pipenv")
           dep = source.dependencies.detect { |d| d.name == "isort" }
           assert dep
           assert_equal "pipenv", dep.record["type"]
-          assert /^4\..*$/.match dep.version
+          # pylint requires isort <5,>=4.2.5
+          assert Gem::Requirement.new("<5", ">=4.2.5").satisfied_by?(Gem::Version.new(dep.version))
           assert dep.record["homepage"]
           assert dep.record["summary"]
         end


### PR DESCRIPTION
Fixes CI by matching versions on indirect dependencies using `Gem::Requirement#satisfied_by?` and `Gem::Version` to match expected indirect dependency ranges rather than an exact version.

Matching exact versions on indirect dependencies has been pretty brittle since they're usually specified with range version requirements.  The exact version that gets installed can then change over time.