### PR TITLE
Delete unneeded error raising

### DIFF
--- a/lib/licensed/configuration.rb
+++ b/lib/licensed/configuration.rb
@@ -148,13 +148,9 @@ module Licensed
 
     # Find a default configuration file in the given directory.
     # File preference is given by the order of elements in DEFAULT_CONFIG_FILES
-    #
-    # Raises Licensed::Configuration::LoadError if a file isn't found
     def self.find_config(directory)
-      config_file = DEFAULT_CONFIG_FILES.map { |file| directory.join(file) }
-                                        .find { |file| file.exist? }
-
-      config_file || raise(LoadError, "Licensed configuration not found in #{directory}")
+      DEFAULT_CONFIG_FILES.map { |file| directory.join(file) }
+                          .find { |file| file.exist? }
     end
 
     # Parses the configuration given at `config_path` and returns the values
@@ -162,7 +158,7 @@ module Licensed
     #
     # Raises Licensed::Configuration::LoadError if the file type isn't known
     def self.parse_config(config_path)
-      return {} unless config_path.file?
+      return {} if config_path.nil? || !config_path.file?
 
       extension = config_path.extname.downcase.delete "."
       config = case extension

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -57,11 +57,9 @@ describe Licensed::Configuration do
       assert_equal Pathname.pwd.join(".licenses"), config.cache_path
     end
 
-    it "raises an error if a default config file is not found" do
+    it "returns empty sourses hash without default config file" do
       Dir.mktmpdir do |dir|
-        assert_raises ::Licensed::Configuration::LoadError do
-          Licensed::Configuration.load_from(dir)
-        end
+        assert_equal Licensed::Configuration.load_from(dir)["sources"], {}
       end
     end
 


### PR DESCRIPTION
Looks like licensed doesn't need to raise an error without default config file. Even if you add an empty default file everything works and error during installation only make users "feel frustration":)