### PR TITLE
Allow licensed apps to share caches

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -209,6 +209,26 @@ apps:
 
 In this example, the root configuration will contain a default cache path of `.licenses`.  `app1` will inherit this value and append it's name, resulting in a cache path of `.licenses/app1`.
 
+### Sharing caches between apps
+
+Dependency caches can be shared between apps by setting the same cache path on each app.
+
+```yaml
+apps:
+  - source_path: "path/to/app1"
+    cache_path: ".licenses/apps"
+  - source_path: "path/to/app2"
+    cache_path: ".licenses/apps"
+```
+
+When using a source path with a glob pattern, the apps created from the glob pattern can share a dependency by setting an explicit cache path and setting `shared_cache` to true.
+
+```yaml
+source_path: "path/to/apps/*"
+cache_path: ".licenses/apps"
+shared_cache: true
+```
+
 ## Source specific configuration
 
 See the [source documentation](./sources) for details on any source specific configuration.

--- a/lib/licensed/commands/cache.rb
+++ b/lib/licensed/commands/cache.rb
@@ -11,20 +11,39 @@ module Licensed
         Licensed::Reporters::CacheReporter.new
       end
 
-      protected
-
-      # Run the command for all enumerated dependencies found in a dependency source,
-      # recording results in a report.
+      # Run the command.
       # Removes any cached records that don't match a current application
       # dependency.
       #
-      # app - The application configuration for the source
-      # source - A dependency source enumerator
+      # options - Options to run the command with
       #
-      # Returns whether the command succeeded for the dependency source enumerator
-      def run_source(app, source)
+      # Returns whether the command was a success
+      def run(**options)
+        begin
+          @cache_paths = Set.new
+          @files = Set.new
+
+          result = super
+          clear_stale_cached_records if result
+
+          result
+        ensure
+          @cache_paths = nil
+          @files = nil
+        end
+      end
+
+      protected
+
+      # Run the command for all enabled sources for an application configuration,
+      # recording results in a report.
+      #
+      # app - An application configuration
+      #
+      # Returns whether the command succeeded for the application.
+      def run_app(app)
         result = super
-        clear_stale_cached_records(app, source) if result
+        @cache_paths << app.cache_path
         result
       end
 
@@ -43,6 +62,7 @@ module Licensed
         end
 
         filename = app.cache_path.join(source.class.type, "#{dependency.name}.#{DependencyRecord::EXTENSION}")
+        @files << filename.to_s
         cached_record = Licensed::DependencyRecord.read(filename)
         if options[:force] || save_dependency_record?(dependency, cached_record)
           if dependency.record.matches?(cached_record)
@@ -90,12 +110,13 @@ module Licensed
       # source - A dependency source enumerator
       #
       # Returns nothing
-      def clear_stale_cached_records(app, source)
-        names = source.dependencies.map { |dependency| File.join(source.class.type, dependency.name) }
-        Dir.glob(app.cache_path.join(source.class.type, "**/*.#{DependencyRecord::EXTENSION}")).each do |file|
-          file_path = Pathname.new(file)
-          relative_path = file_path.relative_path_from(app.cache_path).to_s
-          FileUtils.rm(file) unless names.include?(relative_path.chomp(".#{DependencyRecord::EXTENSION}"))
+      def clear_stale_cached_records
+        @cache_paths.each do |cache_path|
+          Dir.glob(cache_path.join("**/*.#{DependencyRecord::EXTENSION}")).each do |file|
+            next if @files.include?(file)
+
+            FileUtils.rm(file)
+          end
         end
       end
     end

--- a/lib/licensed/configuration.rb
+++ b/lib/licensed/configuration.rb
@@ -108,7 +108,12 @@ module Licensed
     def detect_cache_path(options, inherited_options)
       return options["cache_path"] unless options["cache_path"].to_s.empty?
 
-      cache_path = inherited_options["cache_path"] || DEFAULT_CACHE_PATH
+      # if cache_path and shared_cache are both set in inherited_options,
+      # don't append the app name to the cache path
+      cache_path = inherited_options["cache_path"]
+      return cache_path if cache_path && inherited_options["shared_cache"] == true
+
+      cache_path ||= DEFAULT_CACHE_PATH
       File.join(cache_path, self["name"])
     end
 
@@ -167,6 +172,9 @@ module Licensed
         # will handle configurations that don't have these explicitly set
         dir_name = File.basename(path)
         config["name"] = "#{config["name"]}-#{dir_name}" if config["name"]
+
+        # if a cache_path is set and is not marked as shared, append the app name
+        # to the end of the cache path to make a unique cache path for the app
         if config["cache_path"] && config["shared_cache"] != true
           config["cache_path"] = File.join(config["cache_path"], dir_name)
         end

