### PR TITLE
Ignore unmet npm peer dependencies

### DIFF
--- a/lib/licensed/sources/npm.rb
+++ b/lib/licensed/sources/npm.rb
@@ -48,6 +48,7 @@ module Licensed
       # package name to it's metadata
       def recursive_dependencies(dependencies, result = {})
         dependencies.each do |name, dependency|
+          next if dependency["peerMissing"]
           next if yarn_lock_present && dependency["missing"]
           (result[name] ||= []) << dependency
           recursive_dependencies(dependency["dependencies"] || {}, result)

--- a/test/fixtures/npm/package.json
+++ b/test/fixtures/npm/package.json
@@ -2,8 +2,9 @@
   "name": "fixtures",
   "version": "1.0.0",
   "dependencies": {
-    "autoprefixer": "5.2.0",
-    "@github/query-selector": "1.0.3"
+    "@github/query-selector": "1.0.3",
+    "@optimizely/optimizely-sdk": "4.0.0",
+    "autoprefixer": "5.2.0"
   },
   "devDependencies": {
     "string.prototype.startswith": "0.2.0"

--- a/test/sources/npm_test.rb
+++ b/test/sources/npm_test.rb
@@ -76,6 +76,14 @@ if Licensed::Shell.tool_available?("npm")
         end
       end
 
+      it "does not include missing indirect peer dependencies" do
+        Dir.chdir fixtures do
+          # peer dependency of @optimizely/js-sdk-datafile-manager, which is
+          # an indirect dependency through @optimizely/optimizely-sdk
+          refute source.dependencies.detect { |dep| dep.name == "@react-native-community/async-storage" }
+        end
+      end
+
       describe "with multiple instances of a dependency" do
         it "includes version in the dependency name for multiple unique versions" do
           Dir.chdir fixtures do


### PR DESCRIPTION
closes https://github.com/github/licensed/issues/264

This change causes the npm source to ignore packages that have `peerMissing` data available, specifying that they are a peer dependency that hasn't been installed.

As a note for future followup, it looks like `npm list` json output includes a `_shrinkwrap` property which includes in a single list all of the installed dependencies.  It looks like that list doesn't include the peer dependency here.  It might be worth looking into whether that's usable to detect installed packages.

/cc @jasonkarns FYI