### PR TITLE
Fix lock filename for gems.rb

### DIFF
--- a/lib/licensed/sources/bundler.rb
+++ b/lib/licensed/sources/bundler.rb
@@ -74,7 +74,7 @@ module Licensed
         end
       end
 
-      GEMFILES = %w{Gemfile gems.rb}.freeze
+      GEMFILES = { "Gemfile" => "Gemfile.lock", "gems.rb" => "gems.locked" }
       DEFAULT_WITHOUT_GROUPS = %i{development test}
 
       def enabled?
@@ -272,14 +272,15 @@ module Licensed
 
       # Returns the path to the Bundler Gemfile
       def gemfile_path
-        @gemfile_path ||= GEMFILES.map { |g| config.pwd.join g }
+        @gemfile_path ||= GEMFILES.keys
+                                  .map { |g| config.pwd.join g }
                                   .find { |f| f.exist? }
       end
 
       # Returns the path to the Bundler Gemfile.lock
       def lockfile_path
         return unless gemfile_path
-        @lockfile_path ||= gemfile_path.dirname.join("#{gemfile_path.basename}.lock")
+        @lockfile_path ||= gemfile_path.dirname.join(GEMFILES[gemfile_path.basename.to_s])
       end
 
       # Returns the configured bundler executable to use, or "bundle" by default.

--- a/test/sources/bundler_test.rb
+++ b/test/sources/bundler_test.rb
@@ -24,6 +24,17 @@ if Licensed::Shell.tool_available?("bundle")
         end
       end
 
+      it "is true if gems.locked exists" do
+        Dir.mktmpdir do |tmp|
+          Dir.chdir(tmp) do
+            File.write("gems.rb", "")
+            File.write("gems.locked", "")
+
+            assert source.enabled?
+          end
+        end
+      end
+
       it "is false no Gemfile.lock exists" do
         Dir.chdir(Dir.tmpdir) do
           refute source.enabled?
@@ -98,11 +109,11 @@ if Licensed::Shell.tool_available?("bundle")
         end
       end
 
-      it "returns gems.rb.lock for gems.rb gemfile_path" do
+      it "returns gems.locked for gems.rb gemfile_path" do
         Dir.mktmpdir do |tmp|
           Dir.chdir(tmp) do
             File.write("gems.rb", "")
-            assert_equal Pathname.pwd.join("gems.rb.lock"), source.lockfile_path
+            assert_equal Pathname.pwd.join("gems.locked"), source.lockfile_path
           end
         end
       end


### PR DESCRIPTION
Fixes https://github.com/github/licensed/issues/295

This fixes the mapping of `gems.rb.lock` to `gems.locked`.  I opted for an explicit mapping of gemfile name to lockfile name in order to make the code simple to reason about.  I added some tests and this should be👌  good to go.