### PR TITLE
Add "sources" CLI arg to filter which sources are run during a command

### DIFF
--- a/lib/licensed/cli.rb
+++ b/lib/licensed/cli.rb
@@ -30,8 +30,11 @@ module Licensed
     desc "list", "List dependencies"
     method_option :config, aliases: "-c", type: :string,
       desc: "Path to licensed configuration file"
+    method_option :sources, aliases: "-s", type: :array,
+      desc: "Individual source(s) to evaluate.  Must also be enabled via configuration."
     def list
-      run Licensed::Commands::List.new(config: config)
+      run Licensed::Commands::List.new(config: config),
+          { sources: options[:sources] }
     end
 
     desc "notices", "Generate a NOTICE file from cached records"

--- a/lib/licensed/cli.rb
+++ b/lib/licensed/cli.rb
@@ -40,8 +40,11 @@ module Licensed
     desc "notices", "Generate a NOTICE file from cached records"
     method_option :config, aliases: "-c", type: :string,
       desc: "Path to licensed configuration file"
+    method_option :sources, aliases: "-s", type: :array,
+      desc: "Individual source(s) to evaluate.  Must also be enabled via configuration."
     def notices
-      run Licensed::Commands::Notices.new(config: config)
+      run Licensed::Commands::Notices.new(config: config),
+          { sources: options[:sources] }
     end
 
     map "-v" => :version

--- a/lib/licensed/cli.rb
+++ b/lib/licensed/cli.rb
@@ -10,8 +10,11 @@ module Licensed
       desc: "Overwrite licenses even if version has not changed."
     method_option :config, aliases: "-c", type: :string,
       desc: "Path to licensed configuration file"
+    method_option :sources, aliases: "-s", type: :array,
+      desc: "Individual source(s) to evaluate.  Must also be enabled via configuration."
     def cache
-      run Licensed::Commands::Cache.new(config: config), force: options[:force]
+      run Licensed::Commands::Cache.new(config: config),
+          { force: options[:force], sources: options[:sources] }
     end
 
     desc "status", "Check status of dependencies' cached licenses"

--- a/lib/licensed/cli.rb
+++ b/lib/licensed/cli.rb
@@ -20,8 +20,11 @@ module Licensed
     desc "status", "Check status of dependencies' cached licenses"
     method_option :config, aliases: "-c", type: :string,
       desc: "Path to licensed configuration file"
+    method_option :sources, aliases: "-s", type: :array,
+      desc: "Individual source(s) to evaluate.  Must also be enabled via configuration."
     def status
-      run Licensed::Commands::Status.new(config: config)
+      run Licensed::Commands::Status.new(config: config),
+          { sources: options[:sources] }
     end
 
     desc "list", "List dependencies"

--- a/lib/licensed/commands/cache.rb
+++ b/lib/licensed/commands/cache.rb
@@ -32,19 +32,26 @@ module Licensed
 
       protected
 
-      # Run the command for all enabled sources for an application configuration,
+      # Run the command for all enumerated dependencies found in a dependency source,
       # recording results in a report.
+      # Enumerating dependencies in the source is skipped if a :sources option
+      # is provided and the evaluated `source.class.type` is not in the :sources values
       #
-      # app - An application configuration
+      # app - The application configuration for the source
+      # source - A dependency source enumerator
       #
-      # Returns whether the command succeeded for the application.
-      def run_app(app)
-        result = super
+      # Returns whether the command succeeded for the dependency source enumerator
+      def run_source(app, source)
+        super do |report|
+          if Array(options[:sources]).any? && !options[:sources].include?(source.class.type)
+            report.warnings << "skipped source"
+            next :skip
+          end
 
-        # add the full cache path to the list of cache paths evaluted during this run
-        cache_paths << app.cache_path
-
-        result
+          # add the full cache path to the list of cache paths
+          # that should be cleaned up after the command run
+          cache_paths << app.cache_path.join(source.class.type)
+        end
       end
 
       # Cache dependency record data.

--- a/lib/licensed/commands/command.rb
+++ b/lib/licensed/commands/command.rb
@@ -21,7 +21,9 @@ module Licensed
         begin
           result = reporter.report_run(self) do |report|
             # allow additional report data to be given by commands
