### PR TITLE
Update tests to use supported versions of cabal

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
     strategy:
       matrix:
         ghc: [ '8.2.2', '8.6.5' ]
-        cabal: [ '2.0', '3.0' ]
+        cabal: [ '2.2', '2.4', '3.0', 'latest' ]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby


### PR DESCRIPTION
closes https://github.com/github/licensed/issues/265

Looks like cabal 2.0 is [no longer supported](https://github.com/actions/setup-haskell#version-support) by the `setup-haskell` action, so I've updated the test workflow accordingly, and added a few more cabal versions to test