### PR TITLE
Use caching in test CI action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,7 +84,7 @@ jobs:
     - uses: actions/cache@preview
       with:
         path: test/fixtures/cabal/dist-newstyle
-        key: ${{ runner.os }}-fixtures-cabal-${{ matrix.ghc }}-${{ matrix.cabal }}-${{ hashFiles('test/fixtures/cabal/app.cabal') }}
+        key: ${{ runner.os }}-fixtures-cabal-${{ matrix.ghc }}-${{ matrix.cabal }}-${{ hashFiles(format('{0}{1}', github.workspace, '/test/fixtures/cabal/app.cabal') }}
     - name: Bootstrap
       run: script/bootstrap
     - name: Set up fixtures
@@ -203,6 +203,7 @@ jobs:
       uses: actions/setup-ruby@v1
       with:
         ruby-version: 2.6.x
+    - run: bundle lock
     - uses: actions/cache@preview
       with:
         path: vendor/gems

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,10 @@ jobs:
       uses: actions/setup-ruby@v1
       with:
         ruby-version: 2.6.x
+    - uses: actions/cache@preview
+      with:
+        path: vendor/gems
+        key: ${{ runner.os }}-gem-2.6.x-${{ hashFiles('Gemfile.lock') }}
     - name: Bootstrap
       run: script/bootstrap
     - name: Set up fixtures
@@ -42,6 +46,10 @@ jobs:
       run: |
         yes | gem uninstall bundler --all
         gem install bundler -v "${{ matrix.bundler }}"
+    - uses: actions/cache@preview
+      with:
+        path: vendor/gems
+        key: ${{ runner.os }}-gem-2.6.x-${{ hashFiles('Gemfile.lock') }}
     - name: Bootstrap
       run: script/bootstrap
     - name: Set up fixtures
@@ -66,6 +74,14 @@ jobs:
       with:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: ${{ matrix.cabal }}
+    - uses: actions/cache@preview
+      with:
+        path: vendor/gems
+        key: ${{ runner.os }}-gem-2.6.x-${{ hashFiles('Gemfile.lock') }}
+    - uses: actions/cache@preview
+      with:
+        path: test/fixtures/cabal/dist-newstyle
+        key: ${{ runner.os }}-fixtures-cabal-${{ matrix.ghc }}-${{ matrix.cabal }}-${{ hashFiles('test/fixtures/cabal/app.cabal') }}
     - name: Bootstrap
       run: script/bootstrap
     - name: Set up fixtures
@@ -86,6 +102,10 @@ jobs:
         ruby-version: ${{matrix.ruby}}
     - name: Set up Bundler
       run: gem install bundler
+    - uses: actions/cache@preview
+      with:
+        path: vendor/gems
+        key: ${{ runner.os }}-gem-${{ matrix.ruby }}-${{ hashFiles('Gemfile.lock') }}
     - name: Bootstrap
       run: script/bootstrap
     - name: Build and lint
@@ -104,7 +124,11 @@ jobs:
     - name: Set up Ruby
       uses: actions/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: 2.6.x    
+    - uses: actions/cache@preview
+      with:
+        path: vendor/gems
+        key: ${{ runner.os }}-gem-2.6.x-${{ hashFiles('Gemfile.lock') }}
     - name: Bootstrap
       run: script/bootstrap
     - name: Set up fixtures
@@ -127,6 +151,10 @@ jobs:
       uses: actions/setup-ruby@v1
       with:
         ruby-version: 2.6.x
+    - uses: actions/cache@preview
+      with:
+        path: vendor/gems
+        key: ${{ runner.os }}-gem-2.6.x-${{ hashFiles('Gemfile.lock') }}
     - name: Bootstrap
       run: script/bootstrap
     - name: Set up fixtures
@@ -149,6 +177,10 @@ jobs:
       uses: actions/setup-ruby@v1
       with:
         ruby-version: 2.6.x
+    - uses: actions/cache@preview
+      with:
+        path: vendor/gems
+        key: ${{ runner.os }}-gem-2.6.x-${{ hashFiles('Gemfile.lock') }}
     - name: Bootstrap
       run: script/bootstrap
     - name: Set up fixtures
@@ -164,6 +196,10 @@ jobs:
       uses: actions/setup-ruby@v1
       with:
         ruby-version: 2.6.x
+    - uses: actions/cache@preview
+      with:
+        path: vendor/gems
+        key: ${{ runner.os }}-gem-2.6.x-${{ hashFiles('Gemfile.lock') }}
     - name: Bootstrap
       run: script/bootstrap
     - name: Gradle version
@@ -187,6 +223,10 @@ jobs:
       uses: actions/setup-ruby@v1
       with:
         ruby-version: 2.6.x
+    - uses: actions/cache@preview
+      with:
+        path: vendor/gems
+        key: ${{ runner.os }}-gem-2.6.x-${{ hashFiles('Gemfile.lock') }}
     - name: Bootstrap
       run: script/bootstrap
     - name: Install virtualenv
@@ -209,6 +249,10 @@ jobs:
       uses: actions/setup-ruby@v1
       with:
         ruby-version: 2.6.x
+    - uses: actions/cache@preview
+      with:
+        path: vendor/gems
+        key: ${{ runner.os }}-gem-2.6.x-${{ hashFiles('Gemfile.lock') }}
     - name: Bootstrap
       run: script/bootstrap
     - name: Install pipenv
@@ -233,6 +277,10 @@ jobs:
       uses: actions/setup-ruby@v1
       with:
         ruby-version: 2.6.x
+    - uses: actions/cache@preview
+      with:
+        path: vendor/gems
+        key: ${{ runner.os }}-gem-2.6.x-${{ hashFiles('Gemfile.lock') }}
     - name: Bootstrap
       run: script/bootstrap
     - name: Set up fixtures
@@ -256,6 +304,10 @@ jobs:
       uses: actions/setup-ruby@v1
       with:
         ruby-version: 2.6.x
+    - uses: actions/cache@preview
+      with:
+        path: vendor/gems
+        key: ${{ runner.os }}-gem-2.6.x-${{ hashFiles('Gemfile.lock') }}
     - name: Bootstrap
       run: script/bootstrap
     - name: Set up fixtures
@@ -271,6 +323,10 @@ jobs:
       uses: actions/setup-ruby@v1
       with:
         ruby-version: 2.6.x
+    - uses: actions/cache@preview
+      with:
+        path: vendor/gems
+        key: ${{ runner.os }}-gem-2.6.x-${{ hashFiles('Gemfile.lock') }}
     - name: Bootstrap
       run: script/bootstrap
     - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
       uses: actions/setup-ruby@v1
       with:
         ruby-version: 2.6.x
+    - run: bundle lock
     - uses: actions/cache@preview
       with:
         path: vendor/gems
@@ -46,6 +47,7 @@ jobs:
       run: |
         yes | gem uninstall bundler --all
         gem install bundler -v "${{ matrix.bundler }}"
+    - run: bundle lock
     - uses: actions/cache@preview
       with:
         path: vendor/gems
@@ -74,6 +76,7 @@ jobs:
       with:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: ${{ matrix.cabal }}
+    - run: bundle lock
     - uses: actions/cache@preview
       with:
         path: vendor/gems
@@ -102,6 +105,7 @@ jobs:
         ruby-version: ${{matrix.ruby}}
     - name: Set up Bundler
       run: gem install bundler
+    - run: bundle lock
     - uses: actions/cache@preview
       with:
         path: vendor/gems
@@ -124,7 +128,8 @@ jobs:
     - name: Set up Ruby
       uses: actions/setup-ruby@v1
       with:
-        ruby-version: 2.6.x    
+        ruby-version: 2.6.x
+    - run: bundle lock
     - uses: actions/cache@preview
       with:
         path: vendor/gems
@@ -151,6 +156,7 @@ jobs:
       uses: actions/setup-ruby@v1
       with:
         ruby-version: 2.6.x
+    - run: bundle lock
     - uses: actions/cache@preview
       with:
         path: vendor/gems
@@ -177,6 +183,7 @@ jobs:
       uses: actions/setup-ruby@v1
       with:
         ruby-version: 2.6.x
+    - run: bundle lock
     - uses: actions/cache@preview
       with:
         path: vendor/gems
@@ -223,6 +230,7 @@ jobs:
       uses: actions/setup-ruby@v1
       with:
         ruby-version: 2.6.x
+    - run: bundle lock
     - uses: actions/cache@preview
       with:
         path: vendor/gems
@@ -249,6 +257,7 @@ jobs:
       uses: actions/setup-ruby@v1
       with:
         ruby-version: 2.6.x
+    - run: bundle lock
     - uses: actions/cache@preview
       with:
         path: vendor/gems
@@ -277,6 +286,7 @@ jobs:
       uses: actions/setup-ruby@v1
       with:
         ruby-version: 2.6.x
+    - run: bundle lock
     - uses: actions/cache@preview
       with:
         path: vendor/gems
@@ -304,6 +314,7 @@ jobs:
       uses: actions/setup-ruby@v1
       with:
         ruby-version: 2.6.x
+    - run: bundle lock
     - uses: actions/cache@preview
       with:
         path: vendor/gems
@@ -323,6 +334,7 @@ jobs:
       uses: actions/setup-ruby@v1
       with:
         ruby-version: 2.6.x
+    - run: bundle lock
     - uses: actions/cache@preview
       with:
         path: vendor/gems

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/cache@preview
       with:
         path: vendor/gems
-        key: ${{ runner.os }}-gem-2.6.x-${{ hashFiles('Gemfile.lock') }}
+        key: ${{ runner.os }}-gem-2.6.x-${{ hashFiles(format('{0}{1}', github.workspace, '/Gemfile.lock')) }}
     - name: Bootstrap
       run: script/bootstrap
     - name: Set up fixtures
@@ -51,7 +51,7 @@ jobs:
     - uses: actions/cache@preview
       with:
         path: vendor/gems
-        key: ${{ runner.os }}-gem-2.6.x-${{ hashFiles('Gemfile.lock') }}
+        key: ${{ runner.os }}-gem-2.6.x-${{ hashFiles(format('{0}{1}', github.workspace, '/Gemfile.lock')) }}
     - name: Bootstrap
       run: script/bootstrap
     - name: Set up fixtures
@@ -80,7 +80,7 @@ jobs:
     - uses: actions/cache@preview
       with:
         path: vendor/gems
-        key: ${{ runner.os }}-gem-2.6.x-${{ hashFiles('Gemfile.lock') }}
+        key: ${{ runner.os }}-gem-2.6.x-${{ hashFiles(format('{0}{1}', github.workspace, '/Gemfile.lock')) }}
     - uses: actions/cache@preview
       with:
         path: test/fixtures/cabal/dist-newstyle
@@ -109,7 +109,7 @@ jobs:
     - uses: actions/cache@preview
       with:
         path: vendor/gems
-        key: ${{ runner.os }}-gem-${{ matrix.ruby }}-${{ hashFiles('Gemfile.lock') }}
+        key: ${{ runner.os }}-gem-${{ matrix.ruby }}-${{ hashFiles(format('{0}{1}', github.workspace, '/Gemfile.lock')) }}
     - name: Bootstrap
       run: script/bootstrap
     - name: Build and lint
@@ -133,7 +133,7 @@ jobs:
     - uses: actions/cache@preview
       with:
         path: vendor/gems
-        key: ${{ runner.os }}-gem-2.6.x-${{ hashFiles('Gemfile.lock') }}
+        key: ${{ runner.os }}-gem-2.6.x-${{ hashFiles(format('{0}{1}', github.workspace, '/Gemfile.lock')) }}
     - name: Bootstrap
       run: script/bootstrap
     - name: Set up fixtures
@@ -160,7 +160,7 @@ jobs:
     - uses: actions/cache@preview
       with:
         path: vendor/gems
-        key: ${{ runner.os }}-gem-2.6.x-${{ hashFiles('Gemfile.lock') }}
+        key: ${{ runner.os }}-gem-2.6.x-${{ hashFiles(format('{0}{1}', github.workspace, '/Gemfile.lock')) }}
     - name: Bootstrap
       run: script/bootstrap
     - name: Set up fixtures
@@ -187,7 +187,7 @@ jobs:
     - uses: actions/cache@preview
       with:
         path: vendor/gems
-        key: ${{ runner.os }}-gem-2.6.x-${{ hashFiles('Gemfile.lock') }}
+        key: ${{ runner.os }}-gem-2.6.x-${{ hashFiles(format('{0}{1}', github.workspace, '/Gemfile.lock')) }}
     - name: Bootstrap
       run: script/bootstrap
     - name: Set up fixtures
@@ -206,7 +206,7 @@ jobs:
     - uses: actions/cache@preview
       with:
         path: vendor/gems
-        key: ${{ runner.os }}-gem-2.6.x-${{ hashFiles('Gemfile.lock') }}
+        key: ${{ runner.os }}-gem-2.6.x-${{ hashFiles(format('{0}{1}', github.workspace, '/Gemfile.lock')) }}
     - name: Bootstrap
       run: script/bootstrap
     - name: Gradle version
@@ -234,7 +234,7 @@ jobs:
     - uses: actions/cache@preview
       with:
         path: vendor/gems
-        key: ${{ runner.os }}-gem-2.6.x-${{ hashFiles('Gemfile.lock') }}
+        key: ${{ runner.os }}-gem-2.6.x-${{ hashFiles(format('{0}{1}', github.workspace, '/Gemfile.lock')) }}
     - name: Bootstrap
       run: script/bootstrap
     - name: Install virtualenv
@@ -261,7 +261,7 @@ jobs:
     - uses: actions/cache@preview
       with:
         path: vendor/gems
-        key: ${{ runner.os }}-gem-2.6.x-${{ hashFiles('Gemfile.lock') }}
+        key: ${{ runner.os }}-gem-2.6.x-${{ hashFiles(format('{0}{1}', github.workspace, '/Gemfile.lock')) }}
     - name: Bootstrap
       run: script/bootstrap
     - name: Install pipenv
@@ -290,7 +290,7 @@ jobs:
     - uses: actions/cache@preview
       with:
         path: vendor/gems
-        key: ${{ runner.os }}-gem-2.6.x-${{ hashFiles('Gemfile.lock') }}
+        key: ${{ runner.os }}-gem-2.6.x-${{ hashFiles(format('{0}{1}', github.workspace, '/Gemfile.lock')) }}
     - name: Bootstrap
       run: script/bootstrap
     - name: Set up fixtures
@@ -318,7 +318,7 @@ jobs:
     - uses: actions/cache@preview
       with:
         path: vendor/gems
-        key: ${{ runner.os }}-gem-2.6.x-${{ hashFiles('Gemfile.lock') }}
+        key: ${{ runner.os }}-gem-2.6.x-${{ hashFiles(format('{0}{1}', github.workspace, '/Gemfile.lock')) }}
     - name: Bootstrap
       run: script/bootstrap
     - name: Set up fixtures
@@ -338,7 +338,7 @@ jobs:
     - uses: actions/cache@preview
       with:
         path: vendor/gems
-        key: ${{ runner.os }}-gem-2.6.x-${{ hashFiles('Gemfile.lock') }}
+        key: ${{ runner.os }}-gem-2.6.x-${{ hashFiles(format('{0}{1}', github.workspace, '/Gemfile.lock')) }}
     - name: Bootstrap
       run: script/bootstrap
     - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,7 +84,7 @@ jobs:
     - uses: actions/cache@preview
       with:
         path: test/fixtures/cabal/dist-newstyle
-        key: ${{ runner.os }}-fixtures-cabal-${{ matrix.ghc }}-${{ matrix.cabal }}-${{ hashFiles(format('{0}{1}', github.workspace, '/test/fixtures/cabal/app.cabal') }}
+        key: ${{ runner.os }}-fixtures-cabal-${{ matrix.ghc }}-${{ matrix.cabal }}-${{ hashFiles(format('{0}{1}', github.workspace, '/test/fixtures/cabal/app.cabal')) }}
     - name: Bootstrap
       run: script/bootstrap
     - name: Set up fixtures


### PR DESCRIPTION
This utilizes the new [`actions/cache`](https://github.com/actions/cache) GitHub action to cache the output from the most costly aspects of running the test ci:

- bootstrapping licensed
  - this uses a cache key based on the version of ruby used and a hash of Gemfile.lock
  - Gemfile.lock isn't checked in, so each CI job needs a `bundle lock` step to generate the lockfile without pulling dependencies
- installing cabal dependencies
   - cache key is based on the versions of ghc and cabal used, and a hash of the fixture `app.cabal` file
   - will need to see whether there are other options to make the most out of caching that directory.  for now it seems to work and I'll keep an eye on it over time