### PR TITLE
add isc license to allowed by default

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,6 +85,7 @@ allowed:
   - bsd-2-clause
   - bsd-3-clause
   - cc0-1.0
+  - isc
 
 # These dependencies are explicitly ignored.
 # They shouldn't be cached at all, and will not have cached metadata written to the repo.


### PR DESCRIPTION
During testing the yarn source I found out a number of packages have the ISC license (98 out of 1394 in my case). E.g. https://github.com/isaacs/chownr/blob/v1.1.3/LICENSE.

[ci skip]