### PR TITLE
cleanup more warnings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,7 +93,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup php
-      uses: nanasess/setup-php@v1.0.2
+      uses: nanasess/setup-php@v3.0.4
       with:
         php-version: ${{ matrix.php }}
     - name: Set up Ruby

--- a/test/commands/command_test.rb
+++ b/test/commands/command_test.rb
@@ -20,13 +20,13 @@ describe Licensed::Commands::Command do
   it "runs a command for all dependencies in the configuration" do
     command.run
     command.config.apps.each do |app|
-      app_report = command.reporter.report.reports.find { |report| report.name == app["name"] }
+      app_report = command.reporter.report.reports.find { |r| r.name == app["name"] }
       assert app_report
 
-      source_report = app_report.reports.find { |report| report.name == "#{app["name"]}.#{TestSource.type}" }
+      source_report = app_report.reports.find { |r| r.name == "#{app["name"]}.#{TestSource.type}" }
       assert source_report
 
-      assert source_report.reports.find { |report| report.name == "#{app["name"]}.#{TestSource.type}.dependency" }
+      assert source_report.reports.find { |r| r.name == "#{app["name"]}.#{TestSource.type}.dependency" }
     end
   end
 
@@ -43,10 +43,10 @@ describe Licensed::Commands::Command do
     proc = lambda { |app, _| raise Licensed::Shell::Error.new(["#{app["name"]}"], 0, nil) }
     refute command.run(source_proc: proc)
 
-    reports = command.reporter.report.all_reports.select { |report| report.target.is_a?(Licensed::AppConfiguration) }
+    reports = command.reporter.report.all_reports.select { |r| r.target.is_a?(Licensed::AppConfiguration) }
     refute_empty reports
-    reports.each do |report|
-      assert_includes report.errors, "'#{report.name}' exited with status 0\n"
+    reports.each do |r|
+      assert_includes r.errors, "'#{r.name}' exited with status 0\n"
     end
   end
 
@@ -54,10 +54,10 @@ describe Licensed::Commands::Command do
     proc = lambda { |app, source, _| raise Licensed::Shell::Error.new(["#{app["name"]}.#{source.class.type}"], 0, nil) }
     refute command.run(dependency_proc: proc)
 
-    reports = command.reporter.report.all_reports.select { |report| report.target.is_a?(Licensed::Sources::Source) }
+    reports = command.reporter.report.all_reports.select { |r| r.target.is_a?(Licensed::Sources::Source) }
     refute_empty reports
-    reports.each do |report|
-      assert_includes report.errors, "'#{report.name}' exited with status 0\n"
+    reports.each do |r|
+      assert_includes r.errors, "'#{r.name}' exited with status 0\n"
     end
   end
 
@@ -76,7 +76,7 @@ describe Licensed::Commands::Command do
     dependency_name = "#{apps.first["name"]}.test.dependency"
     proc = lambda { |app, source, dep| dep.errors << "error" }
     refute command.run(dependency_proc: proc)
-    report = command.reporter.report.all_reports.find { |report| report.name == dependency_name }
+    report = command.reporter.report.all_reports.find { |r| r.name == dependency_name }
     assert report
     assert_includes report.errors, "error"
   end
@@ -85,26 +85,26 @@ describe Licensed::Commands::Command do
     proc = lambda { |app, source, _| raise Licensed::Sources::Source::Error.new("#{app["name"]}.#{source.class.type}") }
     refute command.run(dependency_proc: proc)
 
-    reports = command.reporter.report.all_reports.select { |report| report.target.is_a?(Licensed::Sources::Source) }
+    reports = command.reporter.report.all_reports.select { |r| r.target.is_a?(Licensed::Sources::Source) }
     refute_empty reports
-    reports.each do |report|
-      assert_includes report.errors, report.name
+    reports.each do |r|
+      assert_includes r.errors, r.name
     end
   end
 
   it "allows implementations to add extra data to reports with a yielded block" do
     command.run
 
-    report = command.reporter.report.all_reports.find { |report| report.target.is_a?(Licensed::Commands::Command) }
+    report = command.reporter.report.all_reports.find { |r| r.target.is_a?(Licensed::Commands::Command) }
     assert_equal true, report["extra"]
 
