### PR TITLE
Allow glob patterns in reviewed packages configuration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -118,12 +118,6 @@ ignored:
   bower:
     - some-internal-package
 
-  go:
-    # ignore all Go packages from import paths starting with github.com/internal-package
-    # see the `File.fnmatch?` documentation for details on how patterns are matched.
-    # comparisons use the FNM_CASEFOLD and FNM_PATHNAME flags
-    - github.com/internal-package/**/*
-
 # These dependencies have licenses not on the `allowed` list and have been reviewed.
 # They will be cached and checked, but will not raise errors or warnings for a
 # non-allowed license.  Dependencies on this list will still raise errors if

--- a/docs/sources/go.md
+++ b/docs/sources/go.md
@@ -24,6 +24,26 @@ The setting supports absolute, relative and expandable (e.g. "~") paths.  Relati
 
 Non-empty `GOPATH` configuration settings will override the `GOPATH` environment variable while enumerating `go` dependencies.  The `GOPATH` environment variable is restored once dependencies have been enumerated.
 
+#### Reviewing and ignoring all packages from a Go module
+
+Go's package and module structure has common conventions that documentation and metadata for all packages in a module live in the module root.  In this scenario all packages share the same LICENSE information and can be reviewed or ignored at the module level rather than per-package using glob patterns.
+
+```yaml
+reviewed:
+  go:
+    # review all Go packages from import paths starting with github.com/external-package
+    # see the `File.fnmatch?` documentation for details on how patterns are matched.
+    # comparisons use the FNM_CASEFOLD and FNM_PATHNAME flags
+    - github.com/external-package/**/*
+
+ignored:
+  go:
+    # ignore all Go packages from import paths starting with github.com/internal-package
+    # see the `File.fnmatch?` documentation for details on how patterns are matched.
+    # comparisons use the FNM_CASEFOLD and FNM_PATHNAME flags
+    - github.com/internal-package/**/*
+```
+
 #### Versioning
 
 The go source supports multiple versioning strategies to determine if cached dependency metadata is stale.  A version strategy is chosen based on the availability of go module information along with the current app configuration.

--- a/lib/licensed/configuration.rb
+++ b/lib/licensed/configuration.rb
@@ -69,7 +69,9 @@ module Licensed
 
     # Is the given dependency reviewed?
     def reviewed?(dependency)
-      Array(self["reviewed"][dependency["type"]]).include?(dependency["name"])
+      Array(self["reviewed"][dependency["type"]]).any? do |pattern|
+        File.fnmatch?(pattern, dependency["name"], File::FNM_PATHNAME | File::FNM_CASEFOLD)
+      end
     end
 
     # Is the given dependency ignored?

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -305,12 +305,56 @@ describe Licensed::AppConfiguration do
   end
 
   describe "review" do
-    let(:package) { { "type" => "bundler", "name" => "bundler" } }
+    let(:package) { { "type" => "go", "name" => "github.com/github/licensed/package" } }
 
     it "marks the dependency as reviewed" do
       refute config.reviewed?(package)
       config.review package
       assert config.reviewed?(package)
+    end
+
+    describe "with glob patterns" do
+      it "does not match trailing ** to multiple path segments" do
+        refute config.reviewed?(package)
+        config.review package.merge("name" => "github.com/github/**")
+        refute config.reviewed?(package)
+      end
+
+      it "matches internal ** to multiple path segments" do
+        refute config.reviewed?(package)
+        config.review package.merge("name" => "github.com/**/package")
+        assert config.reviewed?(package)
+      end
+
+      it "matches trailing * to single path segment" do
+        refute config.reviewed?(package)
+        config.review package.merge("name" => "github.com/github/licensed/*")
+        assert config.reviewed?(package)
+      end
+
+      it "maches internal * to single path segment" do
+        refute config.reviewed?(package)
+        config.review package.merge("name" => "github.com/*/licensed/package")
+        assert config.reviewed?(package)
+      end
+
+      it "matches multiple globstars in a pattern" do
+        refute config.reviewed?(package)
+        config.review package.merge("name" => "**/licensed/*")
+        assert config.reviewed?(package)
+      end
+
+      it "does not match * to multiple path segments" do
+        refute config.reviewed?(package)
+        config.review package.merge("name" => "github.com/github/*")
+        refute config.reviewed?(package)
+      end
+
+      it "is case insensitive" do
+        refute config.reviewed?(package)
+        config.review package.merge("name" => "GITHUB.com/github/**")
+        refute config.reviewed?(package)
+      end
     end
   end
 


### PR DESCRIPTION
closes https://github.com/github/licensed/issues/311
closes https://github.com/github/licensed/issues/310
ref https://github.com/github/licensed/pull/225#issuecomment-692381481

This allows globs to be set for `reviewed` dependencies similar to the functionality that already exists for `ignored` dependencies.

Due to this functionality being potentially dangerous and it's intended use case only making sense for the go source I've moved the relevant documentation from general configuration docs to go-specific docs.