### PR TITLE
Reenable push to rubygems in prep for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,14 +101,13 @@ jobs:
         asset_name: licensed-${{github.event.release.tag_name}}-darwin-x64.tar.gz
         asset_content_type: application/gzip
 
-    # TODO: uncomment once testing completed
-    # - name: Publish gem to RubyGems
-    #   run: |
-    #     mkdir -p $HOME/.gem
-    #     touch $HOME/.gem/credentials
-    #     chmod 0600 $HOME/.gem/credentials
-    #     printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
-    #     gem push $GEM
-    #   env:
-    #     GEM_HOST_API_KEY: ${{secrets.RUBYGEMS_AUTH_TOKEN}}
-    #     GEM: licensed-${{github.event.release.tag_name}}.gem
+    - name: Publish gem to RubyGems
+      run: |
+        mkdir -p $HOME/.gem
+        touch $HOME/.gem/credentials
+        chmod 0600 $HOME/.gem/credentials
+        printf -- "---\n:rubygems_api_key: ${RUBYGEMS_API_KEY}\n" > $HOME/.gem/credentials
+        gem push $GEM
+      env:
+        RUBYGEMS_API_KEY: ${{secrets.RUBYGEMS_AUTH_TOKEN}}
+        GEM: licensed-${{github.event.release.tag_name}}.gem

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
         ruby-version: 2.6.x
 
     - name: Build gem
-      run: gem build *.gemspec
+      run: gem build licensed.gemspec -o licensed-${{github.event.release.tag_name}}.gem
 
     - uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
Testing the new release workflow generally went well :+1:.  There was an error due to a naming mismatch between the default gem file name using `Licensed::VERSION` and the action expecting something using the release tag name.  I've fixed that by naming the output file to match the expected file name with `-o licensed-${{github.even.release.tag_name}}.gem`.

Reenabling pushing gems to rubygems to prepare for releasing 2.14