### PR TITLE
Add NuGet source

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -281,6 +281,30 @@ jobs:
     - name: Run tests
       run: script/test npm
 
+  nuget:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup dotnet
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.202
+    - name: Set up Ruby
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 2.6.x
+    - run: bundle lock
+    - uses: actions/cache@v1
+      with:
+        path: vendor/gems
+        key: ${{ runner.os }}-gem-2.6.x-${{ hashFiles('**/Gemfile.lock') }}
+    - name: Bootstrap
+      run: script/bootstrap
+    - name: Set up fixtures
+      run: script/source-setup/nuget
+    - name: Run tests
+      run: script/test nuget
+
   pip:
     runs-on: ubuntu-latest
     strategy:

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Dependencies will be automatically detected for all of the following sources by 
 1. [Manifest lists (manifests)](./docs/sources/manifests.md)
 1. [Mix](./docs/sources/mix.md)
 1. [NPM](./docs/sources/npm.md)
+1. [NuGet](./docs/sources/nuget.md)
 1. [Pip](./docs/sources/pip.md)
 1. [Pipenv](./docs/sources/pipenv.md)
 1. [Yarn](./docs/sources/yarn.md)

--- a/docs/sources/nuget.md
+++ b/docs/sources/nuget.md
@@ -1,34 +1,14 @@
 # NuGet
 
-The NuGet source will detect ProjectReference-style restored packages by inspecting `project.assets.json` files for dependencies. It requires that `dotnet restore` has already ran on the project, and that a `nuget.config` exists at the root.
+The NuGet source will detect ProjectReference-style restored packages by inspecting `project.assets.json` files for dependencies. It requires that `dotnet restore` has already ran on the project.
+
+The source currently expects that `source_path` is set to the `obj` directory containing the `project.assets.json`.
+For example, if your project lives at `foo/foo.proj`, you likely want to set `source_path` to `foo/obj`.
+If in MSBuild you have customized your `obj` paths (e.g. to live outside your source tree), you may need to set `source_path` to something different such as `../obj/foo`.
 
 ### Search strategy
 This source looks for licenses:
-1. Specified by SPDX expression via `<license type="expression">` in a package's `.nuspec`
-2. Specified by filepath via `<license type="file">` in a package's `.nuspec`
-3. Specified by `<licenseUrl>` in a package's `.nuspec`. Depending on the URL, the license can sometimes be determined without downloading the license content.
-4. In license files such as `LICENSE.txt`, even if not specified in the `.nuspec` 
-
-### Customizing the obj root
-If your project's `obj` folder isn't located within the source tree, you can change it in the licensed configuration:
-```yml
-nuget:
-  obj_root: ../obj
-```
-
-### Excluding projects
-You can exclude projects from being evaluated by using:
-```yml
-nuget:
-  projects:
-    exclude:
-      - Foo.Tests
-```
-
-You can also have `licensed` emit a list of the projects that consume a dependency into the cached dependency files by using:
-```yml
-nuget:
-  projects:
-    dump: true
-```
-This can help you determine projects that you may wish to exclude.
+1. Specified by SPDX expression via `<license type="expression">` in a package's `.nuspec` (via licensee)
+2. In license files such as `LICENSE.txt`, even if not specified in the `.nuspec` (via licensee)
+3. Specified by filepath via `<license type="file">` in a package's `.nuspec`, even if not a standard license filename.
+4. By downloading and inspecting the contents of `<licenseUrl>` in a package's `.nuspec`, if not found otherwise.

