### PR TITLE
Remove Configuration < AppConfiguration inheritance

### DIFF
--- a/lib/licensed/commands/environment.rb
+++ b/lib/licensed/commands/environment.rb
@@ -23,14 +23,14 @@ module Licensed
             "allowed" => config["allowed"],
             "ignored" => config["ignored"],
             "reviewed" => config["reviewed"],
-            "version_strategy" => self.version_strategy
+            "version_strategy" => self.version_strategy,
+            "root" => config.root
           }
         end
       end
 
       def run(**options)
         super do |report|
-          report["root"] = config.root
           report["git_repo"] = Licensed::Git.git_repo?
         end
       end

--- a/lib/licensed/git.rb
+++ b/lib/licensed/git.rb
@@ -11,7 +11,9 @@ module Licensed
       # or nil if not in a git repository.
       def repository_root
         return unless available?
-        Licensed::Shell.execute("git", "rev-parse", "--show-toplevel", allow_failure: true)
+        root = Licensed::Shell.execute("git", "rev-parse", "--show-toplevel", allow_failure: true)
+        return nil if root.empty?
+        root
       end
 
       # Returns true if a git repository is found, false otherwise

--- a/test/commands/command_test.rb
+++ b/test/commands/command_test.rb
@@ -74,8 +74,8 @@ describe Licensed::Commands::Command do
 
   it "reports errors found on a dependency" do
     dependency_name = "#{apps.first["name"]}.test.dependency"
-    configuration.apps.first["test"] = { errors: ["error"] }
-    refute command.run
+    proc = lambda { |app, source, dep| dep.errors << "error" }
+    refute command.run(dependency_proc: proc)
     report = command.reporter.report.all_reports.find { |report| report.name == dependency_name }
     assert report
     assert_includes report.errors, "error"

--- a/test/commands/environment_test.rb
+++ b/test/commands/environment_test.rb
@@ -28,7 +28,6 @@ describe Licensed::Commands::Environment do
       command.run
 
       report = reporter.report
-      assert_equal config.root, report["root"]
       assert_equal Licensed::Git.git_repo?, report["git_repo"]
     end
 

--- a/test/commands/list_test.rb
+++ b/test/commands/list_test.rb
@@ -3,17 +3,13 @@ require "test_helper"
 
 describe Licensed::Commands::List do
   let(:reporter) { TestReporter.new }
-  let(:config) { Licensed::Configuration.new }
-  let(:source) { TestSource.new(config) }
+  let(:apps) { [] }
+  let(:source_config) { {} }
+  let(:config) { Licensed::Configuration.new("apps" => apps, "sources" => { "test" => true }, "test" => source_config) }
   let(:command) { Licensed::Commands::List.new(config: config) }
   let(:fixtures) { File.expand_path("../../fixtures", __FILE__) }
 
   before do
-    config.apps.each do |app|
-      app.sources.clear
-      app.sources << source
-    end
-
     Spy.on(command, :create_reporter).and_return(reporter)
   end
 
@@ -22,22 +18,23 @@ describe Licensed::Commands::List do
       let(:source_type) { source_class.type }
       let(:config_file) { File.join(fixtures, "command/#{source_type}.yml") }
       let(:config) { Licensed::Configuration.load_from(config_file) }
-      let(:source) { source_class.new(config) }
-      let(:expected_dependency) { config["expected_dependency"] }
 
       it "lists dependencies" do
         config.apps.each do |app|
-          enabled = Dir.chdir(app.source_path) { source.enabled? }
+          enabled = Dir.chdir(app.source_path) { app.sources.any? { |source| source.enabled? } }
           next unless enabled
 
           command.run
           app_report = reporter.report.reports.find { |app_report| app_report.target == app }
           assert app_report
 
-          source_report = app_report.reports.find { |source_report| source_report.target == source }
-          assert source_report
+          app.sources.each do |source|
+            source_report = app_report.reports.find { |source_report| source_report.target == source }
+            assert source_report
 
-          assert source_report.reports.find { |dependency_report| dependency_report.name.include?(expected_dependency) }
+            expected_dependency = app["expected_dependency"]
+            assert source_report.reports.find { |dependency_report| dependency_report.name.include?(expected_dependency) }
+          end
         end
       end
     end
@@ -49,13 +46,29 @@ describe Licensed::Commands::List do
     assert dependencies.any? { |dependency| dependency.name == "licensed.test.dependency" }
     count = dependencies.size
 
-    config.ignore("type" => "test", "name" => "dependency")
+    config.apps.each do |app|
+      app.ignore("type" => "test", "name" => "dependency")
+    end
+
     command.run
     dependencies = reporter.report.all_reports
     refute dependencies.any? { |dependency| dependency.name == "licensed.test.dependency" }
     ignored_count = dependencies.size
 
-    assert_equal count - 1, ignored_count
+    assert_equal count - config.apps.size, ignored_count
+  end
+
+  it "changes the current directory to app.source_path while running" do
+    config.apps.each do |app|
+      app["source_path"] = fixtures
+    end
+
+    command.run
+
+    reports = reporter.report.all_reports
+    dependency_report = reports.find { |dependency| dependency.name == "licensed.test.dependency" }
+    assert dependency_report
+    assert_equal fixtures, dependency_report[:dependency].path
   end
 
   describe "with multiple apps" do
@@ -73,22 +86,12 @@ describe Licensed::Commands::List do
         }
       ]
     end
-    let(:config) { Licensed::Configuration.new("apps" => apps) }
 
     it "lists dependencies for all apps" do
       command.run
-      apps.each do |app|
+      config.apps.each do |app|
         assert reporter.report.reports.find { |report| report.name == app["name"] }
       end
-    end
-  end
-
-  describe "with app.source_path" do
-    let(:config) { Licensed::Configuration.new("source_path" => fixtures) }
-
-    it "changes the current directory to app.source_path while running" do
-      command.run
-      assert_equal fixtures, source.dependencies.first.record["dir"]
     end
   end
 end

--- a/test/commands/status_test.rb
+++ b/test/commands/status_test.rb
@@ -4,19 +4,17 @@ require "test_helper"
 describe Licensed::Commands::Status do
   let(:cache_path) { Dir.mktmpdir }
   let(:reporter) { TestReporter.new }
-  let(:config) { Licensed::Configuration.new("cache_path" => cache_path) }
-  let(:source) { TestSource.new(config) }
+  let(:apps) { [] }
+  let(:source_config) { {} }
+  let(:config) { Licensed::Configuration.new("apps" => apps, "cache_path" => cache_path, "sources" => { "test" => true }, "test" => source_config) }
   let(:verifier) { Licensed::Commands::Status.new(config: config) }
+  let(:fixtures) { File.expand_path("../../fixtures", __FILE__) }
 
   before do
-    config.apps.each do |app|
-      app.sources.clear
-      app.sources << source
-    end
-
     Spy.on(verifier, :create_reporter).and_return(reporter)
 
-    generator = Licensed::Commands::Cache.new(config: config.dup)
+    generator_config = Marshal.load(Marshal.dump(config))
+    generator = Licensed::Commands::Cache.new(config: generator_config)
     Spy.on(generator, :create_reporter).and_return(TestReporter.new)
     generator.run(force: true)
   end
@@ -27,8 +25,8 @@ describe Licensed::Commands::Status do
     end
   end
 
