### PR TITLE
Raise an error when a reviewed dependency has changed license text

### DIFF
--- a/lib/licensed/commands/status.rb
+++ b/lib/licensed/commands/status.rb
@@ -35,7 +35,11 @@ module Licensed
         else
           report.errors << "cached dependency record out of date" if cached_record["version"] != dependency.version
           report.errors << "missing license text" if cached_record.licenses.empty?
-          report.errors << "license needs review: #{cached_record["license"]}" if license_needs_review?(app, cached_record)
+          if cached_record["review_changed_license"]
+            report.errors << "license text has changed and needs re-review. if the new text is ok, remove the `review_changed_license` flag from the cached record"
+          elsif license_needs_review?(app, cached_record)
+            report.errors << "license needs review: #{cached_record["license"]}"
+          end
         end
 
         report.errors.empty?


### PR DESCRIPTION
closes https://github.com/github/licensed/issues/244

Adds a flag to cached metadata during `licensed cache` when
1. there is a cached record for a dependency
2. the cached record's license text does not match the dependency's current license text
3. the dependency is marked `reviewed` in the configuration

If the flag is detected during `licensed status`, it will show an error and `status` will exit with a failure code
```
"license text has changed and needs re-review. if the new text is ok, remove the `review_changed_license` flag from the cached record"
```

I also considered an option of simply unmarking the dependency as `reviewed` in the configuration in this case and letting the current unreviewed license checks catch the scenario, but I'm not sure if that would be confusing for users.

/cc @gareth @mlinksva does this sound right?  I'd be interested in your thoughts on the error text and whether there is a more straightforward solution.  The error feels pretty chatty but I'm not sure how to make it shorter without losing the context of what's wrong and how to fix it.