### PR TITLE
Fix warnings in cli_test

### DIFF
--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -25,10 +25,10 @@ describe "licensed" do
     end
 
     it "accepts a path to a config file" do
-      out, status = Open3.capture2 "bundle exec exe/licensed cache -c #{config_path}"
+      out, = Open3.capture2 "bundle exec exe/licensed cache -c #{config_path}"
       refute out =~ /Usage/i
 
-      out, status = Open3.capture2 "bundle exec exe/licensed cache --config #{config_path}"
+      out, = Open3.capture2 "bundle exec exe/licensed cache --config #{config_path}"
       refute out =~ /Usage/i
     end
   end
@@ -49,10 +49,10 @@ describe "licensed" do
     end
 
     it "accepts a path to a config file" do
-      out, status = Open3.capture2 "bundle exec exe/licensed status -c #{config_path}"
+      out, = Open3.capture2 "bundle exec exe/licensed status -c #{config_path}"
       refute out =~ /Usage/i
 
-      out, status = Open3.capture2 "bundle exec exe/licensed status --config #{config_path}"
+      out, = Open3.capture2 "bundle exec exe/licensed status --config #{config_path}"
       refute out =~ /Usage/i
     end
   end
@@ -73,10 +73,10 @@ describe "licensed" do
     end
 
     it "accepts a path to a config file" do
-      out, status = Open3.capture2 "bundle exec exe/licensed list -c #{config_path}"
+      out, = Open3.capture2 "bundle exec exe/licensed list -c #{config_path}"
       refute out =~ /Usage/i
 
-      out, status = Open3.capture2 "bundle exec exe/licensed list --config #{config_path}"
+      out, = Open3.capture2 "bundle exec exe/licensed list --config #{config_path}"
       refute out =~ /Usage/i
     end
   end
@@ -84,13 +84,13 @@ describe "licensed" do
   describe "version" do
     it "outputs VERSION constant" do
       expected_out = "#{Licensed::VERSION}\n"
-      out, status = Open3.capture2 "bundle exec exe/licensed version"
+      out, = Open3.capture2 "bundle exec exe/licensed version"
       assert_equal out, expected_out
 
-      out, status = Open3.capture2 "bundle exec exe/licensed -v"
+      out, = Open3.capture2 "bundle exec exe/licensed -v"
       assert_equal out, expected_out
 
-      out, status = Open3.capture2 "bundle exec exe/licensed --version"
+      out, = Open3.capture2 "bundle exec exe/licensed --version"
       assert_equal out, expected_out
     end
   end


### PR DESCRIPTION
From https://github.com/github/licensed/runs/841619135?check_suite_focus=true#step:9:4

> /home/runner/work/licensed/licensed/test/cli_test.rb:28: warning: assigned but unused variable - status
> /home/runner/work/licensed/licensed/test/cli_test.rb:52: warning: assigned but unused variable - status
> /home/runner/work/licensed/licensed/test/cli_test.rb:76: warning: assigned but unused variable - status
> /home/runner/work/licensed/licensed/test/cli_test.rb:87: warning: assigned but unused variable - status

This PR updates `cli_test` to remove those warnings