### PR TITLE
Add command to output `NOTICE` file

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ See the [migration documentation](./docs/migrating_to_newer_versions.md) for mor
 ### Dependencies
 
 Licensed uses the `libgit2` bindings for Ruby provided by `rugged`. `rugged` requires `cmake` and `pkg-config` which you may need to install before you can install Licensed.
-   
+
    >  Ubuntu
-    
+
     sudo apt-get install cmake pkg-config
-    
+
    >  OS X
-       
+
     brew install cmake pkg-config
 
 ### With a Gemfile
@@ -64,8 +64,10 @@ For system wide usage, install licensed to a location on `$PATH`, e.g. `/usr/loc
 
 - `licensed list`: Output enumerated dependencies only.
 - `licensed cache`: Cache licenses and metadata.
-- `licensed status`: Check status of dependencies' cached licenses. For example:
+- `licensed status`: Check status of dependencies' cached licenses.
+- `licensed notices`: Write a `NOTICES` file for each application configuration.
 - `licensed version`: Show current installed version of Licensed. Aliases: `-v|--version`
+- `licensed env`: Output environment information from the licensed configuration.
 
 See the [commands documentation](./docs/commands.md) for additional documentation, or run `licensed -h` to see all of the current available commands.
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ For system wide usage, install licensed to a location on `$PATH`, e.g. `/usr/loc
 - `licensed list`: Output enumerated dependencies only.
 - `licensed cache`: Cache licenses and metadata.
 - `licensed status`: Check status of dependencies' cached licenses.
-- `licensed notices`: Write a `NOTICES` file for each application configuration.
+- `licensed notices`: Write a `NOTICE` file for each application configuration.
 - `licensed version`: Show current installed version of Licensed. Aliases: `-v|--version`
 - `licensed env`: Output environment information from the licensed configuration.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -33,7 +33,7 @@ A dependency will fail the status checks if:
 
 ## `notices`
 
-Outputs license and notice text for all dependencies in each app into a `NOTICE` file in the app's `source_path`.  If an app uses a shared cache path, the file name will contain the app name as well, e.g. `NOTICE.my_app`.
+Outputs license and notice text for all dependencies in each app into a `NOTICE` file in the app's `cache_path`.  If an app uses a shared cache path, the file name will contain the app name as well, e.g. `NOTICE.my_app`.
 
 The `NOTICE` file contents are retrieved from cached records, with the assumption that cached records have already been reviewed in a compliance workflow.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -33,7 +33,7 @@ A dependency will fail the status checks if:
 
 ## `notices`
 
-Outputs license and notice text for all dependencies in each app into a `NOTICES` file in the app's `source_path`.  If an app uses a shared cache path, the file name will contain the app name as well, e.g. `NOTICES.my_app`.
+Outputs license and notice text for all dependencies in each app into a `NOTICE` file in the app's `source_path`.  If an app uses a shared cache path, the file name will contain the app name as well, e.g. `NOTICE.my_app`.
 
 The `NOTICE` file contents are retrieved from cached records, with the assumption that cached records have already been reviewed in a compliance workflow.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -31,6 +31,12 @@ A dependency will fail the status checks if:
 5. The cached record is flagged for re-review.
    - This occurs when the record's license text has changed since the record was reviewed.
 
+## `notices`
+
+Outputs license and notice text for all dependencies in each app into a `NOTICES` file in the app's `source_path`.  If an app uses a shared cache path, the file name will contain the app name as well, e.g. `NOTICES.my_app`.
+
+The `NOTICE` file contents are retrieved from cached records, with the assumption that cached records have already been reviewed in a compliance workflow.
+
 ## `env`
 
 Prints the runtime environment used by licensed after loading a configuration file.  By default the output is in YAML format, but can be output in JSON using the `--json` flag.

--- a/lib/licensed/cli.rb
+++ b/lib/licensed/cli.rb
@@ -28,7 +28,7 @@ module Licensed
       run Licensed::Commands::List.new(config: config)
     end
 
-    desc "notices", "Generate a NOTICES file from cached records"
+    desc "notices", "Generate a NOTICE file from cached records"
     method_option :config, aliases: "-c", type: :string,
       desc: "Path to licensed configuration file"
     def notices

--- a/lib/licensed/cli.rb
+++ b/lib/licensed/cli.rb
@@ -28,6 +28,13 @@ module Licensed
       run Licensed::Commands::List.new(config: config)
     end
 
+    desc "notices", "Generate a NOTICES file from cached records"
+    method_option :config, aliases: "-c", type: :string,
+      desc: "Path to licensed configuration file"
+    def notices
+      run Licensed::Commands::Notices.new(config: config)
+    end
+
     map "-v" => :version
     map "--version" => :version
     desc "version", "Show Installed Version of Licensed, [-v, --version]"

