### PR TITLE
Cleanup warnings from shadowed variables

### DIFF
--- a/lib/licensed/dependency.rb
+++ b/lib/licensed/dependency.rb
@@ -74,7 +74,7 @@ module Licensed
     def license_contents
       files = matched_files.reject { |f| f == package_file }
                            .group_by(&:content)
-                           .map { |content, files| { "sources" => license_content_sources(files), "text" => content } }
+                           .map { |content, sources| { "sources" => license_content_sources(sources), "text" => content } }
 
       files << generated_license_contents if files.empty?
       files.compact

--- a/lib/licensed/reporters/cache_reporter.rb
+++ b/lib/licensed/reporters/cache_reporter.rb
@@ -27,32 +27,32 @@ module Licensed
           shell.info "  #{source.class.type}"
           result = yield report
 
-          warning_reports = report.all_reports.select { |report| report.warnings.any? }.to_a
+          warning_reports = report.all_reports.select { |r| r.warnings.any? }.to_a
           if warning_reports.any?
             shell.newline
             shell.warn "  * Warnings:"
-            warning_reports.each do |report|
-              display_metadata = report.map { |k, v| "#{k}: #{v}" }.join(", ")
+            warning_reports.each do |r|
+              display_metadata = r.map { |k, v| "#{k}: #{v}" }.join(", ")
 
-              shell.warn "    * #{report.name}"
+              shell.warn "    * #{r.name}"
               shell.warn "    #{display_metadata}" unless display_metadata.empty?
-              report.warnings.each do |warning|
+              r.warnings.each do |warning|
                 shell.warn "      - #{warning}"
               end
               shell.newline
             end
           end
 
-          errored_reports = report.all_reports.select { |report| report.errors.any? }.to_a
+          errored_reports = report.all_reports.select { |r| r.errors.any? }.to_a
           if errored_reports.any?
             shell.newline
             shell.error "  * Errors:"
-            errored_reports.each do |report|
-              display_metadata = report.map { |k, v| "#{k}: #{v}" }.join(", ")
+            errored_reports.each do |r|
+              display_metadata = r.map { |k, v| "#{k}: #{v}" }.join(", ")
 
-              shell.error "    * #{report.name}"
+              shell.error "    * #{r.name}"
               shell.error "    #{display_metadata}" unless display_metadata.empty?
-              report.errors.each do |error|
+              r.errors.each do |error|
                 shell.error "      - #{error}"
               end
               shell.newline

--- a/lib/licensed/reporters/list_reporter.rb
+++ b/lib/licensed/reporters/list_reporter.rb
@@ -28,16 +28,16 @@ module Licensed
           shell.info "  #{source.class.type}"
           result = yield report
 
-          errored_reports = report.all_reports.select { |report| report.errors.any? }.to_a
+          errored_reports = report.all_reports.select { |r| r.errors.any? }.to_a
           if errored_reports.any?
             shell.newline
             shell.error "  * Errors:"
-            errored_reports.each do |report|
-              display_metadata = report.map { |k, v| "#{k}: #{v}" }.join(", ")
+            errored_reports.each do |r|
+              display_metadata = r.map { |k, v| "#{k}: #{v}" }.join(", ")
 
-              shell.error "    * #{report.name}"
+              shell.error "    * #{r.name}"
               shell.error "    #{display_metadata}" unless display_metadata.empty?
-              report.errors.each do |error|
+              r.errors.each do |error|
                 shell.error "      - #{error}"
               end
               shell.newline

--- a/lib/licensed/reporters/status_reporter.rb
+++ b/lib/licensed/reporters/status_reporter.rb
@@ -15,20 +15,20 @@ module Licensed
           result = yield report
 
           all_reports = report.all_reports
-          errored_reports = all_reports.select { |report| report.errors.any? }.to_a
+          errored_reports = all_reports.select { |r| r.errors.any? }.to_a
 
-          dependency_count = all_reports.select { |report| report.target.is_a?(Licensed::Dependency) }.size
-          error_count = errored_reports.sum { |report| report.errors.size }
+          dependency_count = all_reports.select { |r| r.target.is_a?(Licensed::Dependency) }.size
+          error_count = errored_reports.sum { |r| r.errors.size }
 
           if error_count > 0
             shell.newline
             shell.error "Errors:"
-            errored_reports.each do |report|
-              display_metadata = report.map { |k, v| "#{k}: #{v}" }.join(", ")
+            errored_reports.each do |r|
+              display_metadata = r.map { |k, v| "#{k}: #{v}" }.join(", ")
 
-              shell.error "* #{report.name}"
+              shell.error "* #{r.name}"
               shell.error "  #{display_metadata}" unless display_metadata.empty?
-              report.errors.each do |error|
+              r.errors.each do |error|
                 shell.error "    - #{error}"
               end
               shell.newline

--- a/lib/licensed/sources/cabal.rb
+++ b/lib/licensed/sources/cabal.rb
@@ -111,11 +111,11 @@ module Licensed
         info = package_info_command(id).strip
         return missing_package(id) if info.empty?
 
-        info.lines.each_with_object({}) do |line, info|
+        info.lines.each_with_object({}) do |line, hsh|
           key, value = line.split(":", 2).map(&:strip)
           next unless key && value
 
-          info[key] = value
+          hsh[key] = value
         end
       end
 


### PR DESCRIPTION
This cleans up warnings about shadowed variables that were printed when running tests.  There shouldn't be any functional change here.