-    report = command.reporter.report.all_reports.find { |report| report.target.is_a?(Licensed::AppConfiguration) }
+    report = command.reporter.report.all_reports.find { |r| r.target.is_a?(Licensed::AppConfiguration) }
     assert_equal true, report["extra"]
 
-    report = command.reporter.report.all_reports.find { |report| report.target.is_a?(Licensed::Sources::Source) }
+    report = command.reporter.report.all_reports.find { |r| r.target.is_a?(Licensed::Sources::Source) }
     assert_equal true, report["extra"]
 
-    report = command.reporter.report.all_reports.find { |report| report.target.is_a?(Licensed::Dependency) }
+    report = command.reporter.report.all_reports.find { |r| r.target.is_a?(Licensed::Dependency) }
     assert_equal true, report["extra"]
   end
 end

--- a/test/commands/environment_test.rb
+++ b/test/commands/environment_test.rb
@@ -35,7 +35,7 @@ describe Licensed::Commands::Environment do
       command.run
 
       config.apps.each do |app|
-        report = reporter.report.all_reports.find { |report| report.target == app }
+        report = reporter.report.all_reports.find { |r| r.target == app }
         assert report
 
         Licensed::Commands::Environment::AppEnvironment.new(app).to_h.each do |key, value|

--- a/test/commands/list_test.rb
+++ b/test/commands/list_test.rb
@@ -25,15 +25,15 @@ describe Licensed::Commands::List do
           next unless enabled
 
           command.run
-          app_report = reporter.report.reports.find { |app_report| app_report.target == app }
+          app_report = reporter.report.reports.find { |r| r.target == app }
           assert app_report
 
           app.sources.each do |source|
-            source_report = app_report.reports.find { |source_report| source_report.target == source }
+            source_report = app_report.reports.find { |r| r.target == source }
             assert source_report
 
             expected_dependency = app["expected_dependency"]
-            assert source_report.reports.find { |dependency_report| dependency_report.name.include?(expected_dependency) }
+            assert source_report.reports.find { |r| r.name.include?(expected_dependency) }
           end
         end
       end

--- a/test/commands/status_test.rb
+++ b/test/commands/status_test.rb
@@ -26,13 +26,13 @@ describe Licensed::Commands::Status do
   end
 
   def dependency_errors(app, source, dependency_name = "dependency")
-    app_report = reporter.report.reports.find { |app_report| app_report.name == app["name"] }
+    app_report = reporter.report.reports.find { |r| r.name == app["name"] }
     assert app_report
 
-    source_report = app_report.reports.find { |source_report| source_report.target == source }
+    source_report = app_report.reports.find { |r| r.target == source }
     assert source_report
 
-    dependency_report = source_report.reports.find { |dependency_report| dependency_report.name.include?(dependency_name) }
+    dependency_report = source_report.reports.find { |r| r.name.include?(dependency_name) }
     dependency_report&.errors || []
   end
 

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -98,7 +98,7 @@ describe Licensed::Configuration do
       options["source_path"] = File.expand_path("../fixtures/*", __FILE__)
       expected_source_paths = Dir.glob(options["source_path"]).select { |p| File.directory?(p) }
       expected_source_paths.each do |source_path|
-        app = config.apps.find { |app| app["source_path"] == source_path }
+        app = config.apps.find { |a| a["source_path"] == source_path }
         assert app
         dir_name = File.basename(source_path)
         assert_equal app.root.join(Licensed::AppConfiguration::DEFAULT_CACHE_PATH, dir_name),
@@ -131,7 +131,7 @@ describe Licensed::Configuration do
       apps << { "source_path" => File.expand_path("../fixtures/*", __FILE__) }
       expected_source_paths = Dir.glob(apps[0]["source_path"]).select { |p| File.directory?(p) }
       expected_source_paths.each do |source_path|
-        app = config.apps.find { |app| app["source_path"] == source_path }
+        app = config.apps.find { |a| a["source_path"] == source_path }
         assert app
         dir_name = File.basename(source_path)
         assert_equal app.root.join(Licensed::AppConfiguration::DEFAULT_CACHE_PATH, dir_name),