-  def dependency_errors(dependency_name = "dependency")
-    app_report = reporter.report.reports.find { |app_report| app_report.name == config["name"] }
+  def dependency_errors(app, source, dependency_name = "dependency")
+    app_report = reporter.report.reports.find { |app_report| app_report.name == app["name"] }
     assert app_report
 
     source_report = app_report.reports.find { |source_report| source_report.target == source }
@@ -40,94 +38,174 @@ describe Licensed::Commands::Status do
 
   it "warns if license is not allowed" do
     verifier.run
-    assert_includes dependency_errors, "license needs review: mit"
+    config.apps.each do |app|
+      app.sources.each do |source|
+        assert_includes dependency_errors(app, source), "license needs review: mit"
+      end
+    end
   end
 
   it "does not warn if license is allowed" do
-    config.allow "mit"
+    config.apps.each do |app|
+      app.allow "mit"
+    end
+
     verifier.run
-    refute_includes dependency_errors, "license needs review: mit"
+    config.apps.each do |app|
+      app.sources.each do |source|
+        refute_includes dependency_errors(app, source), "license needs review: mit"
+      end
+    end
   end
 
   it "does not warn if dependency is ignored" do
     verifier.run
-    assert dependency_errors.any?
+    config.apps.each do |app|
+      app.sources.each do |source|
+        assert dependency_errors(app, source).any?
+        app.ignore "type" => source.class.type, "name" => "dependency"
+      end
+    end
 
-    config.ignore "type" => "test", "name" => "dependency"
     verifier.run
 
-    assert dependency_errors.empty?
+    config.apps.each do |app|
+      app.sources.each do |source|
+        assert dependency_errors(app, source).empty?
+      end
+    end
   end
 
   it "does not warn if dependency is reviewed" do
     verifier.run
-    assert dependency_errors.any?
+    config.apps.each do |app|
+      app.sources.each do |source|
+        assert dependency_errors(app, source).any?
+        app.ignore "type" => source.class.type, "name" => "dependency"
+      end
+    end
 
-    config.review "type" => "test", "name" => "dependency"
     verifier.run
-    assert dependency_errors.empty?
+    config.apps.each do |app|
+      app.sources.each do |source|
+        assert dependency_errors(app, source).empty?
+      end
+    end
   end
 
   it "warns if license is empty" do
-    filename = config.cache_path.join("test/dependency.#{Licensed::DependencyRecord::EXTENSION}")
-    record = Licensed::DependencyRecord.new
-    record.save(filename)
+    config.apps.each do |app|
+      filename = app.cache_path.join("test/dependency.#{Licensed::DependencyRecord::EXTENSION}")
+      record = Licensed::DependencyRecord.new
+      record.save(filename)
+    end
 
     verifier.run
-    assert_includes dependency_errors, "missing license text"
+    config.apps.each do |app|
+      app.sources.each do |source|
+        assert_includes dependency_errors(app, source), "missing license text"
+      end
+    end
   end
 
   it "warns if record is empty with notices" do
-    filename = config.cache_path.join("test/dependency.#{Licensed::DependencyRecord::EXTENSION}")
-    record = Licensed::DependencyRecord.new(notices: ["notice"])
-    record.save(filename)
+    config.apps.each do |app|
+      filename = app.cache_path.join("test/dependency.#{Licensed::DependencyRecord::EXTENSION}")
+      record = Licensed::DependencyRecord.new(notices: ["notice"])
+      record.save(filename)
+    end
 
     verifier.run
-    assert_includes dependency_errors, "missing license text"
+    config.apps.each do |app|
+      app.sources.each do |source|
+        assert_includes dependency_errors(app, source), "missing license text"
+      end
+    end
   end
 
   it "does not warn if license is not empty" do
-    filename = config.cache_path.join("test/dependency.#{Licensed::DependencyRecord::EXTENSION}")
-    record = Licensed::DependencyRecord.new(licenses: ["license"])
-    record.save(filename)
+    config.apps.each do |app|
+      filename = app.cache_path.join("test/dependency.#{Licensed::DependencyRecord::EXTENSION}")
+      record = Licensed::DependencyRecord.new(licenses: ["license"])
+      record.save(filename)
+    end
 
     verifier.run
-    refute_includes dependency_errors, "missing license text"
+    config.apps.each do |app|
+      app.sources.each do |source|
+        refute_includes dependency_errors(app, source), "missing license text"
+      end
+    end
   end
 
   it "warns if versions do not match" do
-    filename = config.cache_path.join("test/dependency.#{Licensed::DependencyRecord::EXTENSION}")
-    record = Licensed::DependencyRecord.read(filename)
-    record["version"] = "9001"
-    record.save(filename)
+    config.apps.each do |app|
+      filename = app.cache_path.join("test/dependency.#{Licensed::DependencyRecord::EXTENSION}")
+      record = Licensed::DependencyRecord.read(filename)
+      record["version"] = "9001"
+      record.save(filename)
+    end
 
     verifier.run
-    assert_includes dependency_errors, "cached dependency record out of date"
+    config.apps.each do |app|
+      app.sources.each do |source|
+        assert_includes dependency_errors(app, source), "cached dependency record out of date"
+      end
+    end
   end
 
   it "warns if cached license data missing" do
-    FileUtils.rm config.cache_path.join("test/dependency.#{Licensed::DependencyRecord::EXTENSION}")
+    config.apps.each do |app|
+      FileUtils.rm app.cache_path.join("test/dependency.#{Licensed::DependencyRecord::EXTENSION}")
+    end
+
     verifier.run
-    assert_includes dependency_errors, "cached dependency record not found"
+    config.apps.each do |app|
+      app.sources.each do |source|
+        assert_includes dependency_errors(app, source), "cached dependency record not found"
+      end
+    end
   end
 
   it "does not warn if cached license data missing for ignored gem" do
-    FileUtils.rm config.cache_path.join("test/dependency.#{Licensed::DependencyRecord::EXTENSION}")
-    config.ignore "type" => "test", "name" => "dependency"
+    config.apps.each do |app|
+      FileUtils.rm app.cache_path.join("test/dependency.#{Licensed::DependencyRecord::EXTENSION}")
+      app.ignore "type" => "test", "name" => "dependency"
+    end
 
     verifier.run
-    refute_includes dependency_errors, "cached license data missing"
+    config.apps.each do |app|
+      app.sources.each do |source|
+        refute_includes dependency_errors(app, source), "cached dependency record not found"
+      end
+    end
   end
 
   it "does not include ignored dependencies in dependency counts" do
     verifier.run
     count = reporter.report.all_reports.size
 
-    config.ignore "type" => "test", "name" => "dependency"
+    config.apps.each do |app|
+      app.ignore "type" => "test", "name" => "dependency"
+    end
+
     verifier.run
     ignored_count = reporter.report.all_reports.size
 
-    assert_equal count - 1, ignored_count
+    assert_equal count - config.apps.size, ignored_count
+  end
+
+  it "changes the current directory to app.source_path while running" do
+    config.apps.each do |app|
+      app["source_path"] = fixtures
+    end
+
+    verifier.run
+
+    reports = reporter.report.all_reports
+    dependency_report = reports.find { |dependency| dependency.name == "licensed.test.dependency" }
+    assert dependency_report
+    assert_equal fixtures, dependency_report[:dependency].path
   end
 
   describe "with multiple apps" do
@@ -145,7 +223,6 @@ describe Licensed::Commands::Status do
         }
       ]
     end
-    let(:config) { Licensed::Configuration.new("apps" => apps) }
 
     it "verifies dependencies for all apps" do
       verifier.run
@@ -155,26 +232,22 @@ describe Licensed::Commands::Status do
     end
   end
 