--- a/lib/licensed/commands.rb
+++ b/lib/licensed/commands.rb
@@ -6,5 +6,6 @@ module Licensed
     require "licensed/commands/status"
     require "licensed/commands/list"
     require "licensed/commands/environment"
+    require "licensed/commands/notices"
   end
 end

--- a/lib/licensed/commands/notices.rb
+++ b/lib/licensed/commands/notices.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+module Licensed
+  module Commands
+    class Notices < Command
+      # Create a reporter to use during a command run
+      #
+      # options - The options the command was run with
+      #
+      # Raises a Licensed::Reporters::CacheReporter
+      def create_reporter(options)
+        Licensed::Reporters::NoticesReporter.new
+      end
+
+      protected
+
+      # Load stored dependency record data to add to the notices report.
+      #
+      # app - The application configuration for the dependency
+      # source - The dependency source enumerator for the dependency
+      # dependency - An application dependency
+      # report - A report hash for the command to provide extra data for the report output.
+      #
+      # Returns true.
+      def evaluate_dependency(app, source, dependency, report)
+        filename = app.cache_path.join(source.class.type, "#{dependency.name}.#{DependencyRecord::EXTENSION}")
+        report["cached_record"] = Licensed::DependencyRecord.read(filename)
+        if !report["cached_record"]
+          report["warning"] = "expected cached record not found at #{filename}"
+        end
+
+        true
+      end
+    end
+  end
+end

--- a/lib/licensed/reporters.rb
+++ b/lib/licensed/reporters.rb
@@ -7,5 +7,6 @@ module Licensed
     require "licensed/reporters/list_reporter"
     require "licensed/reporters/json_reporter"
     require "licensed/reporters/yaml_reporter"
+    require "licensed/reporters/notices_reporter"
   end
 end

--- a/lib/licensed/reporters/notices_reporter.rb
+++ b/lib/licensed/reporters/notices_reporter.rb
@@ -14,7 +14,7 @@ module Licensed
       # Note - must be called from inside the `report_run` scope
       def report_app(app)
         super do |report|
-          filename = app["shared_cache"] ? "NOTICES.#{app["name"]}" : "NOTICES"
+          filename = app["shared_cache"] ? "NOTICE.#{app["name"]}" : "NOTICE"
           path = app.cache_path.join(filename)
           shell.info "Writing notices for #{app["name"]} to #{path}"
 

--- a/lib/licensed/reporters/notices_reporter.rb
+++ b/lib/licensed/reporters/notices_reporter.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Licensed
+  module Reporters
+    class NoticesReporter < Reporter
+      TEXT_SEPARATOR = "\n\n#{("-" * 5)}\n\n".freeze
+      LICENSE_SEPARATOR = "\n#{("*" * 5)}\n".freeze
+
+      # Reports on an application configuration in a notices command run
+      #
+      # app - An application configuration
+      #
+      # Returns the result of the yielded method
+      # Note - must be called from inside the `report_run` scope
+      def report_app(app)
+        super do |report|
+          filename = app["shared_cache"] ? "NOTICES.#{app["name"]}" : "NOTICES"
+          path = app.cache_path.join(filename)
+          shell.info "Writing notices for #{app["name"]} to #{path}"
+
+          result = yield report
+
+          File.open(path, "w") do |file|
+            file << "THIRD PARTY NOTICES\n"
+            file << LICENSE_SEPARATOR
+            file << report.all_reports
+                          .map { |r| notices(r) }
+                          .compact
+                          .join(LICENSE_SEPARATOR)
+          end
+
+          result
+        end
+      end
+
+      # Reports on a dependency in a notices command run.
+      #
+      # dependency - An application dependency
+      #
+      # Returns the result of the yielded method
+      # Note - must be called from inside the `report_run` scope
+      def report_dependency(dependency)
+        super do |report|
+          result = yield report
+          shell.warn "* #{report["warning"]}" if report["warning"]
+          result
+        end
+      end
+
+      # Returns notices information for a dependency report
+      def notices(report)
+        return unless report.target.is_a?(Licensed::Dependency)
+
+        cached_record = report["cached_record"]
+        return unless cached_record
+
+        texts = cached_record.licenses.map(&:text)
+        texts.concat(cached_record.notices)
+
+        <<~NOTICE
+          #{cached_record["name"]}@#{cached_record["version"]}
+
+          #{texts.map(&:strip).reject(&:empty?).compact.join(TEXT_SEPARATOR)}
+        NOTICE
+      end
+    end
+  end
+end