-            yield report if block_given?
+            if block_given?
+              next if (yield report) == :skip
+            end
 
             config.apps.sort_by { |app| app["name"] }
                        .map { |app| run_app(app) }
@@ -57,7 +59,9 @@ module Licensed
           Dir.chdir app.source_path do
             begin
               # allow additional report data to be given by commands
-              yield report if block_given?
+              if block_given?
+                next if (yield report) == :skip
+              end
 
               app.sources.select(&:enabled?)
                          .sort_by { |source| source.class.type }
@@ -81,7 +85,9 @@ module Licensed
         reporter.report_source(source) do |report|
           begin
             # allow additional report data to be given by commands
-            yield report if block_given?
+            if block_given?
+              next if (yield report) == :skip
+            end
 
             source.dependencies.sort_by { |dependency| dependency.name }
                                .map { |dependency| run_dependency(app, source, dependency) }
@@ -114,7 +120,9 @@ module Licensed
 
           begin
             # allow additional report data to be given by commands
-            yield report if block_given?
+            if block_given?
+              next if (yield report) == :skip
+            end
 
             evaluate_dependency(app, source, dependency, report)
           rescue Licensed::Shell::Error => err

--- a/lib/licensed/commands/list.rb
+++ b/lib/licensed/commands/list.rb
@@ -13,6 +13,25 @@ module Licensed
 
       protected
 
+      # Run the command for all enumerated dependencies found in a dependency source,
+      # recording results in a report.
+      # Enumerating dependencies in the source is skipped if a :sources option
+      # is provided and the evaluated `source.class.type` is not in the :sources values
+      #
+      # app - The application configuration for the source
+      # source - A dependency source enumerator
+      #
+      # Returns whether the command succeeded for the dependency source enumerator
+      def run_source(app, source)
+        super do |report|
+          next if Array(options[:sources]).empty?
+          next if options[:sources].include?(source.class.type)
+
+          report.warnings << "skipped source"
+          :skip
+        end
+      end
+
       # Listing dependencies requires no extra work.
       #
       # app - The application configuration for the dependency

--- a/lib/licensed/commands/notices.rb
+++ b/lib/licensed/commands/notices.rb
@@ -13,6 +13,25 @@ module Licensed
 
       protected
 
+      # Run the command for all enumerated dependencies found in a dependency source,
+      # recording results in a report.
+      # Enumerating dependencies in the source is skipped if a :sources option
+      # is provided and the evaluated `source.class.type` is not in the :sources values
+      #
+      # app - The application configuration for the source
+      # source - A dependency source enumerator
+      #
+      # Returns whether the command succeeded for the dependency source enumerator
+      def run_source(app, source)
+        super do |report|
+          next if Array(options[:sources]).empty?
+          next if options[:sources].include?(source.class.type)
+
+          report.warnings << "skipped source"
+          :skip
+        end
+      end
+
       # Load stored dependency record data to add to the notices report.
       #
       # app - The application configuration for the dependency
@@ -25,7 +44,7 @@ module Licensed
         filename = app.cache_path.join(source.class.type, "#{dependency.name}.#{DependencyRecord::EXTENSION}")
         report["cached_record"] = Licensed::DependencyRecord.read(filename)
         if !report["cached_record"]
-          report["warning"] = "expected cached record not found at #{filename}"
+          report.warnings << "expected cached record not found at #{filename}"
         end
 
         true

--- a/lib/licensed/commands/status.rb
+++ b/lib/licensed/commands/status.rb
@@ -15,6 +15,25 @@ module Licensed
 
       protected
 
+      # Run the command for all enumerated dependencies found in a dependency source,
+      # recording results in a report.
+      # Enumerating dependencies in the source is skipped if a :sources option
+      # is provided and the evaluated `source.class.type` is not in the :sources values
+      #
+      # app - The application configuration for the source
+      # source - A dependency source enumerator
+      #
+      # Returns whether the command succeeded for the dependency source enumerator
+      def run_source(app, source)
+        super do |report|
+          next if Array(options[:sources]).empty?
+          next if options[:sources].include?(source.class.type)
+
+          report.warnings << "skipped source"
+          :skip
+        end
+      end
+
       # Verifies that a cached record exists, is up to date and
       # has license data that complies with the licensed configuration.
       #