@@ -151,7 +151,7 @@ describe Licensed::Configuration do
       }
       expected_source_paths = Dir.glob(apps[0]["source_path"]).select { |p| File.directory?(p) }
       expected_source_paths.each do |source_path|
-        app = config.apps.find { |app| app["source_path"] == source_path }
+        app = config.apps.find { |a| a["source_path"] == source_path }
         assert app
         dir_name = File.basename(source_path)
         assert_equal app.root.join(cache_path, dir_name), app.cache_path
@@ -169,7 +169,7 @@ describe Licensed::Configuration do
       }
       expected_source_paths = Dir.glob(apps[0]["source_path"]).select { |p| File.directory?(p) }
       expected_source_paths.each do |source_path|
-        app = config.apps.find { |app| app["source_path"] == source_path }
+        app = config.apps.find { |a| a["source_path"] == source_path }
         assert app
         assert_equal app.root.join(cache_path), app.cache_path
       end
@@ -177,7 +177,6 @@ describe Licensed::Configuration do
 
     it "does not apply an inherited shared_cache setting to an app-configured cache path" do
       cache_path = ".test_licenses"
-      name = "test"
       apps.clear
       apps << {
         "source_path" => File.expand_path("../fixtures/*", __FILE__),
@@ -187,7 +186,7 @@ describe Licensed::Configuration do
 
       expected_source_paths = Dir.glob(apps[0]["source_path"]).select { |p| File.directory?(p) }
       expected_source_paths.each do |source_path|
-        app = config.apps.find { |app| app["source_path"] == source_path }
+        app = config.apps.find { |a| a["source_path"] == source_path }
         assert app
         dir_name = File.basename(source_path)
         assert_equal app.root.join(cache_path, dir_name), app.cache_path

--- a/test/dependency_test.rb
+++ b/test/dependency_test.rb
@@ -129,8 +129,8 @@ describe Licensed::Dependency do
 
         contents = dependency.license_contents.first
         assert contents
-        assert_match /auto-generated/i, contents["sources"]
-        refute_match /copyright \(c\)/i, contents["text"]
+        assert_match(/auto-generated/i, contents["sources"])
+        refute_match(/copyright \(c\)/i, contents["text"])
 
         file = Licensee::ProjectFiles::LicenseFile.new(contents["text"])
         assert_equal "mit", file.license&.key

--- a/test/sources/composer_test.rb
+++ b/test/sources/composer_test.rb
@@ -54,7 +54,7 @@ if Licensed::Shell.tool_available?("php")
 
       it "includes nested dependencies" do
         Dir.chdir fixtures do
-          dep = source.dependencies.detect { |dep| dep.name == "psr/log" }
+          dep = source.dependencies.detect { |d| d.name == "psr/log" }
           assert dep
           assert_equal "composer", dep.record["type"]
           # psr/log requirement for monolog/monolog is `~1.0`

--- a/test/sources/nuget_test.rb
+++ b/test/sources/nuget_test.rb
@@ -89,14 +89,14 @@ if Licensed::Shell.tool_available?("dotnet")
     end
   end
 
-  describe Licensed::Sources::Gradle::Dependency do
+  describe Licensed::Sources::NuGet::NuGetDependency do
     describe "retreive license" do
       it "caches downloaded urls" do
         response = Net::HTTPSuccess.new(1.0, "200", "OK")
         response.stubs(:body).returns("some license")
         Net::HTTP.expects(:get_response).returns(response).once
 
-        data1 = Licensed::Sources::NuGet::NuGetDependency.retrieve_license("https://caches/download/urls")
+        Licensed::Sources::NuGet::NuGetDependency.retrieve_license("https://caches/download/urls")
         data2 = Licensed::Sources::NuGet::NuGetDependency.retrieve_license("https://caches/download/urls")
         assert_equal "some license", data2
       end


### PR DESCRIPTION
Followup to https://github.com/github/licensed/pull/276, this cleans up more warnings brought up by rubocop from a full `script/test` run