### PR TITLE
Use `yarn licenses` to get URLs

### DIFF
--- a/test/sources/yarn_test.rb
+++ b/test/sources/yarn_test.rb
@@ -47,7 +47,6 @@ if Licensed::Shell.tool_available?("yarn")
           assert_equal "yarn", dep.record["type"]
           assert_equal "5.2.0", dep.version
           assert dep.record["homepage"]
-          assert dep.record["summary"]
         end
       end
 
@@ -57,7 +56,6 @@ if Licensed::Shell.tool_available?("yarn")
           assert dep
           assert_equal "1.0.3", dep.version
           assert dep.record["homepage"]
-          assert dep.record["summary"]
         end
       end
 


### PR DESCRIPTION
Closes https://github.com/github/licensed/issues/235

✨ @sergey-alekseev for highlighting that `yarn licenses` includes a url for each dependency.  It's a little odd to be calling `yarn licenses` and then ignoring the returned license data but 🤷‍♂ it's what makes things easy.

This PR replaces the `N` calls to `yarn info` with 1 call to `yarn licenses`, which should drop runtime pretty significantly for projects with large numbers of dependencies.

@sergey-alekseev can you give this a shot and let me know the performance impact vs https://github.com/github/licensed/pull/233#issuecomment-570061513?  It's silly that this ended up as a new PR, but my original response asking for a new issue was under the assumption that changes were needed to the underlying command and sourcing infrastructure.

Once this is merged, I'll cut a new release to get the yarn source into the wild.