### PR TITLE
Addressing some feedback from new yarn source

### DIFF
--- a/lib/licensed/sources/yarn.rb
+++ b/lib/licensed/sources/yarn.rb
@@ -39,7 +39,7 @@ module Licensed
             # if there is more than one package for a name, reference each by
             # "<name>-<version>"
             results.each do |package|
-              all_dependencies[package["id"].sub("@", "-")] = package
+              all_dependencies["#{name}-#{package["version"]}"] = package
             end
           end
         end
@@ -57,7 +57,7 @@ module Licensed
       def recursive_dependencies(path, dependencies, result = {})
         dependencies.each do |dependency|
           next if dependency["shadow"]
-          name, version = dependency["name"].split("@")
+          name, _, version = dependency["name"].rpartition("@")
 
           dependency_path = path.join("node_modules", name)
           (result[name] ||= []) << {

--- a/lib/licensed/sources/yarn.rb
+++ b/lib/licensed/sources/yarn.rb
@@ -5,7 +5,7 @@ module Licensed
   module Sources
     class Yarn < Source
       def enabled?
-        return unless Licensed::Shell.tool_available?("yarn") && Licensed::Shell.tool_available?("npm")
+        return unless Licensed::Shell.tool_available?("yarn")
 
         config.pwd.join("package.json").exist? && config.pwd.join("yarn.lock").exist?
       end
@@ -56,6 +56,8 @@ module Licensed
       # package name to it's metadata
       def recursive_dependencies(path, dependencies, result = {})
         dependencies.each do |dependency|
+          # "shadow" indicate a dependency requirement only, not a
+          # resolved package identifier
           next if dependency["shadow"]
           name, _, version = dependency["name"].rpartition("@")
 

--- a/test/fixtures/npm/package.json
+++ b/test/fixtures/npm/package.json
@@ -2,7 +2,8 @@
   "name": "fixtures",
   "version": "1.0.0",
   "dependencies": {
-    "autoprefixer": "5.2.0"
+    "autoprefixer": "5.2.0",
+    "@github/query-selector": "1.0.3"
   },
   "devDependencies": {
     "string.prototype.startswith": "0.2.0"

--- a/test/fixtures/yarn/package.json
+++ b/test/fixtures/yarn/package.json
@@ -2,7 +2,8 @@
   "name": "fixtures",
   "version": "1.0.0",
   "dependencies": {
-    "autoprefixer": "5.2.0"
+    "autoprefixer": "5.2.0",
+    "@github/query-selector": "1.0.3"
   },
   "devDependencies": {
     "string.prototype.startswith": "0.2.0"

--- a/test/fixtures/yarn/package.json
+++ b/test/fixtures/yarn/package.json
@@ -7,7 +7,7 @@
   "devDependencies": {
     "string.prototype.startswith": "0.2.0"
   },
-  "description": "npm test fixture",
+  "description": "yarn test fixture",
   "repository": "https://github.com/github/licensed",
   "license": "MIT"
 }

--- a/test/sources/npm_test.rb
+++ b/test/sources/npm_test.rb
@@ -40,6 +40,16 @@ if Licensed::Shell.tool_available?("npm")
         end
       end
 
+      it "handles scoped dependency names" do
+        Dir.chdir fixtures do
+          dep = source.dependencies.detect { |d| d.name == "@github/query-selector" }
+          assert dep
+          assert_equal "1.0.3", dep.version
+          assert dep.record["homepage"]
+          assert dep.record["summary"]
+        end
+      end
+
       it "includes indirect dependencies" do
         Dir.chdir fixtures do
           assert source.dependencies.detect { |dep| dep.name == "autoprefixer" }

--- a/test/sources/yarn_test.rb
+++ b/test/sources/yarn_test.rb
@@ -51,6 +51,16 @@ if Licensed::Shell.tool_available?("yarn")
         end
       end
 
+      it "handles scoped dependency names" do
+        Dir.chdir fixtures do
+          dep = source.dependencies.detect { |d| d.name == "@github/query-selector" }
+          assert dep
+          assert_equal "1.0.3", dep.version
+          assert dep.record["homepage"]
+          assert dep.record["summary"]
+        end
+      end
+
       it "includes indirect dependencies" do
         Dir.chdir fixtures do
           assert source.dependencies.detect { |dep| dep.name == "autoprefixer-core" }

--- a/test/sources/yarn_test.rb
+++ b/test/sources/yarn_test.rb
@@ -101,5 +101,15 @@ if Licensed::Shell.tool_available?("yarn")
         end
       end
     end
+
+    describe "packages" do
+      it "returns an empty list if no packages are found" do
+        Dir.mktmpdir do |dir|
+          Dir.chdir dir do
+            assert_empty source.packages
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
:wave: @sergey-alekseev @krzysztof-pawlik-gat thanks for taking a look at the [PR for the new yarn source](https://github.com/github/licensed/pull/232)!

I'd appreciate if you could also take a look at this PR and let me know if I'm addressing all of your comments and feedback 🙇 

1. protecting against extra json output from `yarn list` and `yarn info` by searching for the `tree` and `inspect` types, respectively.
2. moving `JSON.parse` outside the parallel handling from `Parallel.map`
   - I think general lack of thread-safety might have been the cause of @sergey-alekseev's [seen error](https://github.com/github/licensed/pull/232#issuecomment-569618866)
   - the reason to parallelize the calls is that `yarn info` is slow.  that call is still parallelized 👍 
3. nit cleanup on the yarn fixture