### PR TITLE
Release 2.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## 2.11.1
+2020-06-09
+
+### Fixed
+- `notices` command properly reads cached dependency notices contents (https://github.com/github/licensed/pull/283)
+
 ## 2.11.0
 2020-06-02
 
@@ -312,4 +318,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Initial release :tada:
 
-[Unreleased]: https://github.com/github/licensed/compare/2.11.0...HEAD
+[Unreleased]: https://github.com/github/licensed/compare/2.11.1...HEAD

--- a/lib/licensed/version.rb
+++ b/lib/licensed/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Licensed
-  VERSION = "2.11.0".freeze
+  VERSION = "2.11.1".freeze
 
   def self.previous_major_versions
     major_version = Gem::Version.new(Licensed::VERSION).segments.first


### PR DESCRIPTION
## 2.11.1
2020-06-09

### Fixed
- `notices` command properly reads cached dependency notices contents (https://github.com/github/licensed/pull/283)