--- a/lib/licensed/reporters/list_reporter.rb
+++ b/lib/licensed/reporters/list_reporter.rb
@@ -28,6 +28,22 @@ module Licensed
           shell.info "  #{source.class.type}"
           result = yield report
 
+          warning_reports = report.all_reports.select { |r| r.warnings.any? }.to_a
+          if warning_reports.any?
+            shell.newline
+            shell.warn "  * Warnings:"
+            warning_reports.each do |r|
+              display_metadata = r.map { |k, v| "#{k}: #{v}" }.join(", ")
+
+              shell.warn "    * #{r.name}"
+              shell.warn "    #{display_metadata}" unless display_metadata.empty?
+              r.warnings.each do |warning|
+                shell.warn "      - #{warning}"
+              end
+              shell.newline
+            end
+          end
+
           errored_reports = report.all_reports.select { |r| r.errors.any? }.to_a
           if errored_reports.any?
             shell.newline

--- a/lib/licensed/reporters/notices_reporter.rb
+++ b/lib/licensed/reporters/notices_reporter.rb
@@ -33,6 +33,26 @@ module Licensed
         end
       end
 
+
+      # Reports on a dependency source enumerator in a notices command run.
+      # Shows warnings encountered during the run.
+      #
+      # source - A dependency source enumerator
+      #
+      # Returns the result of the yielded method
+      # Note - must be called from inside the `report_run` scope
+      def report_source(source)
+        super do |report|
+          result = yield report
+
+          report.warnings.each do |warning|
+            shell.warn "* #{report.name}: #{warning}"
+          end
+
+          result
+        end
+      end
+
       # Reports on a dependency in a notices command run.
       #
       # dependency - An application dependency
@@ -42,7 +62,9 @@ module Licensed
       def report_dependency(dependency)
         super do |report|
           result = yield report
-          shell.warn "* #{report["warning"]}" if report["warning"]
+          report.warnings.each do |warning|
+            shell.warn "* #{report.name}: #{warning}"
+          end
           result
         end
       end

--- a/lib/licensed/reporters/status_reporter.rb
+++ b/lib/licensed/reporters/status_reporter.rb
@@ -15,6 +15,23 @@ module Licensed
           result = yield report
 
           all_reports = report.all_reports
+
+          warning_reports = all_reports.select { |r| r.warnings.any? }.to_a
+          if warning_reports.any?
+            shell.newline
+            shell.warn "Warnings:"
+            warning_reports.each do |r|
+              display_metadata = r.map { |k, v| "#{k}: #{v}" }.join(", ")
+
+              shell.warn "* #{r.name}"
+              shell.warn "  #{display_metadata}" unless display_metadata.empty?
+              r.warnings.each do |warning|
+                shell.warn "    - #{warning}"
+              end
+              shell.newline
+            end
+          end
+
           errored_reports = all_reports.select { |r| r.errors.any? }.to_a
 
           dependency_count = all_reports.select { |r| r.target.is_a?(Licensed::Dependency) }.size

--- a/test/commands/command_test.rb
+++ b/test/commands/command_test.rb
@@ -107,4 +107,25 @@ describe Licensed::Commands::Command do
     report = command.reporter.report.all_reports.find { |r| r.target.is_a?(Licensed::Dependency) }
     assert_equal true, report["extra"]
   end
+
+  it "allows implementations to skip running a command with a yielded block" do
+    command.run(skip_run: true)
+    refute command.reporter.report.all_reports.find { |r| r.target.is_a?(Licensed::AppConfiguration) }
+  end
+
+  it "allows implementations to skip running apps with a yielded block" do
+    command.run(skip_app: true)
+    refute command.reporter.report.all_reports.find { |r| r.target.is_a?(Licensed::Sources::Source) }
+  end
+
+  it "allows implementations to skip running sources with a yielded block" do
+    command.run(skip_source: true)
+    refute command.reporter.report.all_reports.find { |r| r.target.is_a?(Licensed::Dependency) }
+  end
+
+  it "allows implementations to skip evaluating dependencies with a yielded block" do
+    command.run(skip_dependency: true)
+    report = command.reporter.report.all_reports.find { |r| r.target.is_a?(Licensed::Dependency) }
+    refute_equal true, report["evaluated"]
+  end
 end