-  describe "with app.source_path" do
-    let(:fixtures) { File.expand_path("../../fixtures/npm", __FILE__) }
-    let(:config) { Licensed::Configuration.new("source_path" => fixtures, "cache_path" => cache_path) }
-
-    it "changes the current directory to app.source_path while running" do
-      verifier.run
-      assert_equal fixtures, source.dependencies.first.record["dir"]
-    end
-  end
-
   describe "with explicit dependency file path" do
-    let(:source) { TestSource.new(config, "dependency/path", "name" => "dependency", "cache_path" => cache_path) }
+    let(:source_config) { { name: "dependency/path" } }
 
     it "verifies content at explicit path" do
-      filename = config.cache_path.join("test/dependency/path.#{Licensed::DependencyRecord::EXTENSION}")
-      record = Licensed::DependencyRecord.new
-      record.save(filename)
+      config.apps.each do |app|
+        filename = app.cache_path.join("test/dependency/path.#{Licensed::DependencyRecord::EXTENSION}")
+        record = Licensed::DependencyRecord.new
+        record.save(filename)
+      end
 
       verifier.run
-      assert_includes dependency_errors("dependency/path"), "missing license text"
+      config.apps.each do |app|
+        app.sources.each do |source|
+          assert_includes dependency_errors(app, source, "dependency/path"), "missing license text"
+        end
+      end
     end
   end
 
@@ -183,69 +256,88 @@ describe Licensed::Commands::Status do
     let(:mit) { Licensed::DependencyRecord::License.new(Licensee::License.find("mit").to_s) }
     let(:agpl_3) { Licensed::DependencyRecord::License.new(Licensee::License.find("agpl-3.0").to_s) }
     let(:readme_mit) { Licensed::DependencyRecord::License.new("## License:\n\nMIT") }
-    let(:record_file) { config.cache_path.join("test/dependency.#{Licensed::DependencyRecord::EXTENSION}") }
-    let(:record) { Licensed::DependencyRecord.read(record_file) }
 
     before do
-      config.allow("mit")
-      config.allow("bsd-3-clause")
+      config.apps.each do |app|
+        app.allow("mit")
+        app.allow("bsd-3-clause")
+      end
+    end
 
-      record.licenses.clear
+    def update_records(classification, *licenses)
+      config.apps.each do |app|
+        path = app.cache_path.join("test/dependency.#{Licensed::DependencyRecord::EXTENSION}")
+        record = Licensed::DependencyRecord.read(path)
+        record.licenses.clear
+        record.licenses.push(*licenses)
+        record["license"] = classification
+        record.save(path)
+      end
     end
 
     it "does not warn if the top level license field is allowed" do
       # licenses contains an unapproved license notice (agpl-3.0), but should not be checked
       # because the top level license field is allowed
-      record.licenses.push(mit, agpl_3)
-      record["license"] = "mit"
-      record.save(record_file)
+      update_records("mit", mit, agpl_3)
 
       verifier.run
-      assert dependency_errors.empty?
+      config.apps.each do |app|
+        app.sources.each do |source|
+          assert dependency_errors(app, source).empty?
+        end
+      end
     end
 
     it "warns if the top level license field is not allowed and not 'other'" do
-      record.licenses.push(mit, bsd_3)
       # both record license texts are approved, but licensed should only check
       # them when the record's top level license field is set to other
-      record["license"] = "agpl-3.0"
-      record.save(record_file)
+      update_records("agpl-3.0", mit, bsd_3)
 
       verifier.run
-      assert_includes dependency_errors, "license needs review: agpl-3.0"
+      config.apps.each do |app|
+        app.sources.each do |source|
+          assert_includes dependency_errors(app, source), "license needs review: agpl-3.0"
+        end
+      end
     end
 
     it "warns if any of the license notices is not allowed" do
       # licenses contains an unapproved license notice (agpl-3.0),
       # and will be checked because the top level license field is set to other
-      record.licenses.push(mit, agpl_3)
-      record["license"] = "other"
-      record.save(record_file)
+      update_records("other", mit, agpl_3)
 
       verifier.run
-      assert_includes dependency_errors, "license needs review: other"
+      config.apps.each do |app|
+        app.sources.each do |source|
+          assert_includes dependency_errors(app, source), "license needs review: other"
+        end
+      end
     end
 
     it "does not warn if all of the license notices are allowed" do
       # licenses contains only approved values, which pass status checks
       # when the top level license field is set to other
-      record.licenses.push(mit, bsd_3)
-      record["license"] = "other"
-      record.save(record_file)
+      update_records("other", mit, bsd_3)
 
       verifier.run
-      assert dependency_errors.empty?
+      config.apps.each do |app|
+        app.sources.each do |source|
+          assert dependency_errors(app, source).empty?
+        end
+      end
     end
 
     it "parses readme contents as well as license text" do
       # licenses includes content that will be matched as part of a README file,
       # but not as part of a LICENSE file
-      record.licenses.push(readme_mit, bsd_3)
-      record["license"] = "other"
-      record.save(record_file)
+      update_records("other", readme_mit, bsd_3)
 
       verifier.run
-      assert dependency_errors.empty?
+      config.apps.each do |app|
+        app.sources.each do |source|
+          assert dependency_errors(app, source).empty?
+        end
+      end
     end
   end
 end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -3,55 +3,52 @@ require "test_helper"
 
 describe Licensed::Configuration do
   let(:config) { Licensed::Configuration.new }
+  let(:app) { config.apps.first }
   let(:fixtures) { File.expand_path("../fixtures/config", __FILE__) }
 
-
-  it "accepts a license directory path option" do
-    config["cache_path"] = "path"
-    assert_equal config.root.join("path"), config.cache_path
-  end
-
-  it "sets default values" do
-    assert_equal Pathname.pwd, config.source_path
-    assert_equal config.root.join(".licenses"),
-                 config.cache_path
-    assert_equal File.basename(Dir.pwd), config["name"]
+  it "sets a default cache_path" do
+    assert_equal Pathname.pwd.join(".licenses"), app.cache_path
   end
 
   describe "load_from" do
-    it "loads a config from a relative directory path" do
-      relative_path = Pathname.new(fixtures).relative_path_from(Pathname.pwd)
-      config = Licensed::Configuration.load_from(relative_path)
-      assert_equal "licensed-yml", config["name"]
+    let(:config) { Licensed::Configuration.load_from(load_path) }
+
+    describe "a relative directory path" do
+      let(:load_path) { Pathname.new(fixtures).relative_path_from(Pathname.pwd) }
+      it "loads the configuration" do
+        assert_equal "licensed-yml", app["name"]
+      end
     end
 
-    it "loads a config from an absolute directory path" do
-      config = Licensed::Configuration.load_from(fixtures)
-      assert_equal "licensed-yml", config["name"]
+    describe "an absolute directory path" do
+      let(:load_path) { fixtures }
+      it "loads a config from an absolute directory path" do
+        assert_equal "licensed-yml", app["name"]
+      end
     end
 
-    it "loads a config from a relative file path" do
-      file = File.join(fixtures, "config.yml")
-      relative_path = Pathname.new(file).relative_path_from(Pathname.pwd)
-      config = Licensed::Configuration.load_from(relative_path)
-      assert_equal "config-yml", config["name"]
+    describe "a relative file path" do
+      let(:load_path) do
+        file = File.join(fixtures, "config.yml")
+        Pathname.new(file).relative_path_from(Pathname.pwd)
+      end
+      it "loads a config from a relative file path" do
+        assert_equal "config-yml", app["name"]
+      end
     end
 
