### PR TITLE
Support trailing digest in mix.lock entries

### DIFF
--- a/lib/licensed/sources/mix.rb
+++ b/lib/licensed/sources/mix.rb
@@ -93,8 +93,12 @@ module Licensed
             :[a-zA-Z0-9_]+    # after an Elixir atom,
             ,\s*              # and skipping a comma and any number of spaces,
             "(?<version>.*?)" # capture the contents of a double-quoted string as the version,
-            .*                # and later
+            .*?\],\s*         # and later
             "(?<repo>.*?)"    # capture the contents of a double-quoted string as the repo
+            (?:
+              ,\s*            # a comma
+              "[a-f0-9]{64}"  # a digest
+            )?
             \},?\s*\Z         # right before the final closing brace.
           /x,
 


### PR DESCRIPTION
Updated mix source pattern matching to support a trailing digest in `mix.lock` entries.

This should resolve https://github.com/github/licensed/issues/241.