### PR TITLE
Encode shell output into UTF8

### DIFF
--- a/test/shell_test.rb
+++ b/test/shell_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+require "test_helper"
+require "tmpdir"
+
+describe Licensed::Shell do
+  let(:root) { File.expand_path("../..", __FILE__) }
+
+  describe "#execute" do
+    let(:content) { "��test".dup.force_encoding("ASCII-8BIT") }
+    let(:expected) { "test" }
+
+    it "encodes non-utf8 content in stdout" do
+      Open3.expects(:capture3).returns([content, "", stub(success?: true)])
+      assert_equal expected, Licensed::Shell.execute("test")
+    end
+
+    it "encodes non-utf8 content in stderr" do
+      Open3.expects(:capture3).returns(["", content, stub(success?: false, exitstatus: 1)])
+      err = assert_raises Licensed::Shell::Error do
+        Licensed::Shell.execute("test")
+      end
+
+      assert_equal "'test' exited with status 1\n        #{expected}", err.message
+    end
+  end
+end


### PR DESCRIPTION
It's possible that when running a shell command with `Licensed::Shell.execute` that returned output is not utf8 encoded.  This has been observed to cause issues down the line where a `String#gsub` call crashes licensed with

> `gsub': invalid byte sequence in US-ASCII (ArgumentError)

This PR is a small change to force shell output to be encoded into a format that can be worked with