-    it "loads a config from an absolute file path" do
-      file = File.join(fixtures, "config.yml")
-      config = Licensed::Configuration.load_from(file)
-      assert_equal "config-yml", config["name"]
+    describe "an absolute file path" do
+      let(:load_path) { File.join(fixtures, "config.yml") }
+      it "loads a config from an absolute file path" do
+        assert_equal "config-yml", app["name"]
+      end
     end
 
-    it "loads json configurations" do
-      file = File.join(fixtures, ".licensed.json")
-      config = Licensed::Configuration.load_from(file)
-      assert_equal "licensed-json", config["name"]
-    end
-
-    it "sets a default cache_path" do
-      config = Licensed::Configuration.load_from(fixtures)
-      assert_equal Pathname.pwd.join(".licenses"), config.cache_path
+    describe "a json configuration file" do
+      let(:load_path) { File.join(fixtures, ".licensed.json") }
+      it "loads json configurations" do
+        assert_equal "licensed-json", app["name"]
+      end
     end
 
     it "raises an error if a default config file is not found" do
@@ -70,8 +67,91 @@ describe Licensed::Configuration do
     end
   end
 
+  describe "apps" do
+    it "returns a default app if apps not specified in configuration" do
+      assert_equal 1, config.apps.size
+      assert_equal Pathname.pwd, app.source_path
+      assert_equal app.root.join(Licensed::AppConfiguration::DEFAULT_CACHE_PATH),
+                   app.cache_path
+      assert_equal File.basename(Dir.pwd), app["name"]
+    end
+
+    describe "from configuration options" do
+      let(:apps) do
+        [
+          {
+            "name" => "app1",
+            "override" => "override",
+            "cache_path" => "app1/vendor/licenses",
+            "source_path" => File.expand_path("../../", __FILE__)
+          },
+          {
+            "name" => "app2",
+            "cache_path" => "app2/vendor/licenses",
+            "source_path" => File.expand_path("../../", __FILE__)
+          }
+        ]
+      end
+      let(:config) do
+        Licensed::Configuration.new("apps" => apps,
+                                    "override" => "default",
+                                    "default" => "default")
+      end
+
+      it "returns apps from configuration" do
+        assert_equal 2, config.apps.size
+        assert_equal "app1", config.apps[0]["name"]
+        assert_equal "app2", config.apps[1]["name"]
+      end
+
+      it "includes default options" do
+        assert_equal "default", config.apps[0]["default"]
+        assert_equal "default", config.apps[1]["default"]
+      end
+
+      it "overrides default options" do
+        assert_equal "override", config.apps[0]["override"]
+      end
+
+      it "uses a default name" do
+        apps[0].delete("name")
+        assert_equal "licensed", config.apps[0]["name"]
+      end
+
+      it "uses a default cache path" do
+        apps[0].delete("cache_path")
+        assert_equal config.apps[0].root.join(".licenses/app1"),
+                     config.apps[0].cache_path
+      end
+
+      it "appends the app name to an inherited cache path" do
+        apps[0].delete("cache_path")
+        config = Licensed::Configuration.new("apps" => apps,
+                                             "cache_path" => "vendor/cache")
+        assert_equal config.apps[0].root.join("vendor/cache/app1"),
+                     config.apps[0].cache_path
+      end
+
+      it "does not append the app name to an explicit cache path" do
+        refute config.apps[0].cache_path.to_s.end_with? config.apps[0]["name"]
+      end
+
+      it "raises an error if source_path is not set on an app" do
+        apps[0].delete("source_path")
+        assert_raises ::Licensed::Configuration::LoadError do
+          Licensed::Configuration.new("apps" => apps)
+        end
+      end
+    end
+  end
+end
+
+describe Licensed::AppConfiguration do
+  let(:config) { Licensed::AppConfiguration.new({ "source_path" => Dir.pwd }) }
+  let(:fixtures) { File.expand_path("../fixtures/config", __FILE__) }
+
   describe "ignore" do
-    let(:package) { { "type" => "bundler", "name" => "bundler" } }
+    let(:package) { { "type" => "go", "name" => "github.com/github/licensed/package" } }
 
     it "marks the dependency as ignored" do
       refute config.ignored?(package)
@@ -80,8 +160,6 @@ describe Licensed::Configuration do
     end
 
     describe "with glob patterns" do
-      let(:package) { { "type" => "go", "name" => "github.com/github/licensed/package" } }
-
       it "does not match trailing ** to multiple path segments" do
         refute config.ignored?(package)
         config.ignore package.merge("name" => "github.com/github/**")
@@ -123,10 +201,6 @@ describe Licensed::Configuration do
         config.ignore package.merge("name" => "GITHUB.com/github/**")
         refute config.ignored?(package)
       end
-    end
-
-    it "works with glob patterns" do
-      refute config.ignored?(package)
     end
   end
 
@@ -180,91 +254,16 @@ describe Licensed::Configuration do
     end
   end
 
-  describe "apps" do
-    it "defaults to returning itself" do
-      assert_equal [config], config.apps
-    end
-
-    describe "from configuration options" do
-      let(:apps) do
-        [
-          {
-            "name" => "app1",
-            "override" => "override",
-            "cache_path" => "app1/vendor/licenses",
-            "source_path" => File.expand_path("../../", __FILE__)
-          },
-          {
-            "name" => "app2",
-            "cache_path" => "app2/vendor/licenses",
-            "source_path" => File.expand_path("../../", __FILE__)
-          }
-        ]
-      end
-      let(:config) do
-        Licensed::Configuration.new("apps" => apps,
-                                    "override" => "default",
-                                    "default" => "default")
-      end
-
-      it "returns apps from configuration" do
-        assert_equal 2, config.apps.size
-        assert_equal "app1", config.apps[0]["name"]
-        assert_equal "app2", config.apps[1]["name"]
-      end
-
-      it "includes default options" do
-        assert_equal "default", config.apps[0]["default"]
-        assert_equal "default", config.apps[1]["default"]
-      end
-
-      it "overrides default options" do
-        assert_equal "default", config["override"]
-        assert_equal "override", config.apps[0]["override"]
-      end
-
-      it "uses a default name" do
-        apps[0].delete("name")
-        assert_equal "licensed", config.apps[0]["name"]
-      end
-
-      it "uses a default cache path" do
-        apps[0].delete("cache_path")
-        assert_equal config.root.join(".licenses/app1"),
-                     config.apps[0].cache_path
-      end
-
-      it "appends the app name to an inherited cache path" do
-        apps[0].delete("cache_path")
-        config = Licensed::Configuration.new("apps" => apps,
-                                             "cache_path" => "vendor/cache")
-        assert_equal config.root.join("vendor/cache/app1"),
-                     config.apps[0].cache_path
-      end
-
-      it "does not append the app name to an explicit cache path" do
-        refute config.apps[0].cache_path.to_s.end_with? config.apps[0]["name"]
-      end
-
-      it "raises an error if source_path is not set on an app" do
-        apps[0].delete("source_path")
-        assert_raises ::Licensed::Configuration::LoadError do
-          Licensed::Configuration.new("apps" => apps)
-        end
-      end
-    end
-  end
-
   describe "root" do
     it "can be set to a path from a configuration file" do
       file = File.join(fixtures, "root.yml")
