### PR TITLE
Fix go source search_root to work with go 1.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -170,7 +170,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.7.x', '1.10.x', '1.11.1' ]
+        go: [ '1.7.x', '1.10.x', '1.11.x', '1.12.x', '1.13.x', '1.14.x' ]
     steps:
     - uses: actions/checkout@master
     - name: Setup go
@@ -342,7 +342,7 @@ jobs:
       run: script/source-setup/pipenv
     - name: Run tests
       run: script/test pipenv
-      
+
   yarn:
     runs-on: ubuntu-latest
     strategy:

--- a/lib/licensed/sources/go.rb
+++ b/lib/licensed/sources/go.rb
@@ -155,8 +155,9 @@ module Licensed
         # 3. package root value if available
         # 4. GOPATH if the package directory is under the gopath
         # 5. nil
-        return package.dig("Module", "Dir") if package["Module"]
         return package["Dir"].match("^(.*/vendor)/.*$")[1] if vendored_path?(package["Dir"])
+        module_dir = package.dig("Module", "Dir")
+        return module_dir if module_dir
         return package["Root"] if package["Root"]
         return gopath if package["Dir"]&.start_with?(gopath)
         nil

--- a/lib/licensed/sources/go.rb
+++ b/lib/licensed/sources/go.rb
@@ -87,6 +87,7 @@ module Licensed
         # true if go standard packages includes the import path as given
         return true if go_std_packages.include?(import_path)
         return true if go_std_packages.include?("vendor/#{import_path}")
+        return true if go_std_packages.include?(import_path.sub("golang.org", "internal"))
 
         # additional checks are only for vendored dependencies - return false
         # if package isn't vendored
@@ -96,6 +97,7 @@ module Licensed
         # return true if any of the go standard packages matches against
         # the non-vendored import path
         return true if go_std_packages.include?(non_vendored_import_path)
+        return true if go_std_packages.include?(non_vendored_import_path.sub("golang.org", "internal"))
 
         # modify the import path to look like the import path `go list` returns for vendored std packages
         vendor_path = import_path.sub("#{root_package["ImportPath"]}/", "")

--- a/test/sources/go_test.rb
+++ b/test/sources/go_test.rb
@@ -247,12 +247,11 @@ if Licensed::Shell.tool_available?("go")
       end
 
       it "is the vendor folder if the package is vendored" do
-        source.stubs(:vendored_path?).returns(true)
-        package = { "Dir" => "test/vendor/package/path" }
-        assert_equal "test/vendor", source.search_root(package)
+        package = { "Dir" => "#{config.root}/vendor/package/path" }
+        assert_equal "#{config.root}/vendor", source.search_root(package)
       end
 
-      it "is package['Root'] is given" do
+      it "is package['Root'] if given" do
         package = {
           "Dir" => "test/path",
           "Root" => "test"


### PR DESCRIPTION
closes https://github.com/github/licensed/issues/246

This fixes search root calculation to better work for vendored go modules in go 1.14.  The updated calculation checks specifically for a `Module.Dir` property before returning it, and updates the logic for `vendored_path?` to check specify the base of the path that needs to be matched.  In most cases the base path will be the root packages `ImportPath`, but when looking for a search root that value needs to be a directory.  For a vendoring use case the path should be the project root, given by `config.root`