### PR TITLE
update rake for CVE-2020-8130

### DIFF
--- a/licensed.gemspec
+++ b/licensed.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "ruby-xxHash", "~> 0.4"
   spec.add_dependency "parallel", ">= 0.18.0"
 
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "minitest", "~> 5.8"
   spec.add_development_dependency "mocha", "~> 1.0"
   spec.add_development_dependency "rubocop", "~> 0.49", "< 0.67"


### PR DESCRIPTION
Updates rake to a newer version for CVE-2020-8130

This is a development dependency and shouldn't impact the shipped version of licensed 👍 