-      config = Licensed::Configuration.load_from(file)
+      config = Licensed::Configuration.load_from(file).apps.first
       assert_equal File.expand_path("../..", fixtures), config.root.to_s
     end
 
     it "can be set to true in a configuration file" do
       file = File.join(fixtures, "root_at_configuration.yml")
-      config = Licensed::Configuration.load_from(file)
+      config = Licensed::Configuration.load_from(file).apps.first
       assert_equal fixtures, config.root.to_s
     end
 

--- a/test/fixtures/command/bower.yml
+++ b/test/fixtures/command/bower.yml
@@ -1,3 +1,5 @@
 expected_dependency: jquery
 source_path: test/fixtures/bower
 cache_path: test/fixtures/bower/.licenses
+sources:
+  bower: true

--- a/test/fixtures/command/bundler.yml
+++ b/test/fixtures/command/bundler.yml
@@ -1,3 +1,5 @@
 expected_dependency: semantic
 source_path: test/fixtures/bundler
 cache_path: test/fixtures/bundler/.licenses
+sources:
+  bundler: true

--- a/test/fixtures/command/cabal.yml
+++ b/test/fixtures/command/cabal.yml
@@ -7,3 +7,5 @@ cabal:
     - user
     - test/fixtures/cabal/dist-newstyle/packagedb/ghc-<ghc_version>
     - ~/.cabal/store/ghc-<ghc_version>/package.db
+sources:
+  cabal: true

--- a/test/fixtures/command/composer.yml
+++ b/test/fixtures/command/composer.yml
@@ -1,3 +1,5 @@
 expected_dependency: monolog/monolog
 source_path: test/fixtures/composer
 cache_path: test/fixtures/composer/.licenses
+sources:
+  composer: true

--- a/test/fixtures/command/dep.yml
+++ b/test/fixtures/command/dep.yml
@@ -3,3 +3,5 @@ source_path: test/fixtures/go/src/test
 cache_path: test/fixtures/go/.licenses
 dep:
   allow_ignored: true
+sources:
+  dep: true

--- a/test/fixtures/command/git_submodule.yml
+++ b/test/fixtures/command/git_submodule.yml
@@ -1,3 +1,5 @@
 expected_dependency: submodule
 source_path: test/fixtures/git_submodule/project
 cache_path: test/fixtures/git_submodule/.licenses
+sources:
+  git_submodule: true

--- a/test/fixtures/command/go.yml
+++ b/test/fixtures/command/go.yml
@@ -6,3 +6,6 @@ go:
 apps:
   - source_path: test/fixtures/go/src/test
   - source_path: test/fixtures/go
+
+sources:
+  go: true

--- a/test/fixtures/command/gradle.yml
+++ b/test/fixtures/command/gradle.yml
@@ -1,3 +1,5 @@
 expected_dependency: io.netty:netty-all
 source_path: test/fixtures/gradle
 cache_path: test/fixtures/gradle/.licenses
+sources:
+  gradle: true

--- a/test/fixtures/command/manifest.yml
+++ b/test/fixtures/command/manifest.yml
@@ -3,3 +3,5 @@ source_path: test/fixtures/manifest
 cache_path: test/fixtures/manifest/.licenses
 manifest:
   path: test/fixtures/manifest/manifest.yml
+sources:
+  manifest: true

--- a/test/fixtures/command/mix.yml
+++ b/test/fixtures/command/mix.yml
@@ -1,3 +1,5 @@
 expected_dependency: phoenix
 source_path: test/fixtures/mix
 cache_path: test/fixtures/mix/.licenses
+sources:
+  mix: true

--- a/test/fixtures/command/npm.yml
+++ b/test/fixtures/command/npm.yml
@@ -1,3 +1,5 @@
 expected_dependency: autoprefixer
 source_path: test/fixtures/npm
 cache_path: test/fixtures/npm/.licenses
+sources:
+  npm: true

--- a/test/fixtures/command/pip.yml
+++ b/test/fixtures/command/pip.yml
@@ -3,3 +3,5 @@ source_path: test/fixtures/pip
 cache_path: test/fixtures/pip/.licenses
 python:
   virtual_env_dir: test/fixtures/pip/venv
+sources:
+  pip: true

--- a/test/fixtures/command/pipenv.yml
+++ b/test/fixtures/command/pipenv.yml
@@ -1,0 +1,7 @@
+expected_dependency: pylint
+source_path: test/fixtures/pipenv
+cache_path: test/fixtures/pipenv/.licenses
+python:
+  virtual_env_dir: test/fixtures/pip/venv
+sources:
+  pipenv: true

--- a/test/fixtures/command/yarn.yml
+++ b/test/fixtures/command/yarn.yml
@@ -1,3 +1,5 @@
 expected_dependency: autoprefixer
 source_path: test/fixtures/yarn
 cache_path: test/fixtures/yarn/.licenses
+sources:
+  yarn: true

--- a/test/fixtures/migrations/v2/.licensed.yml
+++ b/test/fixtures/migrations/v2/.licensed.yml
@@ -1,5 +1,4 @@
 name: migration-v2
-cache_path: cache
 
 sources:
   rubygem: true
@@ -17,7 +16,9 @@ rubygem:
 
 apps:
   - source_path: "."
+    cache_path: cache
   - source_path: "."
+    cache_path: cache
     reviewed:
       rubygem: # to verify that individual app configurations are updated as well
         - test

--- a/test/git_test.rb
+++ b/test/git_test.rb
@@ -3,6 +3,8 @@ require "test_helper"
 require "tmpdir"
 
 describe Licensed::Git do
+  let(:root) { File.expand_path("../..", __FILE__) }
+
   describe "git_repo?" do
     it "returns true in a git repo" do
       # licensed is a git repo
@@ -13,6 +15,18 @@ describe Licensed::Git do
       Dir.chdir(Dir.tmpdir) do
         refute Licensed::Git.git_repo?
       end
+    end
+  end
+
+  describe "repository_root" do
+    it "returns nil when not in a git repo" do
+      Dir.chdir(Dir.tmpdir) do
+        assert_nil Licensed::Git.repository_root
+      end
+    end
+
+    it "returns the repository root when in a git repo" do
+      assert_equal root, Licensed::Git.repository_root
     end
   end
 end

--- a/test/reporters/cache_reporter_test.rb
+++ b/test/reporters/cache_reporter_test.rb
@@ -4,11 +4,10 @@ require "test_helper"
 describe Licensed::Reporters::CacheReporter do
   let(:shell) { TestShell.new }
   let(:reporter) { Licensed::Reporters::CacheReporter.new(shell) }
-  let(:app) { { "name" => "app" } }
-  let(:config) { Licensed::Configuration.new }
-  let(:source) { TestSource.new(config) }
+  let(:app) { Licensed::AppConfiguration.new({ "source_path" => Dir.pwd }) }
+  let(:source) { TestSource.new(app) }
   let(:dependency) { source.dependencies.first }
-  let(:command) { TestCommand.new(config: config, reporter: reporter) }
+  let(:command) { TestCommand.new(config: nil, reporter: reporter) }
 
   describe "#report_app" do
     it "runs a block" do

--- a/test/reporters/json_reporter_test.rb
+++ b/test/reporters/json_reporter_test.rb
@@ -5,11 +5,10 @@ require "json"
 describe Licensed::Reporters::JsonReporter do
   let(:shell) { TestShell.new }
   let(:reporter) { Licensed::Reporters::JsonReporter.new(shell) }
