### PR TITLE
Release 2.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## 2.9.2
+2020-04-28
+
+### Changed
+- `licensee` minimum version bumped to 9.13.2 (https://github.com/github/licensed/pull/256)
+
 ## 2.9.1
 2020-03-24
 
@@ -286,4 +292,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Initial release :tada:
 
-[Unreleased]: https://github.com/github/licensed/compare/2.9.1...HEAD
+[Unreleased]: https://github.com/github/licensed/compare/2.9.2...HEAD

--- a/lib/licensed/version.rb
+++ b/lib/licensed/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Licensed
-  VERSION = "2.9.1".freeze
+  VERSION = "2.9.2".freeze
 
   def self.previous_major_versions
     major_version = Gem::Version.new(Licensed::VERSION).segments.first


### PR DESCRIPTION
## 2.9.2
2020-04-28

### Changed
- `licensee` minimum version bumped to 9.13.2 (https://github.com/github/licensed/pull/256)