### PR TITLE
Fix cabal CI failures

### DIFF
--- a/test/fixtures/cabal/app.cabal
+++ b/test/fixtures/cabal/app.cabal
@@ -9,11 +9,14 @@ cabal-version:       >=1.10
 
 library
   hs-source-dirs:      .
-  build-depends:       fused-effects == 0.4.0.0
+  build-depends:       unliftio-core < 0.2.0.0,
+                       fused-effects == 0.4.0.0
   default-language:    Haskell2010
 
 executable app
   hs-source-dirs:      app
   main-is:             Main.hs
-  build-depends:       base, semilattices == 0.0.0.4
+  build-depends:       unliftio-core < 0.2.0.0,
+                       base,
+                       semilattices == 0.0.0.4
   default-language:    Haskell2010


### PR DESCRIPTION
Not entirely sure what the underlying problem is, but unliftio-core >= 0.2 apparently include breaking changes.  I found a reference that setting this dependency explicitly back to <= 0.2 fixed builds, which appears to be working.

This is a build-only fix, and shouldn't affect running tests in CI or the shipped licensed gem 👍 