### PR TITLE
Create and upload release assets on GitHub release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,18 +1,12 @@
-name: Create release
+name: Build and publish release assets
 
-on: create
+on:
+  release:
+    types: [created]
 
 jobs:
-  tag_filter:
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')
-    steps:
-      - run: exit 0
-
   package_linux:
     runs-on: ubuntu-latest
-    needs: tag_filter
-
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby 2.6
@@ -23,17 +17,15 @@ jobs:
     - name: Build package
       run: script/packages/linux
       env:
-        VERSION: ${{github.event.ref}}
+        VERSION: ${{github.event.release.tag_name}}
 
     - uses: actions/upload-artifact@v2
       with:
-        name: ${{github.event.ref}}-linux
-        path: pkg/${{github.event.ref}}/licensed-${{github.event.ref}}-linux-x64.tar.gz
+        name: ${{github.event.release.tag_name}}-linux
+        path: pkg/${{github.event.release.tag_name}}/licensed-${{github.event.release.tag_name}}-linux-x64.tar.gz
 
   package_mac:
     runs-on: macOS-latest
-    needs: tag_filter
-
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby 2.6
@@ -44,17 +36,15 @@ jobs:
     - name: Build package
       run: script/packages/mac
       env:
-        VERSION: ${{github.event.ref}}
+        VERSION: ${{github.event.release.tag_name}}
 
     - uses: actions/upload-artifact@v2
       with:
-        name: ${{github.event.ref}}-darwin
-        path: pkg/${{github.event.ref}}/licensed-${{github.event.ref}}-darwin-x64.tar.gz
+        name: ${{github.event.release.tag_name}}-darwin
+        path: pkg/${{github.event.release.tag_name}}/licensed-${{github.event.release.tag_name}}-darwin-x64.tar.gz
 
   build_gem:
     runs-on: ubuntu-latest
-    needs: tag_filter
-
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby 2.6
@@ -67,21 +57,12 @@ jobs:
 
     - uses: actions/upload-artifact@v2
       with:
-        name: ${{github.event.ref}}-gem
-        path: licensed-${{github.event.ref}}.gem
-
-  create_release:
-    runs-on: ubuntu-latest
-    needs: [package_linux, package_mac, build_gem]
-    steps:
-    - uses: Roang-zero1/github-create-release-action@v1.0.2
-      env:
-        GITHUB_TOKEN: ${{ secrets.API_AUTH_TOKEN }}
-        VERSION_REGEX: "^[[:digit:]]+\\.[[:digit:]]+\\.[[:digit:]]+"
+        name: ${{github.event.release.tag_name}}-gem
+        path: licensed-${{github.event.release.tag_name}}.gem
 
   upload_packages:
     runs-on: ubuntu-latest
-    needs: [create_release]
+    needs: [package_linux, package_mac, build_gem]
 
     steps:
     - name: Set up Ruby 2.6
@@ -92,32 +73,42 @@ jobs:
     - name: Download linux package
       uses: actions/download-artifact@v2
       with:
-        name: ${{github.event.ref}}-linux
+        name: ${{github.event.release.tag_name}}-linux
 
     - name: Download macOS package
       uses: actions/download-artifact@v2
       with:
-        name: ${{github.event.ref}}-darwin
+        name: ${{github.event.release.tag_name}}-darwin
 
     - name: Download gem
       uses: actions/download-artifact@v2
       with:
-        name: ${{github.event.ref}}-gem
+        name: ${{github.event.release.tag_name}}-gem
 
-    - name: Publish packages to GitHub Release
-      uses: Roang-zero1/github-upload-release-artifacts-action@v2.0.0
+    - name: Publish linux package
+      uses: actions/upload-release-asset@v1
       with:
-        args: licensed-${{github.event.ref}}-linux-x64.tar.gz licensed-${{github.event.ref}}-darwin-x64.tar.gz
-      env:
-        GITHUB_TOKEN: ${{secrets.API_AUTH_TOKEN}}
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./licensed-${{github.event.release.tag_name}}-linux-x64.tar.gz
+        asset_name: licensed-${{github.event.release.tag_name}}-linux-x64.tar.gz
+        asset_content_type: application/gzip
 
-    - name: Publish gem to RubyGems
-      run: |
-        mkdir -p $HOME/.gem
-        touch $HOME/.gem/credentials
-        chmod 0600 $HOME/.gem/credentials
-        printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
-        gem push $GEM
-      env:
-        GEM_HOST_API_KEY: ${{secrets.RUBYGEMS_AUTH_TOKEN}}
-        GEM: licensed-${{github.event.ref}}.gem
+    - name: Publish mac package
+      uses: actions/upload-release-asset@v1
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./licensed-${{github.event.release.tag_name}}-darwin-x64.tar.gz
+        asset_name: licensed-${{github.event.release.tag_name}}-darwin-x64.tar.gz
+        asset_content_type: application/gzip
+
+    # TODO: uncomment once testing completed
+    # - name: Publish gem to RubyGems
+    #   run: |
+    #     mkdir -p $HOME/.gem
+    #     touch $HOME/.gem/credentials
+    #     chmod 0600 $HOME/.gem/credentials
+    #     printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+    #     gem push $GEM
+    #   env:
+    #     GEM_HOST_API_KEY: ${{secrets.RUBYGEMS_AUTH_TOKEN}}
+    #     GEM: licensed-${{github.event.release.tag_name}}.gem

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ Pull requests that include a new dependency source must also
 ## Releasing
 If you are the current maintainer of this gem:
 
-1. Create a branch for the release: git checkout -b cut-release-vxx.xx.xx
+1. Create a branch for the release: git checkout -b cut-release-xx.xx.xx
 2. Make sure your local dependencies are up to date: `script/bootstrap`
 3. Ensure that tests are green: `bundle exec rake test`
 4. Bump gem version in lib/licensed/version.rb.
@@ -51,15 +51,16 @@ If you are the current maintainer of this gem:
    2. Install the new gem locally
    3. Test behavior locally, branch deploy, whatever needs to happen
 9. Merge github/licensed PR
-10. Tag and push: `git tag x.xx.xx; git push --tags`
+10. Create a new [github/licensed release](https://github.com/github/licensed/releases)
+   - Set the release name and tag to the release version - `x.xx.x`
+   - Set the release body to the changelog entries for the release
 
 The following steps will happen automatically from a GitHub Actions workflow
-after pushing a new tag. In case that fails, the following steps can be performed manually
+after creating the release. In case that fails, the following steps can be performed manually
 
-11. Push to rubygems.org -- `gem push licensed-x.xx.xx.gem`
+11. Push the gem from (7) to rubygems.org -- `gem push licensed-x.xx.xx.gem`
 12. Build packages for new tag: `VERSION=x.xx.xx bundle exec rake package`
-13. Create release for new tag at github/licensed.
-14. Add built packages to new release
+13. Upload packages from (12) to release from (10)
 
 ## Resources
 


### PR DESCRIPTION
This makes some changes to the release process to reduce some friction points by making the action workflow run on release creation.  The change in process means that

1. Creating new tags no longer create a new release, making tags more generally usable
2. The action workflow is reduced in scope and generally simplified, removing steps to create a release or check that a tag is created

I'll try to test this by creating a test release that targets this branch, but if that doesn't trigger the new workflow I might need to merge this to master in order to test it.  The changes that need verification are (1) making sure the syntax for getting the tag name is correct and (2) making sure that uploading the built packages to the release are working, using the `actions/upload-release-asset` step.