### PR TITLE
Fix handling of vendor path detection in go source

### DIFF
--- a/test/fixtures/command/go.yml
+++ b/test/fixtures/command/go.yml
@@ -5,7 +5,7 @@ go:
 
 apps:
   - source_path: test/fixtures/go/src/test
-  - source_path: test/fixtures/go
+  - source_path: test/fixtures/go/src/test/cmd
 
 sources:
   go: true

--- a/test/fixtures/go/src/test/cmd/command/main.go
+++ b/test/fixtures/go/src/test/cmd/command/main.go
@@ -1,4 +1,4 @@
-package test
+package command
 
 import (
   lru "github.com/hashicorp/golang-lru"

--- a/test/fixtures/go/src/test/internal/fakevendor/github.com/owner/repo/testpackage.go
+++ b/test/fixtures/go/src/test/internal/fakevendor/github.com/owner/repo/testpackage.go
@@ -1,0 +1,9 @@
+package testpackage
+
+import (
+  "fmt"
+)
+
+func HelloWorld() {
+  fmt.Println("hello world")
+}

--- a/test/sources/go_test.rb
+++ b/test/sources/go_test.rb
@@ -6,7 +6,8 @@ if Licensed::Shell.tool_available?("go")
   describe Licensed::Sources::Go do
     let(:gopath) { File.expand_path("../../fixtures/go", __FILE__) }
     let(:fixtures) { File.join(gopath, "src/test") }
-    let(:config) { Licensed::AppConfiguration.new({ "go" => { "GOPATH" => gopath }, "source_path" => Dir.pwd }) }
+    let(:root) { File.join(gopath, "src/test") }
+    let(:config) { Licensed::AppConfiguration.new({ "go" => { "GOPATH" => gopath }, "source_path" => fixtures, "root" => root }) }
     let(:source) { Licensed::Sources::Go.new(config) }
 
     describe "enabled?" do
@@ -31,7 +32,7 @@ if Licensed::Shell.tool_available?("go")
       end
 
       it "works with a configuration path relative to repository root" do
-        config["go"]["GOPATH"] = "test/fixtures/go"
+        config["go"]["GOPATH"] = "../.."
         assert_equal gopath, source.gopath
       end
 
@@ -208,6 +209,7 @@ if Licensed::Shell.tool_available?("go")
 
       describe "with vendored go modules" do
         let(:fixtures) { File.join(gopath, "src/modules_test") }
+        let(:root) { File.join(gopath, "src/modules_test") }
 
         before do
           skip unless source.go_version >= Gem::Version.new("1.11.0")
@@ -229,6 +231,45 @@ if Licensed::Shell.tool_available?("go")
             source.dependencies.each do |dep|
               assert dep.path.include?("vendor/")
             end
+          end
+        end
+      end
+
+      describe "from a subfolder source_path" do
+        let(:fixtures) { File.join(gopath, "src/test/cmd/command") }
+
+        it "includes direct dependencies" do
+          Dir.chdir fixtures do
+            dep = source.dependencies.detect { |d| d.name == "github.com/hashicorp/golang-lru" }
+            assert dep
+            assert_equal "go", dep.record["type"]
+            assert dep.record["homepage"]
+            assert dep.record["summary"]
+          end
+        end
+
+        it "includes indirect dependencies" do
+          Dir.chdir fixtures do
+            dep = source.dependencies.detect { |d| d.name == "github.com/hashicorp/golang-lru/simplelru" }
+            assert dep
+            assert_equal "go", dep.record["type"]
+            assert dep.record["homepage"]
+          end
+        end
+
+        it "searches for license files under the vendor folder for vendored dependencies" do
+          Dir.chdir fixtures do
+            dep = source.dependencies.detect { |d| d.name == "github.com/davecgh/go-spew/spew" }
+            assert dep
+
+            # find the license one directory higher
+            license_path = File.join(root, "vendor/github.com/davecgh/go-spew/LICENSE")
+            license = dep.record.licenses.find { |l| l.sources == ["go-spew/LICENSE"] }
+            assert license
+            assert_equal File.read(license_path), license.text
+
+            # do not find the license outside the vendor folder
+            assert_nil dep.record.licenses.find { |l| l.sources == ["LICENSE"] }
           end
         end
       end
@@ -319,8 +360,12 @@ if Licensed::Shell.tool_available?("go")
         assert source.go_std_package?(package)
       end
 
-      it "returns true if the vendored import path without 'vendor/' matches 'go list std'" do
-        package = { "ImportPath" => "#{root_package_import_path}/vendor/package/2" }
+      it "returns true if the non-vendored import path matches 'go list std'" do
+        package = {
+          "ImportPath" => "#{root_package_import_path}/vendor/package/2",
+          # determining the non-vendored path requires the "Dir" value to be set
+          "Dir" => "#{root}/vendor/package/2"
+        }
         assert source.go_std_package?(package)
       end
 


### PR DESCRIPTION
closes https://github.com/github/licensed/issues/321
closes https://github.com/github/licensed/issues/322

This PR is meant to fix a few issues with how the go source detects whether a package is vendored and what the package's non-vendored import path is.

`go list -e -json` can return import paths that include vendor path parts.  Previously, checking for vendored import paths happened in a few places and in a few different ways.  This change creates a single way to detect for a vendored path in the `vendored_path_parts` function.  The function returns results of `String#match` with a regex on a package's "Dir" value, with named groups for the path to the vendor folder and the remaining import path.  This is a change on the existing functionality which detected a vendored import path based on the packages "ImportPath" value.

There were two broad buckets of usage for checking for whether a package was vendored. First was to get the import path of a package without any vendoring information, and the second was to get the path to the vendor folder for the package.  In all cases, the caller didn't really care whether the package was vendored or not.

One issue I found is that it is not against go's structure rules to have a package import path like `.../pkg/vendor`.  It _is_ against the rules though to have `.../pkg/vendor/*`.  The regex should handle this case, as it only matches on paths that have a folder named `vendor` followed by additional path content.