### PR TITLE
Allow ignoring projects with wildcards

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -95,6 +95,12 @@ ignored:
   bower:
     - some-internal-package
 
+  go:
+    # ignore all go packages from import paths starting with github.com/internal-package
+    # see the `File.fnmatch?` documentation for details on how patterns are matched.
+    # comparisons use the FNM_CASEFOLD and FNM_PATHNAME flags
+    - github.com/internal-package/**/*
+
 # These dependencies have been reviewed.
 # They need to be cached and checked, but do not have a license found that matches the allowed configured licenses.
 reviewed:

--- a/lib/licensed/configuration.rb
+++ b/lib/licensed/configuration.rb
@@ -75,7 +75,9 @@ module Licensed
 
     # Is the given dependency ignored?
     def ignored?(dependency)
-      Array(self["ignored"][dependency["type"]]).include?(dependency["name"])
+      Array(self["ignored"][dependency["type"]]).any? do |pattern|
+        File.fnmatch?(pattern, dependency["name"], File::FNM_PATHNAME | File::FNM_CASEFOLD)
+      end
     end
 
     # Is the license of the dependency allowed?


### PR DESCRIPTION
closes https://github.com/github/licensed/issues/193

This adds pattern matching when ignoring dependencies based on glob patterns and `File.fnmatch?`.  Comparisons use `File::FNM_PATHNAME` for strict `**` vs `*` evaluation, and `FNM_CASEFOLD` for case insensitivity.  For full details, please see the ruby documentation on `File.fnmatch?`