### PR TITLE
Use parallel enumeration for sources

### DIFF
--- a/lib/licensed/sources/cabal.rb
+++ b/lib/licensed/sources/cabal.rb
@@ -43,7 +43,7 @@ module Licensed
           end
         end
 
-        package_ids.map { |id| package_info(id) }.concat(missing)
+        Parallel.map(package_ids) { |id| package_info(id) }.concat(missing)
       end
 
       # Returns the packages document directory and search root directory
@@ -85,7 +85,7 @@ module Licensed
 
         results.merge new_packages
 
-        dependencies = new_packages.flat_map { |n| package_dependencies(n) }
+        dependencies = Parallel.map(new_packages, &method(:package_dependencies)).flatten
 
         return results if dependencies.empty?
 

--- a/lib/licensed/sources/composer.rb
+++ b/lib/licensed/sources/composer.rb
@@ -12,7 +12,7 @@ module Licensed
       end
 
       def enumerate_dependencies
-        Parallel.map(packages) do |package|
+        packages.map do |package|
           Dependency.new(
             name: package["name"],
             version: package["version"],

--- a/lib/licensed/sources/composer.rb
+++ b/lib/licensed/sources/composer.rb
@@ -12,7 +12,7 @@ module Licensed
       end
 
       def enumerate_dependencies
-        packages.map do |package|
+        Parallel.map(packages) do |package|
           Dependency.new(
             name: package["name"],
             version: package["version"],

--- a/lib/licensed/sources/go.rb
+++ b/lib/licensed/sources/go.rb
@@ -14,7 +14,7 @@ module Licensed
 
       def enumerate_dependencies
         with_configured_gopath do
-          Parallel.map(packages) do |package|
+          packages.map do |package|
             import_path = non_vendored_import_path(package["ImportPath"])
             error = package.dig("Error", "Err") if package["Error"]
             package_dir = package["Dir"]
@@ -104,18 +104,20 @@ module Licensed
 
         # find most recent git SHA for a package, or nil if SHA is
         # not available
-        contents_version *contents_version_arguments(package_directory)
+        Dir.chdir package_directory do
+          contents_version *contents_version_arguments
+        end
       end
 
       # Determines the arguments to pass to contents_version based on which
       # version strategy is selected
       #
       # Returns an array of arguments to pass to contents version
-      def contents_version_arguments(package_directory)
+      def contents_version_arguments
         if version_strategy == Licensed::Sources::ContentVersioning::GIT
-          [package_directory]
+          ["."]
         else
-          Dir[File.join(package_directory, "*")]
+          Dir["*"]
         end
       end
 


### PR DESCRIPTION
Following https://github.com/github/licensed/pull/207 and https://github.com/github/licensed/pull/204, this updates a few more sources to use parallel enumeration

1. Cabal
  - when obtaining full package information from package ids
  - when recursively obtaining indirect package dependencies
  - tried when getting package ids for initial set of dependencies found in cabal files, which slowed things down in local testing
2. Go < 1.11
   - when getting package info for all dependencies listed in `root_package["Deps"]`
   - cannot use when getting package version.  this can potentially make many `git` cli calls, but by necessity of being in the target packages git repo I need to `Dir.chdir package_directory`, where `Dir.chdir` is not threadsafe.
3. Manifest
   - when getting package versions which potentially makes many `git` cli calls

Speed gains observed from CI

|  | Cabal | Go | Manifest |
| --- | --- | --- | ----- |
| Absolute | 1-3s | 25-32s | 0s - these were already pretty fast at 3s |
| Relative | 10-30% | 33-39% | 0% |