### PR TITLE
Improvements for go sources

### DIFF
--- a/docs/sources/go.md
+++ b/docs/sources/go.md
@@ -40,3 +40,13 @@ The go source supports multiple versioning strategies to determine if cached dep
    ```yaml
    version_strategy: contents
    ```
+
+#### Go modules support
+
+The go source fully supports go modules, provided that the calling environment has been configured to use go modules.
+
+The go source can be configured to support vendored go modules
+```yaml
+go:
+  mod: vendor
+```

--- a/lib/licensed/sources/dep.rb
+++ b/lib/licensed/sources/dep.rb
@@ -20,7 +20,7 @@ module Licensed
             search_root: search_root.to_s,
             metadata: {
               "type"        => Dep.type,
-              "homepage"    => "https://#{package[:name]}"
+              "homepage"    => homepage(package[:name])
             }
           )
         end
@@ -38,6 +38,12 @@ module Licensed
                             .reject { |import_path| go_std_package?(import_path) }
                             .map { |import_path| { name: import_path, version: project[:revision], project: project[:name] } }
         end
+      end
+
+      # Returns the godoc.org page for a package.
+      def homepage(import_path)
+        return unless import_path
+        "https://godoc.org/#{import_path}"
       end
 
       # Returns whether the package is part of the go std list.  Replaces

--- a/lib/licensed/sources/dep.rb
+++ b/lib/licensed/sources/dep.rb
@@ -44,6 +44,7 @@ module Licensed
       # "golang.org" with "golang_org" to match packages listed in `go list std`
       # as "vendor/golang_org/*" but are vendored as "vendor/golang.org/*"
       def go_std_package?(import_path)
+        return true if go_std_packages.include? "vendor/#{import_path}"
         go_std_packages.include? "vendor/#{import_path.sub(/^golang.org/, "golang_org")}"
       end
 

--- a/lib/licensed/sources/go.rb
+++ b/lib/licensed/sources/go.rb
@@ -59,11 +59,14 @@ module Licensed
       # Returns the list of dependencies as returned by "go list -json -deps"
       # available in go 1.11
       def go_list_deps
+        args = ["-deps"]
+        args << "-mod=vendor" if config.dig("go", "mod") == "vendor"
+
         # the CLI command returns packages in a pretty-printed JSON format but
         # not separated by commas. this gsub adds commas after all non-indented
         # "}" that close root level objects.
         # (?!\z) uses negative lookahead to not match the final "}"
-        deps = package_info_command("-deps").gsub(/^}(?!\z)$/m, "},")
+        deps = package_info_command(*args).gsub(/^}(?!\z)$/m, "},")
         JSON.parse("[#{deps}]")
       end
 

--- a/lib/licensed/sources/go.rb
+++ b/lib/licensed/sources/go.rb
@@ -130,14 +130,10 @@ module Licensed
         end
       end
 
-      # Returns the homepage for a package import_path.  Assumes that the
-      # import path itself is a url domain and path
+      # Returns the godoc.org page for a package.
       def homepage(import_path)
         return unless import_path
-
-        # hacky but generally works due to go packages looking like
-        # "github.com/..." or "golang.org/..."
-        "https://#{import_path}"
+        "https://godoc.org/#{import_path}"
       end
 
       # Returns the root directory to search for a package license

--- a/lib/licensed/sources/go.rb
+++ b/lib/licensed/sources/go.rb
@@ -206,17 +206,12 @@ module Licensed
       def gopath
         return @gopath if defined?(@gopath)
 
-        path = config.dig("go", "GOPATH")
-        @gopath = if path.nil? || path.empty?
-                    ENV["GOPATH"]
-                  else
-                    root = begin
-                             config.root
-                           rescue Licensed::Shell::Error
-                             Pathname.pwd
-                           end
-                    File.expand_path(path, root)
-                  end
+        @gopath = begin
+          path = config.dig("go", "GOPATH")
+          return File.expand_path(path, config.root) unless path.to_s.empty?
+          return ENV["GOPATH"] if ENV["GOPATH"]
+          Licensed::Shell.execute("go", "env", "GOPATH")
+        end
       end
 
       # Returns the current version of go available, as a Gem::Version

--- a/test/sources/dep_test.rb
+++ b/test/sources/dep_test.rb
@@ -41,7 +41,7 @@ describe Licensed::Sources::Dep do
         dep = source.dependencies.detect { |d| d.name == "github.com/gorilla/context" }
         assert dep
         assert_equal "dep", dep.record["type"]
-        assert_equal "https://github.com/gorilla/context", dep.record["homepage"]
+        assert_equal "https://godoc.org/github.com/gorilla/context", dep.record["homepage"]
       end
     end
 

--- a/test/sources/go_test.rb
+++ b/test/sources/go_test.rb
@@ -187,5 +187,44 @@ if Licensed::Shell.tool_available?("go")
         end
       end
     end
+
+    describe "search_root" do
+      it "is nil for nil input" do
+        assert_nil source.search_root(nil)
+      end
+
+      it "is the package module directory if available" do
+        package = {
+          "Module" => { "Dir" => "test" }
+        }
+        assert_equal "test", source.search_root(package)
+      end
+
+      it "is the vendor folder if the package is vendored" do
+        source.stubs(:vendored_path?).returns(true)
+        package = { "Dir" => "test/vendor/package/path" }
+        assert_equal "test/vendor", source.search_root(package)
+      end
+
+      it "is package['Root'] is given" do
+        package = {
+          "Dir" => "test/path",
+          "Root" => "test"
+        }
+        assert_equal "test", source.search_root(package)
+      end
+
+      it "is the available gopath value if gopath directory is an ancestor of the package" do
+        source.stubs(:gopath).returns("test")
+        package = { "Dir" => "test/path" }
+        assert_equal "test", source.search_root(package)
+      end
+
+      it "is nil if a search root cannot be found" do
+        source.stubs(:gopath).returns("/go")
+        package = { "Dir" => "test/path" }
+        assert_nil source.search_root(package)
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR includes a number of improvements for using go-based sources (`go` and `dep`)

### Better checks on matching packages from `go list std`. 

Some versions of the go cli will list paths like `vendor/golang_x/...` and some versions list `vendor/golang.x/...`.  The go and dep sources now account for both formats

### Using a packages godoc page as it's homepage. 

The sources previously used the package import path as it's url.  This doesn't work well for nested packages like `github.com/hashicorp/golang-lru/simplelru` where the uri should be `github.com/hashicorp/golang-lru/tree/<version>/simplelru`.  Since we don't always have a good version to reference and the godoc page should always exist, this is a quick change to use a better path.

### More options for setting the root when searching for go packages license files

This adds a few more options for the search root
- package["Module"]["Dir"] - when using go modules this is the ideal path to use as you are guaranteed to never find a license for a different project.
- package["Root"] is preferred over using gopath as it's more closely tied to package information
- gopath is restricted to only be used when the gopath is an ancestor path of the package

### New default value for used GOPATH

`Sources::Go#gopath` will use `go env GOPATH` as a default value if the GOPATH can't be found from the configuration or `ENV`

### Configuration support for vendored go modules

```yaml
go:
  mod: vendor
```

Setting this configuration will add the `-mod=vendor` when  enumerating dependencies with `go list`.