### PR TITLE
Ensure that nuget dependency path exists before reading

### DIFF
--- a/test/sources/nuget_test.rb
+++ b/test/sources/nuget_test.rb
@@ -90,6 +90,21 @@ if Licensed::Shell.tool_available?("dotnet")
   end
 
   describe Licensed::Sources::Gradle::Dependency do
+    it "does not error for paths that don't exist" do
+      path = Dir.mktmpdir
+      FileUtils.rm_rf(path)
+
+      dep = Licensed::Sources::NuGet::NuGetDependency.new(
+        name: "test",
+        version: "1.0",
+        path: path,
+        metadata: {
+          "name" => "test"
+        }
+      )
+      assert dep.record
+    end
+
     describe "retreive license" do
       it "caches downloaded urls" do
         response = Net::HTTPSuccess.new(1.0, "200", "OK")


### PR DESCRIPTION
A corollary to https://github.com/github/licensed/pull/273 to check that the path to a nuget dependency exists before calling `File.read`.  This is separated from the referenced PR as that is waiting on some [feedback](https://github.com/dotnet/sdk/issues/11773) from the dotnet team and I'd like to put out a new release soon.

Besides making the ☝️ aforementioned fix, this also slightly changes the functionality of the dependency to be just a bit more performant when:
1. not using the `cache` command
2. using the `cache` command when no changes are needed to cached metadata

These make up the broad majority of `licensed` runs, so hopefully this makes things a little bit faster.  Two specific changes here:
1. Don't get the `project_url` or `description` until evaluating a dependency's `license_metadata`.  That function is only called when caching new metadata or overwriting existing metadata, and takes reading and parsing `nuspect_path` out of the common path.
2. Move checks on `nuspec_path` and `nuspec_contents` into each cached `begin/end` block. This has the effect of caching a nil value rather than not caching a value + re-porforming those checks when they evaluate to false.

/cc @paveliak @zarenner FYI on parceling out some of the fix from the referenced PR