### PR TITLE
Fix evaluate dependency bug

### DIFF
--- a/lib/licensed/commands/status.rb
+++ b/lib/licensed/commands/status.rb
@@ -34,7 +34,6 @@ module Licensed
           report.errors << "cached dependency record not found"
         else
           report.errors << "cached dependency record out of date" if cached_record["version"] != dependency.version
-          report.errors << "missing license text" if cached_record.licenses.empty?
           report.errors << "license needs review: #{cached_record["license"]}" if license_needs_review?(app, cached_record)
         end
 


### PR DESCRIPTION
This fixes a bug when adding dependencies that have empty licenses but have their allowed license in the `.licensed.yml`. This happens when we included the `aws-sdk-s3` gem:

our `.licensed.yml`:
```
sources:
  bundler: true
  npm: false
  bower: false
  cabal: false

allowed:
  - mit
  - apache-2.0

reviewed:
  bundler:
    - aws-eventstream
```

and our `.licenses/bundler/aws-eventstream.dep.yml` file:

```
---
name: aws-eventstream
version: 1.0.2
type: bundler
summary: AWS Event Stream Library
homepage: http://github.com/aws/aws-sdk-ruby
license: apache-2.0
licenses: []
notices: []
```

everytime we run `bundle exec licensed status`, we get:

```
* agencymvp.com.bundler.aws-eventstream
  filename: /Users/westoque/GitHub/westoque/rails_app/.licenses/bundler/aws-eventstream.dep.yml
    - missing license text
```

There's really no need to check if licenses are empty because we already do the empty check in `#license_needs_review?`.