--- a/test/commands/list_test.rb
+++ b/test/commands/list_test.rb
@@ -66,9 +66,9 @@ describe Licensed::Commands::List do
     command.run
 
     reports = reporter.report.all_reports
-    dependency_report = reports.find { |dependency| dependency.name == "licensed.test.dependency" }
+    dependency_report = reports.find { |report| report.target.is_a?(Licensed::Dependency) }
     assert dependency_report
-    assert_equal fixtures, dependency_report[:dependency].path
+    assert_equal fixtures, dependency_report.target.path
   end
 
   describe "with multiple apps" do

--- a/test/commands/list_test.rb
+++ b/test/commands/list_test.rb
@@ -71,6 +71,16 @@ describe Licensed::Commands::List do
     assert_equal fixtures, dependency_report.target.path
   end
 
+  it "skips a dependency sources not specified in optional :sources argument" do
+    command.run(sources: "alternate")
+
+    report = reporter.report.all_reports.find { |r| r.target.is_a?(Licensed::Sources::Source) }
+    refute_empty report.warnings
+    assert report.warnings.any? { |w| w == "skipped source" }
+
+    refute reporter.report.all_reports.find { |r| r.target.is_a?(Licensed::Dependency) }
+  end
+
   describe "with multiple apps" do
     let(:apps) do
       [

--- a/test/commands/notices_test.rb
+++ b/test/commands/notices_test.rb
@@ -59,10 +59,20 @@ describe Licensed::Commands::Notices do
           assert report
           assert_nil report["cached_record"]
           path = app.cache_path.join(source.class.type, "#{dependency.name}.#{Licensed::DependencyRecord::EXTENSION}")
-          assert_equal "expected cached record not found at #{path}",
-                       report["warning"]
+          assert_equal ["expected cached record not found at #{path}"],
+                       report.warnings
         end
       end
     end
+  end
+
+  it "skips dependency sources not specified in optional :sources argument" do
+    command.run(sources: "alternate")
+
+    report = reporter.report.all_reports.find { |r| r.target.is_a?(Licensed::Sources::Source) }
+    refute_empty report.warnings
+    assert report.warnings.any? { |w| w == "skipped source" }
+
+    refute reporter.report.all_reports.find { |r| r.target.is_a?(Licensed::Dependency) }
   end
 end

--- a/test/commands/status_test.rb
+++ b/test/commands/status_test.rb
@@ -221,9 +221,9 @@ describe Licensed::Commands::Status do
     verifier.run
 
     reports = reporter.report.all_reports
-    dependency_report = reports.find { |dependency| dependency.name == "licensed.test.dependency" }
+    dependency_report = reports.find { |report| report.target.is_a?(Licensed::Dependency) }
     assert dependency_report
-    assert_equal fixtures, dependency_report[:dependency].path
+    assert_equal fixtures, dependency_report.target.path
   end
 
   describe "with multiple apps" do

--- a/test/commands/status_test.rb
+++ b/test/commands/status_test.rb
@@ -226,6 +226,16 @@ describe Licensed::Commands::Status do
     assert_equal fixtures, dependency_report.target.path
   end
 
+  it "skips a dependency sources not specified in optional :sources argument" do
+    verifier.run(sources: "alternate")
+
+    report = reporter.report.all_reports.find { |r| r.target.is_a?(Licensed::Sources::Source) }
+    refute_empty report.warnings
+    assert report.warnings.any? { |w| w == "skipped source" }
+
+    refute reporter.report.all_reports.find { |r| r.target.is_a?(Licensed::Dependency) }
+  end
+
   describe "with multiple apps" do
     let(:apps) do
       [

--- a/test/reporters/list_reporter_test.rb
+++ b/test/reporters/list_reporter_test.rb
@@ -125,6 +125,33 @@ describe Licensed::Reporters::ListReporter do
                         }
       end
     end
+
+    it "reports warnings during the source run" do
+      reporter.report_run(command) do
+        reporter.report_app(app) do |app_report|
+          reporter.report_source(source) do |source_report|
+            source_report.warnings << "source warning"
+            reporter.report_dependency(dependency) do |dependency_report|
+              dependency_report.warnings << "dependency warning"
+            end
+          end
+        end
+
+        assert_includes shell.messages,
+                        {
+
+                           message: "      - source warning",
+                           newline: true,
+                           style: :warn
+                        }
+        assert_includes shell.messages,
+                        {
+                           message: "      - dependency warning",
+                           newline: true,
+                           style: :warn
+                        }
+      end
+    end
   end
 
   describe "#report_dependency" do

--- a/test/reporters/status_reporter_test.rb
+++ b/test/reporters/status_reporter_test.rb
@@ -39,6 +39,8 @@ describe Licensed::Reporters::StatusReporter do
               report["meta2"] = "data2"
               report.errors << "error1"
               report.errors << "error2"
+              report.warnings << "warning1"
+              report.warnings << "warning2"
             end
           end
         end
@@ -48,6 +50,34 @@ describe Licensed::Reporters::StatusReporter do
                            message: "Checking cached dependency records for #{app["name"]}",
                            newline: true,
                            style: :info
+                        }
+
+        assert_includes shell.messages,
+                        {
+                           message: "* #{app["name"]}.#{source.class.type}.#{dependency.name}",
+                           newline: true,
+                           style: :warn
+                        }
+
+        assert_includes shell.messages,
+                        {
+                           message: "  meta1: data1, meta2: data2",
+                           newline: true,
+                           style: :warn
+                        }
+
+        assert_includes shell.messages,
+                        {
+                          message: "    - warning1",
+                          newline: true,
+                          style: :warn
+                        }
+
+        assert_includes shell.messages,
+                        {
+                          message: "    - warning2",
+                          newline: true,
+                          style: :warn
                         }
 
         assert_includes shell.messages,

