### PR TITLE
Additional check for go standard package

### DIFF
--- a/lib/licensed/sources/go.rb
+++ b/lib/licensed/sources/go.rb
@@ -90,6 +90,10 @@ module Licensed
         # if package isn't vendored
         return false unless vendored_path?(import_path)
 
+        # return true if any of the go standard packages matches against
+        # the non-vendored import path
+        return true if go_std_packages.include?(non_vendored_import_path(import_path))
+
         # modify the import path to look like the import path `go list` returns for vendored std packages
         vendor_path = import_path.sub("#{root_package["ImportPath"]}/", "")
         go_std_packages.include?(vendor_path) || go_std_packages.include?(vendor_path.sub("golang.org", "golang_org"))

--- a/lib/licensed/sources/go.rb
+++ b/lib/licensed/sources/go.rb
@@ -85,6 +85,7 @@ module Licensed
 
         # true if go standard packages includes the import path as given
         return true if go_std_packages.include?(import_path)
+        return true if go_std_packages.include?("vendor/#{import_path}")
 
         # additional checks are only for vendored dependencies - return false
         # if package isn't vendored

--- a/test/sources/go_test.rb
+++ b/test/sources/go_test.rb
@@ -325,6 +325,11 @@ if Licensed::Shell.tool_available?("go")
         assert source.go_std_package?(package)
       end
 
+      it "returns true if the import path with 'vendor/' matches `go list std`" do
+        package = { "ImportPath" => "package/3" }
+        assert source.go_std_package?(package)
+      end
+
       it "returns false if vendored import path does't match 'go list std'" do
         package = { "ImportPath" => "#{root_package_import_path}/vendor/package/5" }
         refute source.go_std_package?(package)

--- a/test/sources/go_test.rb
+++ b/test/sources/go_test.rb
@@ -272,5 +272,63 @@ if Licensed::Shell.tool_available?("go")
         assert_nil source.search_root(package)
       end
     end
+
+    describe "go_std_package?" do
+      let(:root_package_import_path) { "test" }
+
+      before do
+        source.stubs(:root_package).returns("ImportPath" => root_package_import_path)
+        source.stubs(:go_std_packages).returns([
+          "package/1",
+          "package/2",
+          "vendor/package/3",
+          "vendor/golang_org/package/4"
+        ])
+      end
+
+      it "returns false for a nil package" do
+        refute source.go_std_package?(nil)
+      end
+
+      it "returns true if package self-identifies as standard" do
+        package = { "Standard" => true }
+        assert source.go_std_package?(package)
+      end
+
+      it "returns false unless the package contains an import path" do
+        package = {}
+        refute source.go_std_package?(package)
+      end
+
+      it "returns true if the import path matches 'go list std'" do
+        package = { "ImportPath" => "package/1" }
+        assert source.go_std_package?(package)
+      end
+
+      it "returns false for unvendored import paths not matching 'go list std'" do
+        package = { "ImportPath" => "package/no_match" }
+        refute source.go_std_package?(package)
+      end
+
+      it "returns true if the vendored import path matches 'go list std'" do
+        package = { "ImportPath" => "#{root_package_import_path}/vendor/package/3" }
+        assert source.go_std_package?(package)
+      end
+
+      it "returns true if the underscore vendored import path matches 'go list std'" do
+        package = { "ImportPath" => "#{root_package_import_path}/vendor/golang.org/package/4" }
+        assert source.go_std_package?(package)
+      end
+
+      it "returns true if the vendored import path without 'vendor/' matches 'go list std'" do
+        package = { "ImportPath" => "#{root_package_import_path}/vendor/package/2" }
+        assert source.go_std_package?(package)
+      end
+
+      it "returns false if vendored import path does't match 'go list std'" do
+        package = { "ImportPath" => "#{root_package_import_path}/vendor/package/5" }
+        refute source.go_std_package?(package)
+      end
+    end
   end
 end


### PR DESCRIPTION
A few more additional check when determining whether a dependency import path matches a package from the go standard library.

If the package is vendored and the import path would match a go standard package without the `vendor/` path part, consider it a match.

If the package is not vendored, but matches a go standard package path that starts with `vendor/`, consider it a match.