--- a/test/commands/notices_test.rb
+++ b/test/commands/notices_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+require "test_helper"
+
+describe Licensed::Commands::Notices do
+  let(:cache_path) { Dir.mktmpdir }
+  let(:reporter) { TestReporter.new }
+  let(:config) { Licensed::Configuration.new("cache_path" => cache_path, "sources" => { "test" => true }) }
+  let(:command) { Licensed::Commands::Notices.new(config: config) }
+
+  before do
+    Spy.on(command, :create_reporter).and_return(reporter)
+
+    generator_config = Marshal.load(Marshal.dump(config))
+    generator = Licensed::Commands::Cache.new(config: generator_config)
+    Spy.on(generator, :create_reporter).and_return(TestReporter.new)
+    generator.run(force: true)
+  end
+
+  after do
+    config.apps.each do |app|
+      FileUtils.rm_rf app.cache_path
+    end
+  end
+
+  def dependency_report(app, source, dependency_name = "dependency")
+    app_report = reporter.report.reports.find { |r| r.name == app["name"] }
+    assert app_report
+
+    source_report = app_report.reports.find { |r| r.target == source }
+    assert source_report
+
+    source_report.reports.find { |dependency_report| dependency_report.name.include?(dependency_name) }
+  end
+
+  it "reports cached records found for dependencies" do
+    command.run
+
+    config.apps.each do |app|
+      app.sources.each do |source|
+        source.dependencies.each do |dependency|
+          report = dependency_report(app, source, dependency.name)
+          assert report
+          assert_equal dependency.record["name"], report["cached_record"]["name"]
+          assert_equal dependency.record["version"], report["cached_record"]["version"]
+          assert_equal dependency.record.content, report["cached_record"].content
+        end
+      end
+    end
+  end
+
+  it "reports a warning on missing cached records" do
+    config.apps.each { |app| FileUtils.rm_rf app.cache_path }
+    command.run
+
+    config.apps.each do |app|
+      app.sources.each do |source|
+        source.dependencies.each do |dependency|
+          report = dependency_report(app, source, dependency.name)
+          assert report
+          assert_nil report["cached_record"]
+          path = app.cache_path.join(source.class.type, "#{dependency.name}.#{Licensed::DependencyRecord::EXTENSION}")
+          assert_equal "expected cached record not found at #{path}",
+                       report["warning"]
+        end
+      end
+    end
+  end
+end

--- a/test/reporters/notices_reporter_test.rb
+++ b/test/reporters/notices_reporter_test.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+require "test_helper"
+
+describe Licensed::Reporters::NoticesReporter do
+  let(:cache_path) { Dir.mktmpdir }
+  let(:shell) { TestShell.new }
+  let(:reporter) { Licensed::Reporters::NoticesReporter.new(shell) }
+  let(:app) { Licensed::AppConfiguration.new("source_path" => Dir.pwd, "cache_path" => cache_path) }
+  let(:source) { TestSource.new(app) }
+  let(:command) { TestCommand.new(config: nil, reporter: reporter) }
+
+  after do
+    FileUtils.rm_rf app.cache_path
+  end
+
+  describe "#report_app" do
+    it "runs a block" do
+      success = false
+      reporter.report_run(command) do
+        reporter.report_app(app) { success = true }
+      end
+      assert success
+    end
+
+    it "returns the result of the block" do
+      reporter.report_run(command) do
+        assert_equal 1, reporter.report_app(app) { 1 }
+      end
+    end
+
+    it "provides a report hash to the block" do
+      reporter.report_run(command) do
+        reporter.report_app(app) { |report| refute_nil report }
+      end
+    end
+
+    it "prints an informative message to the shell" do
+      reporter.report_run(command) do
+        reporter.report_app(app) {}
+
+        path = app.cache_path.join("NOTICES")
+        assert_includes shell.messages,
+                        {
+                           message: "Writing notices for #{app["name"]} to #{path}",
+                           newline: true,
+                           style: :info
+                        }
+      end
+    end
+
+    it "writes dependencies' licenses and notices to a NOTICES file" do
+      reporter.report_run(command) do
+        reporter.report_app(app) do
+          reporter.report_source(source) do
+            source.dependencies.each do |dependency|
+              reporter.report_dependency(dependency) do |report|
+                report["cached_record"] = Licensed::DependencyRecord.new(
+                  licenses: [
+                    { "sources" => "LICENSE1", "text" => "license1" },
+                    { "sources" => "LICENSE2", "text" => "license2" }
+                  ],
+                  notices: ["notice1", "notice2"]
+                )
+              end
+            end
+          end
+        end
+
+        path = app.cache_path.join("NOTICES")
+        assert File.exist?(path)
+        notices_contents = File.read(path)
+        assert_includes notices_contents, "license1"
+        assert_includes notices_contents, "license2"
+        assert_includes notices_contents, "notice1"
+        assert_includes notices_contents, "notice2"
+      end
+    end
+
+    it "writes dependencies' licenses and notices to a NOTICES.<app> file in a shared cache" do
+      app["shared_cache"] = true
+
+      reporter.report_run(command) do
+        reporter.report_app(app) do
+          reporter.report_source(source) do
+            source.dependencies.each do |dependency|
+              reporter.report_dependency(dependency) do |report|
+                report["cached_record"] = Licensed::DependencyRecord.new(
+                  licenses: [
+                    { "sources" => "LICENSE1", "text" => "license1" },
+                    { "sources" => "LICENSE2", "text" => "license2" }
+                  ],
+                  notices: ["notice1", "notice2"]
+                )
+              end
+            end
+          end
+        end
+
+        path = app.cache_path.join("NOTICES.#{app["name"]}")
+        assert File.exist?(path)
+        notices_contents = File.read(path)
+        assert_includes notices_contents, "license1"
+        assert_includes notices_contents, "license2"
+        assert_includes notices_contents, "notice1"
+        assert_includes notices_contents, "notice2"
+      end
+    end
+  end
+
+  describe "#report_dependency" do
+    it "runs a block" do
+      success = false
+      reporter.report_run(command) do
+        reporter.report_app(app) do
+          reporter.report_source(source) do
+            source.dependencies.each do |dependency|
+              reporter.report_dependency(dependency) { success = true }
+            end
+          end
+        end
+      end
+
+      assert success
+    end
+
+    it "returns the result of the block" do
+      reporter.report_run(command) do
+        reporter.report_app(app) do
+          reporter.report_source(source) do
+            source.dependencies.each do |dependency|
+              assert_equal 1, reporter.report_dependency(dependency) { 1 }
+            end
+          end
+        end
+      end
+    end
+
+    it "provides a report hash to the block" do
+      reporter.report_run(command) do
+        reporter.report_app(app) do
+          reporter.report_source(source) do
+            source.dependencies.each do |dependency|
+              reporter.report_dependency(dependency) { |report| refute_nil report }
+            end
+          end
+        end
+      end
+    end
+
+    it "prints a warning from a dependency report" do
+      reporter.report_run(command) do
+        reporter.report_app(app) do
+          reporter.report_source(source) do
+            source.dependencies.each do |dependency|
+              reporter.report_dependency(dependency) { |report| report["warning"] = "warning" }
+              assert_includes shell.messages,
+                              {
+                                message: "* warning",
+                                newline: true,
+                                style: :warn
+                              }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/reporters/notices_reporter_test.rb
+++ b/test/reporters/notices_reporter_test.rb
@@ -38,7 +38,7 @@ describe Licensed::Reporters::NoticesReporter do
       reporter.report_run(command) do
         reporter.report_app(app) {}
 
