### PR TITLE
release 2.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## 2.12.0
+2020-06-19
+
+### Added
+- `--sources` argument for cache, list, status and notices commands to filter running sources (https://github.com/github/licensed/pull/287)
+
+### Fixed
+- `cache` command will not remove files outside of enabled source cache paths (https://github.com/github/licensed/pull/287)
+
 ## 2.11.1
 2020-06-09
 

--- a/lib/licensed/version.rb
+++ b/lib/licensed/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Licensed
-  VERSION = "2.11.1".freeze
+  VERSION = "2.12.0".freeze
 
   def self.previous_major_versions
     major_version = Gem::Version.new(Licensed::VERSION).segments.first


### PR DESCRIPTION
## 2.12.0
2020-06-19

### Added
- `--sources` argument for cache, list, status and notices commands to filter running sources (https://github.com/github/licensed/pull/287)

### Fixed
- `cache` command will not remove files outside of enabled source cache paths (https://github.com/github/licensed/pull/287)