-  let(:app) { { "name" => "app" } }
-  let(:config) { Licensed::Configuration.new }
-  let(:source) { TestSource.new(config) }
+  let(:app) { Licensed::AppConfiguration.new({ "source_path" => Dir.pwd }) }
+  let(:source) { TestSource.new(app) }
   let(:dependency) { source.dependencies.first }
-  let(:command) { TestCommand.new(config: config, reporter: reporter) }
+  let(:command) { TestCommand.new(config: nil, reporter: reporter) }
 
   describe "#report_run" do
     it "runs a block" do

--- a/test/reporters/list_reporter_test.rb
+++ b/test/reporters/list_reporter_test.rb
@@ -4,11 +4,10 @@ require "test_helper"
 describe Licensed::Reporters::ListReporter do
   let(:shell) { TestShell.new }
   let(:reporter) { Licensed::Reporters::ListReporter.new(shell) }
-  let(:app) { { "name" => "app" } }
-  let(:config) { Licensed::Configuration.new }
-  let(:source) { TestSource.new(config) }
+  let(:app) { Licensed::AppConfiguration.new({ "source_path" => Dir.pwd }) }
+  let(:source) { TestSource.new(app) }
   let(:dependency) { source.dependencies.first }
-  let(:command) { TestCommand.new(config: config, reporter: reporter) }
+  let(:command) { TestCommand.new(config: nil, reporter: reporter) }
 
   describe "#report_app" do
     it "runs a block" do

--- a/test/reporters/reporter_test.rb
+++ b/test/reporters/reporter_test.rb
@@ -3,11 +3,10 @@ require "test_helper"
 
 describe Licensed::Reporters::Reporter do
   let(:reporter) { Licensed::Reporters::Reporter.new }
-  let(:app) { { "name" => "app" } }
-  let(:config) { Licensed::Configuration.new }
-  let(:source) { TestSource.new(config) }
+  let(:app) { Licensed::AppConfiguration.new({ "source_path" => Dir.pwd }) }
+  let(:source) { TestSource.new(app) }
   let(:dependency) { source.dependencies.first }
-  let(:command) { TestCommand.new(config: config, reporter: reporter) }
+  let(:command) { TestCommand.new(config: nil, reporter: reporter) }
 
   describe "#report_run" do
     it "runs a block" do

--- a/test/reporters/status_reporter_test.rb
+++ b/test/reporters/status_reporter_test.rb
@@ -4,11 +4,10 @@ require "test_helper"
 describe Licensed::Reporters::StatusReporter do
   let(:shell) { TestShell.new }
   let(:reporter) { Licensed::Reporters::StatusReporter.new(shell) }
-  let(:app) { { "name" => "app" } }
-  let(:config) { Licensed::Configuration.new }
-  let(:source) { TestSource.new(config) }
+  let(:app) { Licensed::AppConfiguration.new({ "source_path" => Dir.pwd }) }
+  let(:source) { TestSource.new(app) }
   let(:dependency) { source.dependencies.first }
-  let(:command) { TestCommand.new(config: config, reporter: reporter) }
+  let(:command) { TestCommand.new(config: nil, reporter: reporter) }
 
   describe "#report_app" do
     it "runs a block" do

--- a/test/reporters/yaml_reporter_test.rb
+++ b/test/reporters/yaml_reporter_test.rb
@@ -4,11 +4,10 @@ require "test_helper"
 describe Licensed::Reporters::JsonReporter do
   let(:shell) { TestShell.new }
   let(:reporter) { Licensed::Reporters::YamlReporter.new(shell) }
-  let(:app) { { "name" => "app" } }
-  let(:config) { Licensed::Configuration.new }
-  let(:source) { TestSource.new(config) }
+  let(:app) { Licensed::AppConfiguration.new({ "source_path" => Dir.pwd }) }
+  let(:source) { TestSource.new(app) }
   let(:dependency) { source.dependencies.first }
-  let(:command) { TestCommand.new(config: config, reporter: reporter) }
+  let(:command) { TestCommand.new(config: nil, reporter: reporter) }
 
   describe "#report_run" do
     it "runs a block" do

--- a/test/sources/bower_test.rb
+++ b/test/sources/bower_test.rb
@@ -5,7 +5,7 @@ require "tmpdir"
 if Licensed::Shell.tool_available?("bower")
   describe Licensed::Sources::Bower do
     let(:fixtures) { File.expand_path("../../fixtures/bower", __FILE__) }
-    let(:config) { Licensed::Configuration.new }
+    let(:config) { Licensed::AppConfiguration.new({ "source_path" => Dir.pwd }) }
     let(:source) { Licensed::Sources::Bower.new(config) }
 
     describe "enabled?" do

--- a/test/sources/bundler_test.rb
+++ b/test/sources/bundler_test.rb
@@ -5,7 +5,8 @@ require "tmpdir"
 if Licensed::Shell.tool_available?("bundle")
   describe Licensed::Sources::Bundler do
     let(:fixtures) { File.expand_path("../../fixtures/bundler", __FILE__) }
-    let(:config) { Licensed::Configuration.new }
+    let(:source_config) { Hash.new }
+    let(:config) { Licensed::AppConfiguration.new({ "source_path" => Dir.pwd }, "bundler" => source_config) }
     let(:source) { Licensed::Sources::Bundler.new(config) }
 
     before do
@@ -139,7 +140,7 @@ if Licensed::Shell.tool_available?("bundle")
       end
 
       describe "when bundler is not explicitly listed as a dependency" do
-        let(:config) { Licensed::Configuration.new("bundler" => { "without" => "bundler" }) }
+        let(:source_config) { { "without" => "bundler" } }
 
         it "does not include bundler as a dependency" do
           Dir.chdir(fixtures) do
@@ -149,7 +150,7 @@ if Licensed::Shell.tool_available?("bundle")
       end
 
       describe "with excluded groups in the configuration" do
-        let(:config) { Licensed::Configuration.new("bundler" => { "without" => "exclude" }) }
+        let(:source_config) { { "without" => "exclude" } }
 
         it "ignores gems in the excluded groups" do
           Dir.chdir(fixtures) do
@@ -219,6 +220,7 @@ if Licensed::Shell.tool_available?("bundle")
     end
 
     describe "bundler_exe" do
+
       it "returns bundle if not configured" do
         assert_equal "bundle", source.bundler_exe
       end

--- a/test/sources/cabal_test.rb
+++ b/test/sources/cabal_test.rb
@@ -5,7 +5,7 @@ require "tmpdir"
 if Licensed::Shell.tool_available?("ghc")
   describe Licensed::Sources::Cabal do
     let(:fixtures) { File.expand_path("../../fixtures/cabal", __FILE__) }
-    let(:config) { Licensed::Configuration.new }
+    let(:config) { Licensed::AppConfiguration.new({ "source_path" => Dir.pwd }) }
     let(:source) { Licensed::Sources::Cabal.new(config) }
 
     describe "enabled?" do

--- a/test/sources/composer_test.rb
+++ b/test/sources/composer_test.rb
@@ -5,7 +5,7 @@ require "fileutils"
 
 if Licensed::Shell.tool_available?("php")
   describe Licensed::Sources::Composer do
-    let(:config) { Licensed::Configuration.new }
+    let(:config) { Licensed::AppConfiguration.new({ "source_path" => Dir.pwd }) }
     let(:fixtures) { File.expand_path("../../fixtures/composer", __FILE__) }
     let(:source) { Licensed::Sources::Composer.new(config) }
 

