### PR TITLE
Handle dependency notices as hashes when writing a NOTICE file

### DIFF
--- a/lib/licensed/reporters/notices_reporter.rb
+++ b/lib/licensed/reporters/notices_reporter.rb
@@ -55,7 +55,16 @@ module Licensed
         return unless cached_record
 
         texts = cached_record.licenses.map(&:text)
-        texts.concat(cached_record.notices)
+        cached_record.notices.each do |notice|
+          case notice
+          when Hash
+            texts << notice["text"]
+          when String
+            texts << notice
+          else
+            shell.warn "* unable to parse notices for #{report.target.name}"
+          end
+        end
 
         <<~NOTICE
           #{cached_record["name"]}@#{cached_record["version"]}

--- a/test/reporters/notices_reporter_test.rb
+++ b/test/reporters/notices_reporter_test.rb
@@ -48,6 +48,32 @@ describe Licensed::Reporters::NoticesReporter do
       end
     end
 
+    it "prints a warning if dependency notice contents can't be parsed" do
+      reporter.report_run(command) do
+        reporter.report_app(app) do
+          reporter.report_source(source) do
+            source.dependencies.each do |dependency|
+              reporter.report_dependency(dependency) do |report|
+                report["cached_record"] = Licensed::DependencyRecord.new(
+                  licenses: [],
+                  notices: [1]
+                )
+              end
+            end
+          end
+        end
+      end
+
+      source.dependencies.each do |dependency|
+        assert_includes shell.messages,
+                        {
+                           message: "* unable to parse notices for #{dependency.name}",
+                           newline: true,
+                           style: :warn
+                        }
+      end
+    end
+
     it "writes dependencies' licenses and notices to a NOTICE file" do
       reporter.report_run(command) do
         reporter.report_app(app) do
@@ -59,7 +85,10 @@ describe Licensed::Reporters::NoticesReporter do
                     { "sources" => "LICENSE1", "text" => "license1" },
                     { "sources" => "LICENSE2", "text" => "license2" }
                   ],
-                  notices: ["notice1", "notice2"]
+                  notices: [
+                    "notice1",
+                    { "sources" => "NOTICE", "text" => "notice2" }
+                  ]
                 )
               end
             end
@@ -89,7 +118,10 @@ describe Licensed::Reporters::NoticesReporter do
                     { "sources" => "LICENSE1", "text" => "license1" },
                     { "sources" => "LICENSE2", "text" => "license2" }
                   ],
-                  notices: ["notice1", "notice2"]
+                  notices: [
+                    "notice1",
+                    { "sources" => "NOTICE", "text" => "notice2" }
+                  ]
                 )
               end
             end


### PR DESCRIPTION
I introduced a bug when writing the new `licensed notices` command, where an assumption was made that a dependencies notices would only ever be an array of strings.  As it turns out, that was true for the v1.x major version of licensed but it's not true in v2.x.  This updates the notices handling for arrays of strings or hashes, and will print out a warning for any unknown types rather than crashing execution.