--- a/docs/sources/nuget.md
+++ b/docs/sources/nuget.md
@@ -15,3 +15,20 @@ If your project's `obj` folder isn't located within the source tree, you can cha
 nuget:
   obj_root: ../obj
 ```
+
+### Excluding projects
+You can exclude projects from being evaluated by using:
+```yml
+nuget:
+  projects:
+    exclude:
+      - Foo.Tests
+```
+
+You can also have `licensed` emit a list of the projects that consume a dependency into the cached dependency files by using:
+```yml
+nuget:
+  projects:
+    dump: true
+```
+This can help you determine projects that you may wish to exclude.

--- a/docs/sources/nuget.md
+++ b/docs/sources/nuget.md
@@ -1,0 +1,17 @@
+# NuGet
+
+The NuGet source will detect ProjectReference-style restored packages by inspecting `project.assets.json` files for dependencies. It requires that `dotnet restore` has already ran on the project, and that a `nuget.config` exists at the root.
+
+### Search strategy
+This source looks for licenses:
+1. Specified by SPDX expression via `<license type="expression">` in a package's `.nuspec`
+2. Specified by filepath via `<license type="file">` in a package's `.nuspec`
+3. Specified by `<licenseUrl>` in a package's `.nuspec`. Depending on the URL, the license can sometimes be determined without downloading the license content.
+4. In license files such as `LICENSE.txt`, even if not specified in the `.nuspec` 
+
+### Customizing the obj root
+If your project's `obj` folder isn't located within the source tree, you can change it in the licensed configuration:
+```yml
+nuget:
+  obj_root: ../obj
+```

--- a/lib/licensed/sources.rb
+++ b/lib/licensed/sources.rb
@@ -11,6 +11,7 @@ module Licensed
     require "licensed/sources/go"
     require "licensed/sources/manifest"
     require "licensed/sources/npm"
+    require "licensed/sources/nuget"
     require "licensed/sources/pip"
     require "licensed/sources/pipenv"
     require "licensed/sources/gradle"

--- a/lib/licensed/sources/nuget.rb
+++ b/lib/licensed/sources/nuget.rb
@@ -25,7 +25,7 @@ module Licensed
 
         def nuspec_path
           name = @metadata["name"]
-          File.join(self.path, "#{name}.nuspec")
+          File.join(self.path, "#{name.downcase}.nuspec")
         end
 
         def nuspec_contents

--- a/lib/licensed/sources/nuget.rb
+++ b/lib/licensed/sources/nuget.rb
@@ -1,0 +1,226 @@
+# frozen_string_literal: true
+require "json"
+
+module Licensed
+  module Sources
+    # Only supports ProjectReference (project.assets.json) style restore used in .NET Core.
+    # Does not currently support packages.config style restore.
+    class NuGet < Source
+      def self.type
+        "nuget"
+      end
+
+      # Match nuspec license expressions like <license type="expression">MIT</license>
+      class NuspecLicenseExpressionMatcher < Licensee::Matchers::Package
+        LICENSE_EXPRESSION_REGEX = /
+          <license\s*type\s*=\s*\"\s*expression\s*\"\s*>\s*([a-z\-0-9\.]+)\s*<\/license>
+        /ix.freeze
+
+        def license_property
+          return @license_property if defined?(@license_property)
+          match = @file.content.match LICENSE_EXPRESSION_REGEX
+          if match && match[1]
+            @license_property = match[1].downcase
+          end
+        end
+      end
+
+      class NuspecFile < Licensee::ProjectFiles::ProjectFile
+        def possible_matchers
+          [NuspecLicenseExpressionMatcher]
+        end
+      end
+
+      # A pseudo-license file where the license is already known (e.g. inferred from a URL)
+      class KnownLicenseFile < Licensee::ProjectFiles::ProjectFile
+        def initialize(license, metadata)
+          super(license.content, metadata)
+          @license = license
+        end
+
+        def license
+          return @license
+        end
+
+        def confidence
+          100
+        end
+      end
+
+      class NuGetDependency < Licensed::Dependency
+        LICENSE_FILE_REGEX = /<license\s*type\s*=\s*\"\s*file\s*\"\s*>\s*(.*)\s*<\/license>/ix.freeze
+        LICENSE_URL_REGEX = /<licenseUrl>\s*(.*)\s*<\/licenseUrl>/ix.freeze
+
+        def license
+          # By default, multiple of the same/similar licenses (e.g. a package with LICENSE.txt, license, and licenseUrl)
+          # will incorrectly result in an "other" license.
+
+          # Treat license expressions as most trustworthy, then local licenses, then remote licenses, then any license files
+          return @license if defined? @license
+          return @license = package_file.license if package_file && package_file.license
+          return @license = nuspec_local_license_file.license if nuspec_local_license_file && nuspec_local_license_file.license
+          return @license = nuspec_remote_license_file.license if nuspec_remote_license_file && nuspec_remote_license_file.license
+          super
+        end
+
+        def package_name
+          return unless @metadata
+          @metadata["name"]
+        end
+
+        def package_file
+          @package_file ||= NuspecFile.new(nuspec_contents, nuspec_path)
+        end
+
+        def project_files
+          @project_files ||= [license_files, readme_file, package_file, nuspec_local_license_file, nuspec_remote_license_file].flatten.compact
+        end
+
+        def nuspec_path
+          name = @metadata["name"]
+          File.join(self.path, "#{name}.nuspec")
+        end
+
+        def nuspec_contents
+          return unless nuspec_path
+          @nuspec_contents ||= File.read(nuspec_path)
+        end
+
+        # Look for a <license type="file"> element in the nuspec that points to an
+        # on-disk license file (which licensee may not find due to a non-standard filename)
+        def nuspec_local_license_file
+          return @nuspec_local_license_file if defined?(@nuspec_local_license_file)
+          return unless nuspec_contents
+
+          match = @nuspec_contents.match LICENSE_FILE_REGEX
+          if match && match[1]
+            license_path = File.join(File.dirname(nuspec_path), match[1])
+            return unless File.exist?(license_path)
+            license_data = File.read(license_path)
+            @nuspec_local_license_file = Licensee::ProjectFiles::LicenseFile.new(license_data, license_path)
+          end
+        end
+
+        # Look for a <licenseUrl> element in the nuspec that either is known to contain a license identifier
+        # in the URL, or points to license text on the internet that can be downloaded.
+        def nuspec_remote_license_file
+          return @nuspec_remote_license_file if defined?(@nuspec_remote_license_file)
+          return unless nuspec_contents
+
+          match = nuspec_contents.match LICENSE_URL_REGEX
+          if match && match[1]
+            url = original_url = match[1]
+
+            # Skip downloading if the URL contains a license identifier itself
+            if known_license = inspect_url_for_license(url)
+              return @nuspec_remote_license_file = KnownLicenseFile.new(known_license, { uri: url })
+            end
+
+            unless ignored_url?(url)
+              # Transform URLs that are known to return HTML but have a corresponding text-based URL
+              url = get_text_content_url(url)
+
+              # Attempt to fetch the license content
+              license_data = retrieve_license(url)
+              unless license_data.nil?
+                @nuspec_remote_license_file = Licensee::ProjectFiles::LicenseFile.new(license_data, { uri: original_url })
+              end
+            end
+          end
+        end
+
+        def get_text_content_url(url)
+          # Convert github file URLs to raw URLs
+          if match = url.match(/https?:\/\/(?:www\.)?github.com\/([^\/]+)\/([^\/]+)\/blob\/(.*)/i)
+            url = "https://github.com/#{match[1]}/#{match[2]}/raw/#{match[3]}"
+          else
+            url
+          end
+        end
+
+        def inspect_url_for_license(url)
+          if match = url.match(/https?:\/\/licenses.nuget.org\/(.*)/i)
+            Licensee::License.find(match[1])
+          elsif match = url.match(/https?:\/\/opensource.org\/licenses\/(.*)/i)
+            Licensee::License.find(match[1])
+          elsif match = url.match(/https?:\/\/(?:www\.)?apache.org\/licenses\/(.*?)(?:\.html|\.txt)?$/i)
+            Licensee::License.find(match[1].gsub("LICENSE", "Apache"))
+          end
+        end
+
+        def ignored_url?(url)
+          url == "https://aka.ms/deprecateLicenseUrl"
+        end
+
+        def retrieve_license(url, redirect_limit = 2)
+          return if redirect_limit == 0
+          begin
+            response = Net::HTTP.get_response(URI(url))
+            case response
+            when Net::HTTPSuccess     then response.body
+            when Net::HTTPRedirection then retrieve_license(response["location"], redirect_limit - 1)
+            end
+          rescue
+          end
+        end
+      end
+
+      def enabled?
+        nuget_config_exists(config.pwd)
+      end
+
+      def nuget_obj_root
+        config.dig("nuget", "obj_root") || config.pwd
+      end
+
+      def nuget_config_exists(root)
+        # Multiple supported casings: https://github.com/NuGet/Home/issues/1427
+        File.exist?(File.join(root, "nuget.config")) || File.exist?(File.join(root, "NuGet.config")) || File.exist?(File.join(root, "NuGet.Config"))
+      end
+
+      def enumerate_dependencies
+        packages.map do |key, package|
+          NuGetDependency.new(
+            name: "#{package["name"]} #{package["version"]}",
+            version: package["version"],
+            path: package["path"],
+            metadata: {
+              "type"     => NuGet.type,
+              "name"     => package["name"]
+            }
+          )
+        end
+      end
+
+      # Inspect project.assets.json files for package references.
+      # Ideally we'd use `dotnet list package` instead, but its output isn't
+      # easily machine readable, and it also requires repos to have a .sln file
+      # to evaluate multiple projects.
+      def packages
+        return @packages_by_id if defined?(@packages_by_id)
+        @packages_by_id = Hash.new
+        Dir.glob(File.join(nuget_obj_root, "**/project.assets.json")).map do |file|
+          gather_packages(file)
+        end
+        @packages_by_id
+      end
+
+      def gather_packages(project_assets_file)
+        json = JSON.parse(File.read(project_assets_file))
+        nuget_packages_dir = json["project"]["restore"]["packagesPath"]
+        json["targets"].keys.map do |target|
+          json["targets"][target].keys.map do |reference|
+            next if @packages_by_id.has_key?(reference)
+            next unless json["targets"][target][reference]["type"] == "package"
+            package_id_parts = reference.partition("/")
+            path = File.join(nuget_packages_dir, json["libraries"][reference]["path"])
+            @packages_by_id[reference] = {
+              "name"    => package_id_parts[0],
+              "version" => package_id_parts[-1],
+              "path"    => path }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/licensed/sources/nuget.rb
+++ b/lib/licensed/sources/nuget.rb
@@ -15,10 +15,12 @@ module Licensed
         LICENSE_FILE_REGEX = /<license\s*type\s*=\s*\"\s*file\s*\"\s*>\s*(.*)\s*<\/license>/ix.freeze
         LICENSE_URL_REGEX = /<licenseUrl>\s*(.*)\s*<\/licenseUrl>/ix.freeze
         PROJECT_URL_REGEX = /<projectUrl>\s*(.*)\s*<\/projectUrl>/ix.freeze
+        PROJECT_DESC_REGEX = /<description>\s*(.*)\s*<\/description>/ix.freeze
 
         def initialize(name:, version:, path:, search_root: nil, metadata: {}, errors: [])
           super(name: name, version: version, path: path, search_root: search_root, metadata: metadata, errors: errors)
           @metadata["homepage"] = project_url if project_url
+          @metadata["summary"] = description if description
         end
 
         def nuspec_path
@@ -32,10 +34,19 @@ module Licensed
         end
 
         def project_url
-          return unless nuspec_contents
           return @project_url if defined?(@project_url)
+          return unless nuspec_contents
           @project_url = begin
             match = nuspec_contents.match PROJECT_URL_REGEX
+            match[1] if match && match[1]
+          end
+        end
+
+        def description
+          return @description if defined?(@description)
+          return unless nuspec_contents
+          @description = begin
+            match = nuspec_contents.match PROJECT_DESC_REGEX
             match[1] if match && match[1]
           end
         end

--- a/lib/licensed/sources/nuget.rb
+++ b/lib/licensed/sources/nuget.rb
@@ -176,8 +176,7 @@ module Licensed
       def enumerate_dependencies
         json = JSON.parse(project_assets_file)
         nuget_packages_dir = json["project"]["restore"]["packagesPath"]
-        project_name = json["project"]["restore"]["projectName"]
-        json["targets"].each_with_object({}) do |(target_key, target), dependencies|
+        json["targets"].each_with_object({}) do |(_, target), dependencies|
           target.each do |reference_key, reference|
             # Ignore project references
             next unless reference["type"] == "package"

--- a/licensed.gemspec
+++ b/licensed.gemspec
@@ -23,13 +23,14 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.3.0"
 
-  spec.add_dependency "licensee", ">= 9.13.2", "< 10.0.0"
+  spec.add_dependency "licensee", ">= 9.14.0", "< 10.0.0"
   spec.add_dependency "thor", ">= 0.19"
   spec.add_dependency "pathname-common_prefix", "~> 0.0.1"
   spec.add_dependency "tomlrb", "~> 1.2"
   spec.add_dependency "bundler", ">= 1.10"
   spec.add_dependency "ruby-xxHash", "~> 0.4"
   spec.add_dependency "parallel", ">= 0.18.0"
+  spec.add_dependency "reverse_markdown", "~> 1.0"
 
   spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "minitest", "~> 5.8"

--- a/script/source-setup/nuget
+++ b/script/source-setup/nuget
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+if [ -z "$(which dotnet)" ]; then
+  echo "A local dotnet installation is required for dotnet/nuget development." >&2
+  exit 127
+fi
+
+# setup test fixtures
+BASE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd $BASE_PATH/test/fixtures/nuget
+
+if [ "$1" == "-f" ]; then
+  dotnet clean
+fi
+
+dotnet restore

--- a/test/commands/cache_test.rb
+++ b/test/commands/cache_test.rb
@@ -34,10 +34,11 @@ describe Licensed::Commands::Cache do
           generator.run
 
           expected_dependency = app["expected_dependency"]
+          expected_dependency_name = app["expected_dependency_name"] || expected_dependency
           path = app.cache_path.join("#{source_type}/#{expected_dependency}.#{Licensed::DependencyRecord::EXTENSION}")
           assert path.exist?
           record = Licensed::DependencyRecord.read(path)
-          assert_equal expected_dependency, record["name"]
+          assert_equal expected_dependency_name, record["name"]
           assert record["license"]
         end
       end

--- a/test/fixtures/command/nuget.yml
+++ b/test/fixtures/command/nuget.yml
@@ -1,0 +1,6 @@
+expected_dependency: Newtonsoft.Json-12.0.3
+expected_dependency_name: Newtonsoft.Json
+source_path: test/fixtures/nuget/obj
+cache_path: test/fixtures/nuget/obj/.licenses
+sources:
+  nuget: true

--- a/test/fixtures/nuget/Class1.cs
+++ b/test/fixtures/nuget/Class1.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace nuget
+{
+    public class Class1
+    {
+    }
+}

--- a/test/fixtures/nuget/nuget.config
+++ b/test/fixtures/nuget/nuget.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/test/fixtures/nuget/nuget.csproj
+++ b/test/fixtures/nuget/nuget.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Has a license expression, LICENSE.md, and licenseUrl-->
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+
+    <!-- Has a EULA-agreement.txt file (and also a bogus licenseUrl) -->
+    <PackageReference Include="Microsoft.Azure.Kusto.Data" Version="8.0.7" />
+    
+    <!-- Has only a licenseUrl to https://opensource.org/licenses/mit which we should interpret offline -->
+    <PackageReference Include="Handlebars.Net" Version="1.10.1" />
+
+    <!-- Has only a licenseUrl to http://www.apache.org/licenses/LICENSE-2.0 which we should interpret offline -->
+    <PackageReference Include="Serilog" Version="2.5.0" />
+
+    <!-- Has only a licenseUrl to https://github.com/benaadams/Ben.Demystifier/blob/master/LICENSE which we should convert to a "raw" URL and fetch -->
+    <PackageReference Include="Ben.Demystifier" Version="0.1.4" />
+  </ItemGroup>
+</Project>

--- a/test/fixtures/nuget/nuget.csproj
+++ b/test/fixtures/nuget/nuget.csproj
@@ -19,5 +19,8 @@
 
     <!-- Has only a licenseUrl to https://github.com/benaadams/Ben.Demystifier/blob/master/LICENSE which we should convert to a "raw" URL and fetch -->
     <PackageReference Include="Ben.Demystifier" Version="0.1.4" />
+
+    <!-- Has a LICENSE.txt which is also specified via <license type="file"> (and has a deprecated licenseUrl) -->
+    <PackageReference Include="Microsoft.Build.Traversal" Version="2.0.2" />
   </ItemGroup>
 </Project>

--- a/test/sources/nuget_test.rb
+++ b/test/sources/nuget_test.rb
@@ -87,23 +87,6 @@ if Licensed::Shell.tool_available?("dotnet")
         end
       end
     end
-
-    describe "download license url" do
-      it "tranforms to github raw urls" do
-        response = Net::HTTPSuccess.new(1.0, "200", "OK")
-        response.stubs(:body).returns(Licensee::License.find("apache-2.0").content)
-        Net::HTTP.expects(:get_response).with(URI("https://github.com/benaadams/Ben.Demystifier/raw/master/LICENSE")).returns(response)
-        Dir.chdir fixtures do
-          dep = source.dependencies.detect { |d| d.name == "Ben.Demystifier-0.1.4" }
-          assert dep
-
-          assert_equal "apache-2.0", dep.license_key
-          assert_equal 1, dep.matched_files.count
-          assert_equal 1, dep.record.licenses.count
-          assert dep.record.licenses.find { |l| l.text =~ /Apache/ && l.sources == ["https://github.com/benaadams/Ben.Demystifier/blob/master/LICENSE"] }
-        end
-      end
-    end
   end
 
   describe Licensed::Sources::Gradle::Dependency do
@@ -116,6 +99,12 @@ if Licensed::Shell.tool_available?("dotnet")
         data1 = Licensed::Sources::NuGet::NuGetDependency.retrieve_license("https://caches/download/urls")
         data2 = Licensed::Sources::NuGet::NuGetDependency.retrieve_license("https://caches/download/urls")
         assert_equal "some license", data2
+      end
+
+      it "transforms github urls to raw urls" do
+        original_url = "https://www.github.com/benaadams/Ben.Demystifier/blob/master/LICENSE"
+        new_url = Licensed::Sources::NuGet::NuGetDependency.text_content_url(original_url)
+        assert_equal "https://github.com/benaadams/Ben.Demystifier/raw/master/LICENSE", new_url
       end
 
       it "strips html" do

--- a/test/sources/nuget_test.rb
+++ b/test/sources/nuget_test.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+require "test_helper"
+require "tmpdir"
+require "fileutils"
+
+if Licensed::Shell.tool_available?("dotnet")
+  describe Licensed::Sources::NuGet do
+    let(:config) { Licensed::AppConfiguration.new({ "source_path" => Dir.pwd }) }
+    let(:fixtures) { File.expand_path("../../fixtures/nuget", __FILE__) }
+    let(:source) { Licensed::Sources::NuGet.new(config) }
+
+    describe "enabled?" do
+      it "is true if nuget.config exists" do
+        Dir.mktmpdir do |dir|
+          Dir.chdir(dir) do
+            File.write "nuget.config", ""
+            assert source.enabled?
+          end
+        end
+      end
+
+      it "is false if no nuget.config exists" do
+        Dir.mktmpdir do |dir|
+          Dir.chdir(dir) do
+            refute source.enabled?
+          end
+        end
+      end
+    end
+
+    describe "dependencies" do
+      it "includes declared dependencies" do
+        Dir.chdir fixtures do
+          dep = source.dependencies.detect { |d| d.name == "Newtonsoft.Json 12.0.3" }
+          assert dep
+          assert_equal "nuget", dep.record["type"]
+          assert_equal "Newtonsoft.Json", dep.package_name
+          assert_equal "12.0.3", dep.version
+        end
+      end
+    end
+
+    describe "license expressions" do
+      it "license expression and LICENSE.md and licenseUrl" do
+        Dir.chdir fixtures do
+          dep = source.dependencies.detect { |d| d.name == "Newtonsoft.Json 12.0.3" }
+          assert dep
+
+          assert_equal "mit", dep.license_key
+          assert_equal 3, dep.matched_files.count
+          assert_equal 2, dep.record.licenses.count # The license expression from the nuspec isn't included in the record
+          assert dep.record.licenses.find { |l| l.text =~ /MIT License/ && l.sources == ["LICENSE.md"] }
+        end
+      end
+    end
+
+    describe "license files" do
+      it "finds nonstandard license file using license file property" do
+        Dir.chdir fixtures do
+          dep = source.dependencies.detect { |d| d.name == "Microsoft.Azure.Kusto.Data 8.0.7" }
+          assert dep
+
+          assert_equal "other", dep.license_key
+
+          # Doesn't use licenseUrl since it's ignored (https://aka.ms/deprecateLicenseUrl)
+          assert_equal 1, dep.matched_files.count
+          assert_equal 1, dep.record.licenses.count
+          assert dep.record.licenses.find { |l| l.text =~ /MICROSOFT SOFTWARE LICENSE TERMS/ && l.sources == ["EULA-agreement.txt"] }
+        end
+      end
+    end
+
+    describe "offline license url" do
+      it "understands opensource.org" do
+        Dir.chdir fixtures do
+          dep = source.dependencies.detect { |d| d.name == "Handlebars.Net 1.10.1" }
+          assert dep
+
+          assert_equal "mit", dep.license_key
+          assert_equal 1, dep.matched_files.count
+          assert_equal 1, dep.record.licenses.count
+          assert dep.record.licenses.find { |l| l.text =~ /MIT License/ && l.sources == ["https://opensource.org/licenses/mit"] }
+        end
+      end
+
+      it "understands apache.org" do
+        Dir.chdir fixtures do
+          dep = source.dependencies.detect { |d| d.name == "Serilog 2.5.0" }
+          assert dep
+
+          assert_equal "apache-2.0", dep.license_key
+          assert_equal 1, dep.matched_files.count
+          assert_equal 1, dep.record.licenses.count
+          assert dep.record.licenses.find { |l| l.text =~ /Apache/ && l.sources == ["http://www.apache.org/licenses/LICENSE-2.0"] }
+        end
+      end
+    end
+
+    describe "online license url" do
+      it "tranforms to github raw urls" do
+        Dir.chdir fixtures do
+          dep = source.dependencies.detect { |d| d.name == "Ben.Demystifier 0.1.4" }
+          assert dep
+
+          assert_equal "apache-2.0", dep.license_key
+          assert_equal 1, dep.matched_files.count
+          assert_equal 1, dep.record.licenses.count
+          assert dep.record.licenses.find { |l| l.text =~ /Apache/ && l.sources == ["https://github.com/benaadams/Ben.Demystifier/blob/master/LICENSE"] }
+        end
+      end
+    end
+  end
+end

--- a/test/sources/nuget_test.rb
+++ b/test/sources/nuget_test.rb
@@ -6,20 +6,20 @@ require "fileutils"
 if Licensed::Shell.tool_available?("dotnet")
   describe Licensed::Sources::NuGet do
     let(:config) { Licensed::AppConfiguration.new({ "source_path" => Dir.pwd }) }
-    let(:fixtures) { File.expand_path("../../fixtures/nuget", __FILE__) }
+    let(:fixtures) { File.expand_path("../../fixtures/nuget/obj", __FILE__) }
     let(:source) { Licensed::Sources::NuGet.new(config) }
 
     describe "enabled?" do
-      it "is true if nuget.config exists" do
+      it "is true if project.assets.json exists" do
         Dir.mktmpdir do |dir|
           Dir.chdir(dir) do
-            File.write "nuget.config", ""
+            File.write "project.assets.json", ""
             assert source.enabled?
           end
         end
       end
 
-      it "is false if no nuget.config exists" do
+      it "is false if no project.assets.json exists" do
         Dir.mktmpdir do |dir|
           Dir.chdir(dir) do
             refute source.enabled?

--- a/test/sources/nuget_test.rb
+++ b/test/sources/nuget_test.rb
@@ -71,6 +71,21 @@ if Licensed::Shell.tool_available?("dotnet")
           assert dep.record.licenses.find { |l| l.text =~ /MICROSOFT SOFTWARE LICENSE TERMS/ && l.sources == ["EULA-agreement.txt"] }
         end
       end
+
+      it "ignores standard license file if licensee already found it" do
+        Net::HTTP.expects(:get_response).never
+        Dir.chdir fixtures do
+          dep = source.dependencies.detect { |d| d.name == "Microsoft.Build.Traversal-2.0.2" }
+          assert dep
+
+          assert_equal "mit", dep.license_key
+
+          assert_equal 1, dep.matched_files.count # LICENSE.txt
+          assert_equal 1, dep.record.licenses.count
+          # Ensure LICENSE.txt source doesn't appear twice
+          assert dep.record.licenses.find { |l| l.text =~ /MIT License/ && l.sources == ["LICENSE.txt"] }
+        end
+      end
     end
 
     describe "download license url" do


### PR DESCRIPTION
Add NuGet / dotnet as a supported package source type.

There are a number of open questions remaining since NuGet is somewhat unique in terms of the number of different license mechanisms it has, the most common being fetching licenses from a URL.

FYI this is the first Ruby I've ever written, so I apologize in advance for any atrocities 😃 