### PR TITLE
Release 2.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## 2.14.2
+2020-11-20
+
+## Fixed
+- Yarn source correctly finds dependency paths on disk (https://github.com/github/licensed/pull/326)
+- Go source better handles finding dependencies that have been vendored (https://github.com/github/licensed/pull/323)
+
 ## 2.14.1
 2020-10-09
 
@@ -366,4 +373,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Initial release :tada:
 
-[Unreleased]: https://github.com/github/licensed/compare/2.14.1...HEAD
+[Unreleased]: https://github.com/github/licensed/compare/2.14.2...HEAD

--- a/lib/licensed/version.rb
+++ b/lib/licensed/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Licensed
-  VERSION = "2.14.1".freeze
+  VERSION = "2.14.2".freeze
 
   def self.previous_major_versions
     major_version = Gem::Version.new(Licensed::VERSION).segments.first


### PR DESCRIPTION
## 2.14.2
2020-11-20

## Fixed
- Yarn source correctly finds dependency paths on disk (https://github.com/github/licensed/pull/326)
- Go source better handles finding dependencies that have been vendored (https://github.com/github/licensed/pull/323)