### PR TITLE
Fix thor dependency

### DIFF
--- a/licensed.gemspec
+++ b/licensed.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.3.0"
 
   spec.add_dependency "licensee", ">= 9.13.1", "< 10.0.0"
-  spec.add_dependency "thor", "~> 0.19"
+  spec.add_dependency "thor", ">= 0.19"
   spec.add_dependency "pathname-common_prefix", "~> 0.0.1"
   spec.add_dependency "tomlrb", "~> 1.2"
   spec.add_dependency "bundler", ">= 1.10"


### PR DESCRIPTION
Rails now requires Thor 1.0 or higher so we need to update the
dependency on thor in licensed. 

This will allow 0.19 or anything higher.