### PR TITLE
Install bower for actions CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,8 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: 8
+    - name: Install Bower
+      run: npm install -g bower
     - name: Set up Ruby
       uses: actions/setup-ruby@v1
       with:


### PR DESCRIPTION
Updating CI to install bower as part of the bower test setup, following https://github.com/github/licensed/runs/358614524.