### PR TITLE
add json and yaml reporters to the status command

### DIFF
--- a/lib/licensed/cli.rb
+++ b/lib/licensed/cli.rb
@@ -18,12 +18,14 @@ module Licensed
     end
 
     desc "status", "Check status of dependencies' cached licenses"
+    method_option :format, enum: ["yaml", "json"],
+      desc: "Output format"
     method_option :config, aliases: "-c", type: :string,
       desc: "Path to licensed configuration file"
     method_option :sources, aliases: "-s", type: :array,
       desc: "Individual source(s) to evaluate.  Must also be enabled via configuration."
     def status
-      run Licensed::Commands::Status.new(config: config), sources: options[:sources]
+      run Licensed::Commands::Status.new(config: config), sources: options[:sources], format: options[:format]
     end
 
     desc "list", "List dependencies"

--- a/lib/licensed/commands/status.rb
+++ b/lib/licensed/commands/status.rb
@@ -10,7 +10,14 @@ module Licensed
       #
       # Returns a Licensed::Reporters::StatusReporter
       def create_reporter(options)
-        Licensed::Reporters::StatusReporter.new
+        case options[:format]
+        when "json"
+          Licensed::Reporters::JsonReporter.new
+        when "yaml"
+          Licensed::Reporters::YamlReporter.new
+        else
+          Licensed::Reporters::StatusReporter.new
+        end
       end
 
       protected

--- a/test/commands/status_test.rb
+++ b/test/commands/status_test.rb
@@ -9,6 +9,7 @@ describe Licensed::Commands::Status do
   let(:config) { Licensed::Configuration.new("apps" => apps, "cache_path" => cache_path, "sources" => { "test" => true }, "test" => source_config) }
   let(:verifier) { Licensed::Commands::Status.new(config: config) }
   let(:fixtures) { File.expand_path("../../fixtures", __FILE__) }
+  let(:command) { Licensed::Commands::Status.new(config: config) }
 
   before do
     Spy.on(verifier, :create_reporter).and_return(reporter)
@@ -366,6 +367,20 @@ describe Licensed::Commands::Status do
           assert dependency_errors(app, source).empty?
         end
       end
+    end
+  end
+
+  describe "#create_reporter" do
+    it "uses a status reporter by default" do
+      assert command.create_reporter({}).is_a?(Licensed::Reporters::StatusReporter)
+    end
+
+    it "uses a YAML reporter when format is set to yaml" do
+      assert command.create_reporter(format: "yaml").is_a?(Licensed::Reporters::YamlReporter)
+    end
+
+    it "uses a JSON reporter when format is set to json" do
+      assert command.create_reporter(format: "json").is_a?(Licensed::Reporters::JsonReporter)
     end
   end
 end


### PR DESCRIPTION
As for the `env` command, add the ability to use the `json` and `yaml` reporters to the `status` command. Those output formats are specified via the `--format` flag just like the `env` command. Defaults to the current status reporter.

**Default**
```
$ licensed status
Checking cached dependency records for licensed
............F.....
Errors:
* licensed.bundler.reverse_markdown
  filename: /Users/julianvilas/src/licensed/.licenses/bundler/reverse_markdown.dep.yml
    - license needs review: wtfpl


18 dependencies checked, 1 errors found.
```

**JSON**
```
$ licensed status --format json
{
  "apps": [
    {
      "name": "licensed",
      "sources": [
        {
          "name": "licensed.bundler",
          "dependencies": [
            {
              "name": "licensed.bundler.addressable",
              "filename": "/Users/julianvilas/src/licensed/.licenses/bundler/addressable.dep.yml"
            },
...
            {
              "name": "licensed.bundler.reverse_markdown",
              "errors": [
                "license needs review: wtfpl"
              ],
...
            {
              "name": "licensed.bundler.tomlrb",
              "filename": "/Users/julianvilas/src/licensed/.licenses/bundler/tomlrb.dep.yml"
            }
          ]
        }
      ]
    }
  ]
}
```

**YAML**
```
$ licensed status --format yaml
---
apps:
- name: licensed
  sources:
  - name: licensed.bundler
    dependencies:
    - name: licensed.bundler.addressable
      filename: "/Users/julianvilas/src/licensed/.licenses/bundler/addressable.dep.yml"
...
    - name: licensed.bundler.reverse_markdown
      errors:
      - 'license needs review: wtfpl'
      filename: "/Users/julianvilas/src/licensed/.licenses/bundler/reverse_markdown.dep.yml"
    - name: licensed.bundler.ruby-xxHash
      filename: "/Users/julianvilas/src/licensed/.licenses/bundler/ruby-xxHash.dep.yml"
...
    - name: licensed.bundler.tomlrb
      filename: "/Users/julianvilas/src/licensed/.licenses/bundler/tomlrb.dep.yml"
```