### PR TITLE
Handle yaml parsing errors when reading dependency records from disk

### DIFF
--- a/lib/licensed/commands/command.rb
+++ b/lib/licensed/commands/command.rb
@@ -125,7 +125,7 @@ module Licensed
             end
 
             evaluate_dependency(app, source, dependency, report)
-          rescue Licensed::Shell::Error => err
+          rescue Licensed::DependencyRecord::Error, Licensed::Shell::Error => err
             report.errors << err.message
             false
           end

--- a/lib/licensed/dependency_record.rb
+++ b/lib/licensed/dependency_record.rb
@@ -5,6 +5,8 @@ require "licensee"
 
 module Licensed
   class DependencyRecord
+    class Error < StandardError; end
+
     class License
       attr_reader :text, :sources
       def initialize(content)
@@ -46,6 +48,8 @@ module Licensed
         notices: data.delete("notices"),
         metadata: data
       )
+    rescue Psych::SyntaxError => e
+      raise Licensed::DependencyRecord::Error.new(e.message)
     end
 
     def_delegators :@metadata, :[], :[]=

--- a/test/commands/command_test.rb
+++ b/test/commands/command_test.rb
@@ -72,6 +72,17 @@ describe Licensed::Commands::Command do
     end
   end
 
+  it "catches dependency record errors thrown when evaluating a dependency" do
+    proc = lambda { |app, source, dep| raise Licensed::DependencyRecord::Error.new("dependency record error") }
+    refute command.run(evaluate_proc: proc)
+
+    reports = command.reporter.report.all_reports.select { |report| report.target.is_a?(Licensed::Dependency) }
+    refute_empty reports
+    reports.each do |report|
+      assert_includes report.errors, "dependency record error"
+    end
+  end
+
   it "reports errors found on a dependency" do
     dependency_name = "#{apps.first["name"]}.test.dependency"
     proc = lambda { |app, source, dep| dep.errors << "error" }

--- a/test/dependency_record_test.rb
+++ b/test/dependency_record_test.rb
@@ -28,6 +28,13 @@ describe Licensed::DependencyRecord do
       assert_equal ["license1", "license2"], content.licenses.map(&:text)
       assert_equal ["notice", "author"], content.notices
     end
+
+    it "raises an error on invalid YAML" do
+      File.write(@filename, "name: [")
+      assert_raises Licensed::DependencyRecord::Error do
+        Licensed::DependencyRecord.read(@filename)
+      end
+    end
   end
 
   describe "save" do


### PR DESCRIPTION
Closes https://github.com/github/licensed/issues/304

Adding a rescue for `Psych::SyntaxError` when reading DependencyRecords from disk, which raises the error message to a new internal error type `DependencyRecord::Error`.  That internal error is caught and handled in the command class, with the error message output similar to an error encountered while shelling out a command.