--- a/test/test_helpers/test_command.rb
+++ b/test/test_helpers/test_command.rb
@@ -15,7 +15,9 @@ class TestCommand < Licensed::Commands::Command
 
   def run(**options)
     super do |report|
+      # byebug
       report["extra"] = true
+      next :skip if options[:skip_run]
     end
   end
 
@@ -24,6 +26,7 @@ class TestCommand < Licensed::Commands::Command
   def run_app(app)
     super do |report|
       report["extra"] = true
+      next :skip if options[:skip_app]
     end
   end
 
@@ -31,6 +34,7 @@ class TestCommand < Licensed::Commands::Command
     options[:source_proc].call(app, source) if options[:source_proc]
     super do |report|
       report["extra"] = true
+      next :skip if options[:skip_source]
     end
   end
 
@@ -38,11 +42,13 @@ class TestCommand < Licensed::Commands::Command
     options[:dependency_proc].call(app, source, dependency) if options[:dependency_proc]
     super do |report|
       report["extra"] = true
+      next :skip if options[:skip_dependency]
     end
   end
 
   def evaluate_dependency(app, source, dependency, report)
     return options[:evaluate_proc].call(app, source, dependency) if options[:evaluate_proc]
+    report["evaluated"] = true
     true
   end
 end

--- a/test/test_helpers/test_reporter.rb
+++ b/test/test_helpers/test_reporter.rb
@@ -13,18 +13,4 @@ class TestReporter < Licensed::Reporters::Reporter
       yield report
     end
   end
-
-  # Reports on a dependency in a list command run.
-  #
-  # dependency - An application dependency
-  #
-  # Returns the result of the yielded method
-  # Note - must be called from inside the `report_run` scope
-  def report_dependency(dependency)
-    super do |report|
-      result = yield report
-      report[:dependency] = dependency
-      result
-    end
-  end
 end


### PR DESCRIPTION
closes https://github.com/github/licensed/issues/286

This PR adds an array `-s/--sources` option to the `cache`, `status`, `list` and `notices` commands to restrict which sources those commands operate over.

The purpose of this is to accommodate repos that use dependencies from multiple sources but might only update one source at a time.  For example you could run `bundle install && licensed cache --source bundler`, or set up a bundler post hook to run caching anytime packages are installed.

This also fixes a subtle bug that was introduced when enabling shared cache paths.  In prior versions, it was safe to put extra data under an applications `cache_path`, as long as it wasn't in an evaluated sources cache subdirectory.  With that change any files under `cache_path` that did not match to evaluated dependencies would be deleted.  With this PR, that behavior is reverted 👍 