### PR TITLE
Fix cabal nil reference when packages aren't found

### DIFF
--- a/lib/licensed/sources/cabal.rb
+++ b/lib/licensed/sources/cabal.rb
@@ -222,10 +222,10 @@ module Licensed
 
       # Returns a package info structure with an error set
       def missing_package(id)
-        name, version = if id.index(/\s/).nil?
-          id.split("-", 2)
+        name, _, version = if id.index(/\s/).nil?
+          id.rpartition("-") # e.g. to match the right-most dash from ipid fused-effects-1.0.0.0
         else
-          id.split(/\s/, 2)
+          id.partition(/\s/) # e.g. to match the left-most space from constraint fused-effects > 1.0.0.0
         end
 
         { "name" => name, "version" => version, "error" => "package not found" }

--- a/lib/licensed/sources/cabal.rb
+++ b/lib/licensed/sources/cabal.rb
@@ -109,10 +109,7 @@ module Licensed
       # Returns package information as a hash for the given id
       def package_info(id)
         info = package_info_command(id).strip
-        if info.empty?
-          name, _, version = id.rpartition("-")
-          return missing_package(name, version)
-        end
+        return missing_package(id) if info.empty?
 
         info.lines.each_with_object({}) do |line, info|
           key, value = line.split(":", 2).map(&:strip)

--- a/lib/licensed/sources/cabal.rb
+++ b/lib/licensed/sources/cabal.rb
@@ -79,18 +79,17 @@ module Licensed
       # Recursively finds the dependencies for each cabal package.
       # Returns a `Set` containing the package names for all dependencies
       def recursive_dependencies(package_names, results = Set.new)
-        return [] if package_names.nil? || package_names.empty?
+        return results if package_names.nil? || package_names.empty?
 
         new_packages = Set.new(package_names) - results
-        return [] if new_packages.empty?
+        return results if new_packages.empty?
 
         results.merge new_packages
 
         dependencies = Parallel.map(new_packages, &method(:package_dependencies)).flatten
 
-        return results if dependencies.empty?
-
-        results.merge recursive_dependencies(dependencies, results)
+        recursive_dependencies(dependencies, results)
+        results
       end
 
       # Returns an array of dependency package names for the cabal package

--- a/lib/licensed/sources/cabal.rb
+++ b/lib/licensed/sources/cabal.rb
@@ -48,6 +48,8 @@ module Licensed
       # Returns the packages document directory and search root directory
       # as an array
       def package_docs_dirs(package)
+        return [nil, nil] if package.nil? || package.empty?
+
         unless package["haddock-html"]
           # default to a local vendor directory if haddock-html property
           # isn't available

--- a/test/sources/cabal_test.rb
+++ b/test/sources/cabal_test.rb
@@ -77,8 +77,8 @@ if Licensed::Shell.tool_available?("ghc")
       end
 
       it "sets an error if an indirect dependency isn't found" do
-        # look in a location that doesn't contain any packages
-        config["cabal"] = { "ghc_package_db" => [cabal_db, local_db] }
+        # look in locations that don't contain the package
+        config["cabal"] = { "ghc_package_db" => [local_db, cabal_db, "user"] }
         Dir.chdir(fixtures) do
           dep = source.dependencies.detect { |d| d.name == "bytestring" }
           assert dep

--- a/test/sources/cabal_test.rb
+++ b/test/sources/cabal_test.rb
@@ -66,11 +66,21 @@ if Licensed::Shell.tool_available?("ghc")
         end
       end
 
-      it "sets an error if a dependency isn't found" do
+      it "sets an error if a direct dependency isn't found" do
         # look in a location that doesn't contain any packages
         config["cabal"] = { "ghc_package_db" => [Dir.pwd] }
         Dir.chdir(fixtures) do
           dep = source.dependencies.detect { |d| d.name == "fused-effects" }
+          assert dep
+          assert_includes dep.errors, "package not found"
+        end
+      end
+
+      it "sets an error if an indirect dependency isn't found" do
+        # look in a location that doesn't contain any packages
+        config["cabal"] = { "ghc_package_db" => [cabal_db, local_db] }
+        Dir.chdir(fixtures) do
+          dep = source.dependencies.detect { |d| d.name == "bytestring" }
           assert dep
           assert_includes dep.errors, "package not found"
         end


### PR DESCRIPTION
Fixes https://github.com/github/licensed/issues/228

The underlying issue is that when indirect dependencies can't be found, they returned an empty hash as the data from `Cabal#package_info`.  That hash would then cause a crash when trying to find the package's path on disk.

Fixed this by forcing all dependencies to go through `Cabal#package_info`, and then returning data for a missing package error from that method.  I also added protection against the nil reference in the method where it was happening.