### PR TITLE
Bump licensee to >= 9.13.1

### DIFF
--- a/licensed.gemspec
+++ b/licensed.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.3.0"
 
-  spec.add_dependency "licensee", "~> 9.10"
+  spec.add_dependency "licensee", ">= 9.13.1", "< 10.0.0"
   spec.add_dependency "thor", "~> 0.19"
   spec.add_dependency "pathname-common_prefix", "~> 0.0.1"
   spec.add_dependency "tomlrb", "~> 1.2"

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -2,4 +2,5 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-bundle install --path vendor/gems
+bundle config set path 'vendor/gems'
+bundle install


### PR DESCRIPTION
Bumps licensee to a minimum version of 9.13.1 to pick up a change in octokit to deprecate basic auth.  This also keeps licensee up to date for finding and classifying licenses 👍 

I've tested build exes from this branch with some local projects and everything appears to be working 👍 