### PR TITLE
Add configuration setting for non-production npm dependencies

### DIFF
--- a/docs/sources/npm.md
+++ b/docs/sources/npm.md
@@ -1,3 +1,12 @@
 # NPM
 
 The npm source will detect dependencies `package.json` is found at an apps `source_path`.  It uses `npm list` to enumerate dependencies and metadata.
+
+### Including development dependencies
+
+By default, the npm source will exclude all non-development dependencies.  To include development or test dependencies, set `production_only: false` in the licensed configuration.
+
+```yml
+npm:
+  production_only: false
+```

--- a/lib/licensed/sources/npm.rb
+++ b/lib/licensed/sources/npm.rb
@@ -57,12 +57,19 @@ module Licensed
 
       # Returns the output from running `npm list` to get package metadata
       def package_metadata_command
-        Licensed::Shell.execute("npm", "list", "--json", "--production", "--long", allow_failure: true)
+        args = %w(--json --long)
+        args << "--production" unless include_non_production?
+        Licensed::Shell.execute("npm", "list", *args, allow_failure: true)
       end
 
       # Returns true if a yarn.lock file exists in the current directory
       def yarn_lock_present
         @yarn_lock_present ||= File.exist?(config.pwd.join("yarn.lock"))
+      end
+
+      # Returns whether to include non production dependencies based on the licensed configuration settings
+      def include_non_production?
+        config.dig("npm", "production_only") == false
       end
     end
   end

--- a/test/sources/npm_test.rb
+++ b/test/sources/npm_test.rb
@@ -20,8 +20,10 @@ if Licensed::Shell.tool_available?("npm")
       end
 
       it "is false no npm configs exist" do
-        Dir.chdir(Dir.tmpdir) do
-          refute source.enabled?
+        Dir.mktmpdir do |dir|
+          Dir.chdir(dir) do
+            refute source.enabled?
+          end
         end
       end
     end
@@ -38,7 +40,7 @@ if Licensed::Shell.tool_available?("npm")
         end
       end
 
-      it "includes transient dependencies" do
+      it "includes indirect dependencies" do
         Dir.chdir fixtures do
           assert source.dependencies.detect { |dep| dep.name == "autoprefixer" }
         end
@@ -67,7 +69,7 @@ if Licensed::Shell.tool_available?("npm")
       describe "with multiple instances of a dependency" do
         it "includes version in the dependency name for multiple unique versions" do
           Dir.chdir fixtures do
-            graceful_fs_dependencies = source.dependencies.select { |dep| dep.name == /graceful-fs/ }
+            graceful_fs_dependencies = source.dependencies.select { |dep| dep.name == "graceful-fs" }
             assert_empty graceful_fs_dependencies
 
             graceful_fs_dependencies = source.dependencies.select { |dep| dep.name =~ /graceful-fs/ }

--- a/test/sources/npm_test.rb
+++ b/test/sources/npm_test.rb
@@ -44,9 +44,16 @@ if Licensed::Shell.tool_available?("npm")
         end
       end
 
-      it "does not include dev dependencies" do
+      it "does not include dev dependencies by default" do
         Dir.chdir fixtures do
           refute source.dependencies.detect { |dep| dep.name == "string.prototype.startswith" }
+        end
+      end
+
+      it "includes dev dependencies if configured" do
+        Dir.chdir fixtures do
+          config["npm"] = { "production_only" => false }
+          assert source.dependencies.detect { |dep| dep.name == "string.prototype.startswith" }
         end
       end
 


### PR DESCRIPTION
closes https://github.com/github/licensed/issues/8

This adds an option for the npm source to include non-production dependencies.  By default non-prod dependencies are excluded to maintain backwards compatibility, with non-prod dependencies included when the `production_only` configuration is set to false. 

new setting
```yml
npm:
  production_only: false
```