### PR TITLE
Check for go package directory existence before accessing

### DIFF
--- a/lib/licensed/sources/go.rb
+++ b/lib/licensed/sources/go.rb
@@ -120,7 +120,7 @@ module Licensed
         return go_mod["Version"] if go_mod
 
         package_directory = package["Dir"]
-        return unless package_directory
+        return unless package_directory && File.exist?(package_directory)
 
         # find most recent git SHA for a package, or nil if SHA is
         # not available


### PR DESCRIPTION
Fixes a crash seen when `go list` tells licensed that a package has a directory that doesn't exist.  This was seen when referencing a repo with multiple module while also using `GOFLAGS="-mod=vendor"`.

In this case `go list` was assuming that all dependent packages used would live in the vendor folder, which is not true for other modules defined in the repo.  In go < 1.14 this causes `go list` to fail entirely and in go 1.14 the reference to a directory that doesn't exist causes licensed to crash by trying to `Dir.chdir` to the non-existent repo.  The fix here checks for the existence of the repo before trying to change to its directory.

/cc @vroldanbet @macripps 