### PR TITLE
Protect against parsing empty strings as JSON in npm source

### DIFF
--- a/test/sources/npm_test.rb
+++ b/test/sources/npm_test.rb
@@ -84,6 +84,16 @@ if Licensed::Shell.tool_available?("npm")
         end
       end
 
+      it "raises a Licensed::Sources::Source:Error if npm list returns invalid JSON" do
+        Dir.chdir fixtures do
+          source.stub(:package_metadata_command, "") do
+            assert_raises Licensed::Sources::Source::Error do
+              source.dependencies
+            end
+          end
+        end
+      end
+
       describe "with multiple instances of a dependency" do
         it "includes version in the dependency name for multiple unique versions" do
           Dir.chdir fixtures do


### PR DESCRIPTION
Fixes https://github.com/github/licensed/issues/297

This stops enumeration of the npm source and notifies the user that an error was encountered when a JSON parser error is encountered.  This doesn't affect all cases when `npm list` returns an error - if valid JSON is still output to stdout then the npm source should continue to function.  This only handles cases when what is returned via stdout is invalid for further use.