### PR TITLE
Release 2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## 2.9.0
+2020-03-19
+
+## Added
+- Source paths use glob pattern matching (https://github.com/github/licensed/pull/245)
+
+## Fixed
+- Mix source supports updates to mix.lock format (:tada: @bruce https://github.com/github/licensed/pull/242)
+- Go source supports `go list` format changes in go 1.14 (https://github.com/github/licensed/pull/247)
+
+## Changed
+- `licensed cache` will flag dependencies for re-review when license text changes (https://github.com/github/licensed/pull/248)
+- `licensed status` will raise errors on dependencies that need re-review (https://github.com/github/licensed/pull/248)
+- `licensee` minimum version bumped to 9.13.1 (https://github.com/github/licensed/pull/251)
+
 ## 2.8.0
 2020-01-03
 
@@ -265,4 +280,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Initial release :tada:
 
-[Unreleased]: https://github.com/github/licensed/compare/2.8.0...HEAD
+[Unreleased]: https://github.com/github/licensed/compare/2.9.0...HEAD

--- a/lib/licensed/version.rb
+++ b/lib/licensed/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Licensed
-  VERSION = "2.8.0".freeze
+  VERSION = "2.9.0".freeze
 
   def self.previous_major_versions
     major_version = Gem::Version.new(Licensed::VERSION).segments.first


### PR DESCRIPTION
## 2.9.0
2020-03-19

## Added
- Source paths use glob pattern matching (https://github.com/github/licensed/pull/245)

## Fixed
- Mix source supports updates to mix.lock format (:tada: @bruce https://github.com/github/licensed/pull/242)
- Go source supports `go list` format changes in go 1.14 (https://github.com/github/licensed/pull/247)

## Changed
- `licensed cache` will flag dependencies for re-review when license text changes (https://github.com/github/licensed/pull/248)
- `licensed status` will raise errors on dependencies that need re-review (https://github.com/github/licensed/pull/248)
- `licensee` minimum version bumped to 9.13.1 (https://github.com/github/licensed/pull/251)