--- a/test/sources/dep_test.rb
+++ b/test/sources/dep_test.rb
@@ -4,7 +4,7 @@ require "tmpdir"
 
 describe Licensed::Sources::Dep do
   let(:fixtures) { File.expand_path("../../fixtures/go/src/test", __FILE__) }
-  let(:config) { Licensed::Configuration.new("dep" => { "allow_ignored" => true }) }
+  let(:config) { Licensed::AppConfiguration.new({ "dep" => { "allow_ignored" => true }, "source_path" => Dir.pwd }) }
   let(:source) { Licensed::Sources::Dep.new(config) }
 
   describe "enabled?" do

--- a/test/sources/git_submodule_test.rb
+++ b/test/sources/git_submodule_test.rb
@@ -5,7 +5,7 @@ require "tmpdir"
 if Licensed::Shell.tool_available?("git")
   describe Licensed::Sources::GitSubmodule do
     let(:fixtures) { File.expand_path("../../fixtures/git_submodule/project", __FILE__) }
-    let(:config) { Licensed::Configuration.new }
+    let(:config) { Licensed::AppConfiguration.new({ "source_path" => Dir.pwd }) }
     let(:source) { Licensed::Sources::GitSubmodule.new(config) }
     let(:submodule_repo_path) { File.expand_path("../submodule", fixtures) }
     let(:recursive_repo_path) { File.expand_path("../nested", fixtures) }

--- a/test/sources/go_test.rb
+++ b/test/sources/go_test.rb
@@ -6,7 +6,7 @@ if Licensed::Shell.tool_available?("go")
   describe Licensed::Sources::Go do
     let(:gopath) { File.expand_path("../../fixtures/go", __FILE__) }
     let(:fixtures) { File.join(gopath, "src/test") }
-    let(:config) { Licensed::Configuration.new("go" => { "GOPATH" => gopath }) }
+    let(:config) { Licensed::AppConfiguration.new({ "go" => { "GOPATH" => gopath }, "source_path" => Dir.pwd }) }
     let(:source) { Licensed::Sources::Go.new(config) }
 
     describe "enabled?" do

--- a/test/sources/gradle_test.rb
+++ b/test/sources/gradle_test.rb
@@ -5,7 +5,7 @@ require "fileutils"
 
 describe Licensed::Sources::Gradle do
   let(:fixtures) { File.expand_path("../../fixtures/gradle", __FILE__) }
-  let(:config) { Licensed::Configuration.new }
+  let(:config) { Licensed::AppConfiguration.new({ "source_path" => Dir.pwd }) }
   let(:source) { Licensed::Sources::Gradle.new(config) }
 
   describe "enabled?" do
@@ -52,7 +52,7 @@ end
 
 describe Licensed::Sources::Gradle::Dependency do
   let(:fixtures) { File.expand_path("../../fixtures/gradle", __FILE__) }
-  let(:config) { Licensed::Configuration.new }
+  let(:config) { Licensed::AppConfiguration.new({ "source_path" => Dir.pwd }) }
   let(:source) { Licensed::Sources::Gradle.new(config) }
 
   it "returns the dependency license" do

--- a/test/sources/helpers/content_versioning_test.rb
+++ b/test/sources/helpers/content_versioning_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 
 describe Licensed::Sources::ContentVersioning do
   let(:fixtures) { File.expand_path("../../../fixtures/command", __FILE__) }
-  let(:config) { Licensed::Configuration.new }
+  let(:config) { Licensed::AppConfiguration.new({ "source_path" => Dir.pwd }) }
   let(:helper) do
     obj = mock.extend Licensed::Sources::ContentVersioning
     obj.stubs(:config).returns(config)

--- a/test/sources/manifest_test.rb
+++ b/test/sources/manifest_test.rb
@@ -4,7 +4,8 @@ require "tmpdir"
 
 describe Licensed::Sources::Manifest do
   let(:fixtures) { File.expand_path("../../fixtures/manifest", __FILE__) }
-  let(:config) { Licensed::Configuration.new("cache_path" => fixtures) }
+  let(:source_config) { Hash.new }
+  let(:config) { Licensed::AppConfiguration.new({ "source_path" => Dir.pwd, "cache_path" => fixtures, "manifest" => source_config }) }
   let(:source) { Licensed::Sources::Manifest.new(config) }
 
   describe "enabled?" do
@@ -121,7 +122,8 @@ describe Licensed::Sources::Manifest do
     end
 
     describe "from a generated manifest" do
-      let(:manifest_config) do
+      let(:fixtures) { File.expand_path("../../fixtures/manifest/generated_manifest", __FILE__) }
+      let(:source_config) do
         {
           # exclude all files that aren't in the generated manifest test folder
           "exclude" => [
@@ -130,10 +132,9 @@ describe Licensed::Sources::Manifest do
           ]
         }
       end
-      let(:config) { Licensed::Configuration.new("manifest" => manifest_config) }
 
       it "excludes files matching patterns in the \"exclude\" setting" do
