### PR TITLE
Don't count skipped sources as failures

### DIFF
--- a/lib/licensed/commands/command.rb
+++ b/lib/licensed/commands/command.rb
@@ -22,7 +22,7 @@ module Licensed
           result = reporter.report_run(self) do |report|
             # allow additional report data to be given by commands
             if block_given?
-              next if (yield report) == :skip
+              next true if (yield report) == :skip
             end
 
             config.apps.sort_by { |app| app["name"] }
@@ -60,7 +60,7 @@ module Licensed
             begin
               # allow additional report data to be given by commands
               if block_given?
-                next if (yield report) == :skip
+                next true if (yield report) == :skip
               end
 
               app.sources.select(&:enabled?)
@@ -86,7 +86,7 @@ module Licensed
           begin
             # allow additional report data to be given by commands
             if block_given?
-              next if (yield report) == :skip
+              next true if (yield report) == :skip
             end
 
             source.dependencies.sort_by { |dependency| dependency.name }
@@ -121,7 +121,7 @@ module Licensed
           begin
             # allow additional report data to be given by commands
             if block_given?
-              next if (yield report) == :skip
+              next true if (yield report) == :skip
             end
 
             evaluate_dependency(app, source, dependency, report)

--- a/test/commands/command_test.rb
+++ b/test/commands/command_test.rb
@@ -93,7 +93,7 @@ describe Licensed::Commands::Command do
   end
 
   it "allows implementations to add extra data to reports with a yielded block" do
-    command.run
+    assert command.run
 
     report = command.reporter.report.all_reports.find { |r| r.target.is_a?(Licensed::Commands::Command) }
     assert_equal true, report["extra"]
@@ -109,22 +109,22 @@ describe Licensed::Commands::Command do
   end
 
   it "allows implementations to skip running a command with a yielded block" do
-    command.run(skip_run: true)
+    assert command.run(skip_run: true)
     refute command.reporter.report.all_reports.find { |r| r.target.is_a?(Licensed::AppConfiguration) }
   end
 
   it "allows implementations to skip running apps with a yielded block" do
-    command.run(skip_app: true)
+    assert command.run(skip_app: true)
     refute command.reporter.report.all_reports.find { |r| r.target.is_a?(Licensed::Sources::Source) }
   end
 
   it "allows implementations to skip running sources with a yielded block" do
-    command.run(skip_source: true)
+    assert command.run(skip_source: true)
     refute command.reporter.report.all_reports.find { |r| r.target.is_a?(Licensed::Dependency) }
   end
 
   it "allows implementations to skip evaluating dependencies with a yielded block" do
-    command.run(skip_dependency: true)
+    assert command.run(skip_dependency: true)
     report = command.reporter.report.all_reports.find { |r| r.target.is_a?(Licensed::Dependency) }
     refute_equal true, report["evaluated"]
   end


### PR DESCRIPTION
🤦  fixes an issue where licensed was returning an error exit code when sources were skipped per the `--sources` CLI argument.  The return value from the reporter blocks are propagated up to the command root, which checks that all returned are truthy.  In the case of sources being skipped, a `next (nil) if ...` causes the return value to be falsey and the CLI exits 1.

Fixing this by explicitly returning true when skipping evaluation of a command, app, source and dependency.