--- a/lib/licensed/configuration.rb
+++ b/lib/licensed/configuration.rb
@@ -167,7 +167,9 @@ module Licensed
         # will handle configurations that don't have these explicitly set
         dir_name = File.basename(path)
         config["name"] = "#{config["name"]}-#{dir_name}" if config["name"]
-        config["cache_path"] = File.join(config["cache_path"], dir_name) if config["cache_path"]
+        if config["cache_path"] && config["shared_cache"] != true
+          config["cache_path"] = File.join(config["cache_path"], dir_name)
+        end
 
         config
       end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -175,7 +175,7 @@ describe Licensed::Configuration do
       end
     end
 
-    it "does not inherit the shared_cache setting" do
+    it "does not apply an inherited shared_cache setting to an app-configured cache path" do
       cache_path = ".test_licenses"
       name = "test"
       apps.clear
@@ -184,6 +184,7 @@ describe Licensed::Configuration do
         "cache_path" => cache_path
       }
       options["shared_cache"] = true
+
       expected_source_paths = Dir.glob(apps[0]["source_path"]).select { |p| File.directory?(p) }
       expected_source_paths.each do |source_path|
         app = config.apps.find { |app| app["source_path"] == source_path }
@@ -228,6 +229,26 @@ describe Licensed::AppConfiguration do
     )
     assert_equal config.root.join("vendor/cache"), config.cache_path
     refute config.cache_path.to_s.end_with? config["name"]
+  end
+
+  it "applies an inherited shared_cache setting to an inherited cache path" do
+    config = Licensed::AppConfiguration.new(
+      { "source_path" => Dir.pwd },
+      { "shared_cache" => true, "cache_path" => "vendor/cache" }
+    )
+
+    assert_equal config.root.join("vendor/cache"), config.cache_path
+    refute config.cache_path.to_s.end_with? config["name"]
+  end
+
+  it "does not apply an inherited shared_cache setting to the default cache path" do
+    config = Licensed::AppConfiguration.new(
+      { "source_path" => Dir.pwd },
+      { "shared_cache" => true }
+    )
+
+    assert_equal config.root.join(Licensed::AppConfiguration::DEFAULT_CACHE_PATH, config["name"]),
+                 config.cache_path
   end
 
   describe "ignore" do

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -158,6 +158,40 @@ describe Licensed::Configuration do
         assert_equal "#{name}-#{dir_name}", app["name"]
       end
     end
+
+    it "does not assign unique cache paths if shared_cache is true" do
+      cache_path = ".test_licenses"
+      apps.clear
+      apps << {
+        "source_path" => File.expand_path("../fixtures/*", __FILE__),
+        "cache_path" => cache_path,
+        "shared_cache" => true
+      }
+      expected_source_paths = Dir.glob(apps[0]["source_path"]).select { |p| File.directory?(p) }
+      expected_source_paths.each do |source_path|
+        app = config.apps.find { |app| app["source_path"] == source_path }
+        assert app
+        assert_equal app.root.join(cache_path), app.cache_path
+      end
+    end
+
+    it "does not inherit the shared_cache setting" do
+      cache_path = ".test_licenses"
+      name = "test"
+      apps.clear
+      apps << {
+        "source_path" => File.expand_path("../fixtures/*", __FILE__),
+        "cache_path" => cache_path
+      }
+      options["shared_cache"] = true
+      expected_source_paths = Dir.glob(apps[0]["source_path"]).select { |p| File.directory?(p) }
+      expected_source_paths.each do |source_path|
+        app = config.apps.find { |app| app["source_path"] == source_path }
+        assert app
+        dir_name = File.basename(source_path)
+        assert_equal app.root.join(cache_path, dir_name), app.cache_path
+      end
+    end
   end
 end
 


### PR DESCRIPTION
This adds in an option for users to configure apps that share a cache path, and works both for explicitly declared apps as well as apps defined by glob patterns.

Source paths given with glob patterns need special handling to not append the app folder name to an explicitly specified cache path.  In this scenario users can add a `shared_config: true` configuration value to the same configuration level as the glob source path.

From the docs update:

### Sharing caches between apps

Dependency caches can be shared between apps by setting the same cache path on each app.

```yaml
apps:
  - source_path: "path/to/app1"
    cache_path: ".licenses/apps"
  - source_path: "path/to/app2"
    cache_path: ".licenses/apps"
```

When using a source path with a glob pattern, the apps created from the glob pattern can share a dependency by setting an explicit cache path and setting `shared_cache` to true.

```yaml
source_path: "path/to/apps/*"
cache_path: ".licenses/apps"
shared_cache: true
```

/cc @zarenner this should allow you to cache all dependencies to the same folder.  Does this seem like a viable solution?