### PR TITLE
Fix configuring source path globs that expand into a single directory

### DIFF
--- a/lib/licensed/commands/command.rb
+++ b/lib/licensed/commands/command.rb
@@ -72,6 +72,12 @@ module Licensed
       # Returns whether the command succeeded for the application.
       def run_app(app)
         reporter.report_app(app) do |report|
+          # ensure the app source path exists before evaluation
+          if !Dir.exist?(app.source_path)
+            report.errors << "No such directory #{app.source_path}"
+            next false
+          end
+
           Dir.chdir app.source_path do
             begin
               # allow additional report data to be given by commands

--- a/test/commands/command_test.rb
+++ b/test/commands/command_test.rb
@@ -103,6 +103,19 @@ describe Licensed::Commands::Command do
     end
   end
 
+  it "catches and reports a non-existent app source path" do
+    nonexistent_path = File.join(Dir.pwd, "nonexistent")
+    apps.each { |app| app["source_path"] = nonexistent_path }
+
+    refute command.run
+
+    reports = command.reporter.report.all_reports.select { |r| r.target.is_a?(Licensed::AppConfiguration) }
+    refute_empty reports
+    reports.each do |r|
+      assert_includes r.errors, "No such directory #{nonexistent_path}"
+    end
+  end
+
   it "allows implementations to add extra data to reports with a yielded block" do
     assert command.run
 


### PR DESCRIPTION
closes https://github.com/github/licensed/issues/309

Two part fix to this change
1. Better handle a missing source path in an app so that it doesn't crash the overall execution of licensed.
   - This will now log an error like `No such directory <path>`
2. Better handling of path expansion
   - If the path specifies a directory that exists, don't expand
   - If the path expands into 0 paths, return the original configuration (which will be better handled with the first fix ☝️ )
   - For 1 or more expanded paths, use the existing value mapping that was previously used for 2 or more expanded paths.