-        config["manifest"]["dependencies"] = {
+        source_config["dependencies"] = {
           "manifest_test" => "**/*"
         }
         manifest = source.manifest
@@ -141,7 +142,7 @@ describe Licensed::Sources::Manifest do
       end
 
       it "matches files to dependencies using glob patterns" do
-        config["manifest"]["dependencies"] = {
+        source_config["dependencies"] = {
           "manifest_test" => ["**/*", "!**/nested/*"],
           "nested" => "**/nested/*"
         }
@@ -156,7 +157,7 @@ describe Licensed::Sources::Manifest do
       end
 
       it "raises an error if the \"dependencies\" setting is empty" do
-        config["manifest"]["dependencies"] = {}
+        source_config["dependencies"] = {}
 
         err = assert_raises Licensed::Sources::Source::Error do
           source.manifest
@@ -166,7 +167,7 @@ describe Licensed::Sources::Manifest do
       end
 
       it "raises an error if any files match multiple dependencies" do
-        config["manifest"]["dependencies"] = {
+        source_config["dependencies"] = {
           "manifest_test" => "**/*",
           "manifest_test_2" => "**/*"
         }
@@ -178,7 +179,7 @@ describe Licensed::Sources::Manifest do
       end
 
       it "raises an error if any files do not match any dependencies" do
-        config["manifest"]["dependencies"] = {
+        source_config["dependencies"] = {
           "manifest_test" => "!**/nested/*"
         }
 

--- a/test/sources/mix_test.rb
+++ b/test/sources/mix_test.rb
@@ -5,7 +5,7 @@ require "tmpdir"
 if Licensed::Shell.tool_available?("mix")
   describe Licensed::Sources::Mix do
     let(:fixtures) { File.expand_path("../../fixtures/mix", __FILE__) }
-    let(:config) { Licensed::Configuration.new }
+    let(:config) { Licensed::AppConfiguration.new({ "source_path" => Dir.pwd }) }
     let(:source) { Licensed::Sources::Mix.new(config) }
 
     describe "enabled?" do

--- a/test/sources/npm_test.rb
+++ b/test/sources/npm_test.rb
@@ -5,7 +5,7 @@ require "fileutils"
 
 if Licensed::Shell.tool_available?("npm")
   describe Licensed::Sources::NPM do
-    let(:config) { Licensed::Configuration.new }
+    let(:config) { Licensed::AppConfiguration.new({ "source_path" => Dir.pwd }) }
     let(:fixtures) { File.expand_path("../../fixtures/npm", __FILE__) }
     let(:source) { Licensed::Sources::NPM.new(config) }
 

--- a/test/sources/pip_test.rb
+++ b/test/sources/pip_test.rb
@@ -5,7 +5,7 @@ require "tmpdir"
 if Licensed::Shell.tool_available?("pip")
   describe Licensed::Sources::Pip do
     let (:fixtures)  { File.expand_path("../../fixtures/pip", __FILE__) }
-    let (:config)   { Licensed::AppConfiguration.new({ "sourcepath" => Dir.pwd, "python" => {"virtual_env_dir" => "test/fixtures/pip/venv" } }) }
+    let (:config)   { Licensed::AppConfiguration.new({ "source_path" => Dir.pwd, "python" => {"virtual_env_dir" => "test/fixtures/pip/venv" } }) }
     let (:source)   { Licensed::Sources::Pip.new(config) }
 
     describe "enabled?" do

--- a/test/sources/pip_test.rb
+++ b/test/sources/pip_test.rb
@@ -5,7 +5,7 @@ require "tmpdir"
 if Licensed::Shell.tool_available?("pip")
   describe Licensed::Sources::Pip do
     let (:fixtures)  { File.expand_path("../../fixtures/pip", __FILE__) }
-    let (:config)   { Licensed::Configuration.new("python" => {"virtual_env_dir" => "test/fixtures/pip/venv"}) }
+    let (:config)   { Licensed::AppConfiguration.new({ "sourcepath" => Dir.pwd, "python" => {"virtual_env_dir" => "test/fixtures/pip/venv" } }) }
     let (:source)   { Licensed::Sources::Pip.new(config) }
 
     describe "enabled?" do

--- a/test/sources/pipenv_test.rb
+++ b/test/sources/pipenv_test.rb
@@ -5,7 +5,7 @@ require "tmpdir"
 if Licensed::Shell.tool_available?("pipenv")
   describe Licensed::Sources::Pipenv do
     let (:fixtures) { File.expand_path("../../fixtures/pipenv", __FILE__) }
-    let (:config)   { Licensed::Configuration.new }
+    let (:config)   { Licensed::AppConfiguration.new({ "source_path" => Dir.pwd }) }
     let (:source)   { Licensed::Sources::Pipenv.new(config) }
 
     describe "enabled?" do

--- a/test/sources/source_test.rb
+++ b/test/sources/source_test.rb
@@ -4,7 +4,7 @@ require "tmpdir"
 require "fileutils"
 
 describe Licensed::Sources::Source do
-  let(:config) { Licensed::Configuration.new }
+  let(:config) { Licensed::AppConfiguration.new({ "source_path" => Dir.pwd }) }
   let(:source) { TestSource.new(config) }
 
   describe "dependencies" do

--- a/test/sources/yarn_test.rb
+++ b/test/sources/yarn_test.rb
@@ -5,7 +5,7 @@ require "fileutils"
 
 if Licensed::Shell.tool_available?("yarn")
   describe Licensed::Sources::Yarn do
-    let(:config) { Licensed::Configuration.new }
+    let(:config) { Licensed::AppConfiguration.new({ "source_path" => Dir.pwd }) }
     let(:fixtures) { File.expand_path("../../fixtures/yarn", __FILE__) }
     let(:source) { Licensed::Sources::Yarn.new(config) }
 

--- a/test/test_helpers/test_command.rb
+++ b/test/test_helpers/test_command.rb
@@ -28,14 +28,14 @@ class TestCommand < Licensed::Commands::Command
   end
 
   def run_source(app, source)
-    return options[:source_proc].call(app, source) if options[:source_proc]
+    options[:source_proc].call(app, source) if options[:source_proc]
     super do |report|
       report["extra"] = true
     end
   end
 
   def run_dependency(app, source, dependency)
-    return options[:dependency_proc].call(app, source, dependency) if options[:dependency_proc]
+    options[:dependency_proc].call(app, source, dependency) if options[:dependency_proc]
     super do |report|
       report["extra"] = true
     end

--- a/test/test_helpers/test_reporter.rb
+++ b/test/test_helpers/test_reporter.rb
@@ -13,4 +13,18 @@ class TestReporter < Licensed::Reporters::Reporter
       yield report
     end
   end
+
+  # Reports on a dependency in a list command run.
+  #
+  # dependency - An application dependency
+  #
+  # Returns the result of the yielded method
+  # Note - must be called from inside the `report_run` scope
+  def report_dependency(dependency)
+    super do |report|
+      result = yield report
+      report[:dependency] = dependency
+      result
+    end
+  end
 end

--- a/test/test_helpers/test_source.rb
+++ b/test/test_helpers/test_source.rb
@@ -24,7 +24,7 @@ class TestSource < Licensed::Sources::Source
         "type" => TestSource.type,
         "dir" => Dir.pwd
       }.merge(@metadata)
-    }.merge(config["test"] || {})
+    }.merge(config[self.class.type] || {})
     [Licensed::Dependency.new(**dependency_config)]
   end
 end


### PR DESCRIPTION
This PR makes little functional change, but impacts the majority of tests 😢 

Before the `apps` configuration option was available as a way to reference multiple targets in a repo, the `Configuration` class satisfied the functional role that the `AppConfiguration` class currently does.  When `AppConfiguration` was introduced, the `Configuration` class was made to inherit from `AppConfiguration` to keep the change minimally impactful to a large part of the codebase that used `AppConfiguration` methods but still only expected a single, top-level `Configuration`.

With the [request  to allow wildcard source paths](https://github.com/github/licensed/issues/239), it will no longer be possible to reference a `Configuration` as an `AppConfiguration`.  Where the `source_path` used to be treated as a string path that either existed or didn't, a wildcard `source_path` now needs to be evaluated and expanded into multiple `AppConfiguration`s.

It will be difficult to expand `source_path` at runtime due to cascading dependencies on the `source_path` value
- `AppConfiguration["name"]` defaults to being the right-most directory name of `source_path`
- `AppConfiguration#cache_path` relies on `AppConfiguration["name"]` when a `cache_path` value hasn't been explicitly set for the app

The logical way to expand a wildcard `source_path` is to create `AppConfiguration`s from each actualized value.  To keep things simple then, a root `source_path` would always evaluate into `AppConfiguration`s .  At this point a root `Configuration` that inherits from `AppConfiguration` becomes an architecture decision that only gets used in test code, which distances the test scenarios from production scenarios.

Following all of ☝️ reasoning, this PR drops the inheritance and updates a massive amount of test code to no longer reference a root level configuration

The command tests underwent a pretty major refactor.  it probably would have been alright to make minimal changes, but that would have been putting these changes off until later.  Since the majority of this change is test updates anyway it seemed like a good time to get it done.
   - added `sources` configuration to each `tests/fixtures/command/*.yml` file
   - when not loaded from a file, the configuration specifies to use the `TestSource` source type and allows for `source_config` options to be set as needed for individual tests.
   - with the above, it was no longer necessary to reference a specific `app` or `source` variable, and the tests were updated to use `config.apps.each` to test behavior for different app configurations.
   - I also needed to make some small modifications to the test command and test reporter to maintain assertion parity.

The remainder of the tests were fairly easy to convert.  Replacing `Licensed::Configuration` with `Licensed::AppConfiguration` fixed the majority of use cases, and fixing the handful of remaining issues that came up wasn't too complicated.

There are two logic changes in this PR outside of changes to `configuration.rb`
1. The environment command can no longer reference `root` once in the output since that data no longer lives on the root configuration object.
2.  I found a bug where `Licensed::Git.repository_root` wasn't returning nil as expected when not run from a git repo.  Fixed that and added tests.