-        path = app.cache_path.join("NOTICES")
+        path = app.cache_path.join("NOTICE")
         assert_includes shell.messages,
                         {
                            message: "Writing notices for #{app["name"]} to #{path}",
@@ -48,7 +48,7 @@ describe Licensed::Reporters::NoticesReporter do
       end
     end
 
-    it "writes dependencies' licenses and notices to a NOTICES file" do
+    it "writes dependencies' licenses and notices to a NOTICE file" do
       reporter.report_run(command) do
         reporter.report_app(app) do
           reporter.report_source(source) do
@@ -66,7 +66,7 @@ describe Licensed::Reporters::NoticesReporter do
           end
         end
 
-        path = app.cache_path.join("NOTICES")
+        path = app.cache_path.join("NOTICE")
         assert File.exist?(path)
         notices_contents = File.read(path)
         assert_includes notices_contents, "license1"
@@ -76,7 +76,7 @@ describe Licensed::Reporters::NoticesReporter do
       end
     end
 
-    it "writes dependencies' licenses and notices to a NOTICES.<app> file in a shared cache" do
+    it "writes dependencies' licenses and notices to a NOTICE.<app> file in a shared cache" do
       app["shared_cache"] = true
 
       reporter.report_run(command) do
@@ -96,7 +96,7 @@ describe Licensed::Reporters::NoticesReporter do
           end
         end
 
-        path = app.cache_path.join("NOTICES.#{app["name"]}")
+        path = app.cache_path.join("NOTICE.#{app["name"]}")
         assert File.exist?(path)
         notices_contents = File.read(path)
         assert_includes notices_contents, "license1"


### PR DESCRIPTION
This add a new command `licensed notices`, which outputs a `NOTICE` file for each configured application.  I couldn't find a standard format for the file, so for now it looks like the following, and I'd welcome feedback if there is a preferred format.

```
THIRD PARTY NOTICES

*****
dependency@version

license text
-----
license text
-----
notice text
-----
notice text

*****
dependency@version
.....
```

Most of the work happens in the reporter, though it could arguably be done in the command as well  🤷 

/cc @mlinksva @jeffmcaffer any opinions on the NOTICE file format?