### PR TITLE
Lookup packages in the NugetFallbackFolders

### DIFF
--- a/lib/licensed/sources/nuget.rb
+++ b/lib/licensed/sources/nuget.rb
@@ -175,7 +175,7 @@ module Licensed
       # easily machine readable and doesn't contain everything we need.
       def enumerate_dependencies
         json = JSON.parse(project_assets_file)
-        nuget_packages_dirs = [ json["project"]["restore"]["packagesPath"] ]
+        nuget_packages_dirs = [json["project"]["restore"]["packagesPath"]]
         nuget_packages_dirs << json["project"]["restore"]["fallbackFolders"]
         json["targets"].each_with_object({}) do |(_, target), dependencies|
           target.each do |reference_key, reference|


### PR DESCRIPTION
Some nuget packages may be located in the `NugetFallbackFolders`. We need to scan it too when searching for a package or `licensed cache` would throw exception like this
```
paveliak@Pavels-MacBook-Pro src % licensed cache
Caching dependency records for LightRail.Actions
  nuget
Traceback (most recent call last):
	42: from /usr/local/bin/licensed:23:in `<main>'
	41: from /usr/local/bin/licensed:23:in `load'
	40: from /Library/Ruby/Gems/2.6.0/gems/licensed-2.10.0/exe/licensed:5:in `<top (required)>'
	39: from /Library/Ruby/Gems/2.6.0/gems/thor-1.0.1/lib/thor/base.rb:485:in `start'
	38: from /Library/Ruby/Gems/2.6.0/gems/thor-1.0.1/lib/thor.rb:392:in `dispatch'
	37: from /Library/Ruby/Gems/2.6.0/gems/thor-1.0.1/lib/thor/invocation.rb:127:in `invoke_command'
	36: from /Library/Ruby/Gems/2.6.0/gems/thor-1.0.1/lib/thor/command.rb:27:in `run'
	35: from /Library/Ruby/Gems/2.6.0/gems/licensed-2.10.0/lib/licensed/cli.rb:14:in `cache'
	34: from /Library/Ruby/Gems/2.6.0/gems/licensed-2.10.0/lib/licensed/cli.rb:83:in `run'
	33: from /Library/Ruby/Gems/2.6.0/gems/licensed-2.10.0/lib/licensed/commands/cache.rb:23:in `run'
	32: from /Library/Ruby/Gems/2.6.0/gems/licensed-2.10.0/lib/licensed/commands/command.rb:22:in `run'
	31: from /Library/Ruby/Gems/2.6.0/gems/licensed-2.10.0/lib/licensed/reporters/reporter.rb:64:in `report_run'
	30: from /Library/Ruby/Gems/2.6.0/gems/licensed-2.10.0/lib/licensed/commands/command.rb:27:in `block in run'
	29: from /Library/Ruby/Gems/2.6.0/gems/licensed-2.10.0/lib/licensed/commands/command.rb:27:in `map'
	28: from /Library/Ruby/Gems/2.6.0/gems/licensed-2.10.0/lib/licensed/commands/command.rb:27:in `block (2 levels) in run'
	27: from /Library/Ruby/Gems/2.6.0/gems/licensed-2.10.0/lib/licensed/commands/cache.rb:42:in `run_app'
	26: from /Library/Ruby/Gems/2.6.0/gems/licensed-2.10.0/lib/licensed/commands/command.rb:56:in `run_app'
	25: from /Library/Ruby/Gems/2.6.0/gems/licensed-2.10.0/lib/licensed/reporters/cache_reporter.rb:12:in `report_app'
	24: from /Library/Ruby/Gems/2.6.0/gems/licensed-2.10.0/lib/licensed/reporters/reporter.rb:86:in `report_app'
	23: from /Library/Ruby/Gems/2.6.0/gems/licensed-2.10.0/lib/licensed/reporters/cache_reporter.rb:14:in `block in report_app'
	22: from /Library/Ruby/Gems/2.6.0/gems/licensed-2.10.0/lib/licensed/commands/command.rb:57:in `block in run_app'
	21: from /Library/Ruby/Gems/2.6.0/gems/licensed-2.10.0/lib/licensed/commands/command.rb:57:in `chdir'
	20: from /Library/Ruby/Gems/2.6.0/gems/licensed-2.10.0/lib/licensed/commands/command.rb:64:in `block (2 levels) in run_app'
	19: from /Library/Ruby/Gems/2.6.0/gems/licensed-2.10.0/lib/licensed/commands/command.rb:64:in `map'
	18: from /Library/Ruby/Gems/2.6.0/gems/licensed-2.10.0/lib/licensed/commands/command.rb:64:in `block (3 levels) in run_app'
	17: from /Library/Ruby/Gems/2.6.0/gems/licensed-2.10.0/lib/licensed/commands/command.rb:81:in `run_source'
	16: from /Library/Ruby/Gems/2.6.0/gems/licensed-2.10.0/lib/licensed/reporters/cache_reporter.rb:26:in `report_source'
	15: from /Library/Ruby/Gems/2.6.0/gems/licensed-2.10.0/lib/licensed/reporters/reporter.rb:109:in `report_source'
	14: from /Library/Ruby/Gems/2.6.0/gems/licensed-2.10.0/lib/licensed/reporters/cache_reporter.rb:28:in `block in report_source'
	13: from /Library/Ruby/Gems/2.6.0/gems/licensed-2.10.0/lib/licensed/commands/command.rb:86:in `block in run_source'
	12: from /Library/Ruby/Gems/2.6.0/gems/licensed-2.10.0/lib/licensed/sources/source.rb:48:in `dependencies'
	11: from /Library/Ruby/Gems/2.6.0/gems/licensed-2.10.0/lib/licensed/sources/source.rb:65:in `cached_dependencies'
	10: from /Library/Ruby/Gems/2.6.0/gems/licensed-2.10.0/lib/licensed/sources/nuget.rb:179:in `enumerate_dependencies'
	 9: from /Library/Ruby/Gems/2.6.0/gems/licensed-2.10.0/lib/licensed/sources/nuget.rb:179:in `each_with_object'
	 8: from /Library/Ruby/Gems/2.6.0/gems/licensed-2.10.0/lib/licensed/sources/nuget.rb:179:in `each'
	 7: from /Library/Ruby/Gems/2.6.0/gems/licensed-2.10.0/lib/licensed/sources/nuget.rb:180:in `block in enumerate_dependencies'
	 6: from /Library/Ruby/Gems/2.6.0/gems/licensed-2.10.0/lib/licensed/sources/nuget.rb:180:in `each'
	 5: from /Library/Ruby/Gems/2.6.0/gems/licensed-2.10.0/lib/licensed/sources/nuget.rb:192:in `block (2 levels) in enumerate_dependencies'
	 4: from /Library/Ruby/Gems/2.6.0/gems/licensed-2.10.0/lib/licensed/sources/nuget.rb:192:in `new'
	 3: from /Library/Ruby/Gems/2.6.0/gems/licensed-2.10.0/lib/licensed/sources/nuget.rb:22:in `initialize'
	 2: from /Library/Ruby/Gems/2.6.0/gems/licensed-2.10.0/lib/licensed/sources/nuget.rb:38:in `project_url'
	 1: from /Library/Ruby/Gems/2.6.0/gems/licensed-2.10.0/lib/licensed/sources/nuget.rb:33:in `nuspec_contents'
/Library/Ruby/Gems/2.6.0/gems/licensed-2.10.0/lib/licensed/sources/nuget.rb:33:in `read': No such file or directory @ rb_sysopen - /Users/paveliak/.nuget/packages/microsoft.extensions.platformabstractions/1.1.0/microsoft.extensions.platformabstractions.nuspec (Errno::ENOENT)
```