### PR TITLE
`generated_license_contents`: early return when `license.text` is nil

### DIFF
--- a/lib/licensed/dependency.rb
+++ b/lib/licensed/dependency.rb
@@ -142,6 +142,7 @@ module Licensed
     def generated_license_contents
       return unless license
       return if license.key == "other"
+      return unless license.text.nil?
 
       # strip copyright clauses and any extra newlines
       # many package managers don't provide enough information to

--- a/lib/licensed/dependency.rb
+++ b/lib/licensed/dependency.rb
@@ -142,7 +142,7 @@ module Licensed
     def generated_license_contents
       return unless license
       return if license.key == "other"
-      return unless license.text.nil?
+      return if license.text.nil?
 
       # strip copyright clauses and any extra newlines
       # many package managers don't provide enough information to


### PR DESCRIPTION
I have this error when running `licensed` (in a larger project):
```
/licensed-2.14.2/lib/licensed/dependency.rb:149:in `generated_license_contents': undefined method `lines' for nil:NilClass (NoMethodError)
```

I figured that `license.text` in [dependency.rb:149](https://github.com/github/licensed/blob/2.14.2/lib/licensed/dependency.rb#L149) must be `nil` for this error to occur. 

I am not a ruby developer so feel free to edit the code as much as needed.