### PR TITLE
Set explicit SSL certificate directory when building release packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,60 @@ name: Build and publish release assets
 on:
   release:
     types: [created]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Commit-like version of github/licensed to build package at'
+        required: true
+      release_tag:
+        description: 'Release tag to upload built packages to'
+        required: false
 
 jobs:
+  vars:
+    name: "Gather values for remainder of steps"
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get_version.outputs.version }}
+      upload_url: ${{ steps.get_url.outputs.url }}
+    steps:
+      - id: get_version
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          if [ -z "$VERSION"  ]; then
+            VERSION="${{ github.event.release.tag_name }}"
+          fi
+
+          if [ -z "$VERSION" ]; then
+            echo "could not find a version to build" >&2
+            exit 1
+          fi
+
+          echo "::set-output name=version::$VERSION"
+      - id: get_url
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            let uploadUrl = "${{ github.event.release.upload_url}}"
+            const tag = "${{ github.event.inputs.release_tag }}"
+            if (!uploadUrl && tag) {
+              const { data: release } = await github.repos.getReleaseByTag({
+                ...context.repo,
+                tag
+              })
+
+              if (!release.upload_url) {
+                throw new Error("unable to find a release upload url")
+              }
+
+              uploadUrl = release.upload_url
+            }
+
+            return uploadUrl
+
   package_linux:
+    needs: vars
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -17,14 +68,15 @@ jobs:
     - name: Build package
       run: script/packages/linux
       env:
-        VERSION: ${{github.event.release.tag_name}}
+        VERSION: ${{needs.vars.outputs.version}}
 
     - uses: actions/upload-artifact@v2
       with:
-        name: ${{github.event.release.tag_name}}-linux
-        path: pkg/${{github.event.release.tag_name}}/licensed-${{github.event.release.tag_name}}-linux-x64.tar.gz
+        name: ${{needs.vars.outputs.version}}-linux
+        path: pkg/${{needs.vars.outputs.version}}/licensed-${{needs.vars.outputs.version}}-linux-x64.tar.gz
 
   package_mac:
+    needs: vars
     runs-on: macOS-latest
     steps:
     - uses: actions/checkout@v2
@@ -36,14 +88,15 @@ jobs:
     - name: Build package
       run: script/packages/mac
       env:
-        VERSION: ${{github.event.release.tag_name}}
+        VERSION: ${{needs.vars.outputs.version}}
 
     - uses: actions/upload-artifact@v2
       with:
-        name: ${{github.event.release.tag_name}}-darwin
-        path: pkg/${{github.event.release.tag_name}}/licensed-${{github.event.release.tag_name}}-darwin-x64.tar.gz
+        name: ${{needs.vars.outputs.version}}-darwin
+        path: pkg/${{needs.vars.outputs.version}}/licensed-${{needs.vars.outputs.version}}-darwin-x64.tar.gz
 
   build_gem:
+    needs: vars
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -53,16 +106,17 @@ jobs:
         ruby-version: 2.6.x
 
     - name: Build gem
-      run: gem build licensed.gemspec -o licensed-${{github.event.release.tag_name}}.gem
+      run: gem build licensed.gemspec -o licensed-${{needs.vars.outputs.version}}.gem
 
     - uses: actions/upload-artifact@v2
       with:
-        name: ${{github.event.release.tag_name}}-gem
-        path: licensed-${{github.event.release.tag_name}}.gem
+        name: ${{needs.vars.outputs.version}}-gem
+        path: licensed-${{needs.vars.outputs.version}}.gem
 
   upload_packages:
+    if: ${{ needs.vars.outputs.upload_url }}
     runs-on: ubuntu-latest
-    needs: [package_linux, package_mac, build_gem]
+    needs: [vars, package_linux, package_mac, build_gem]
 
     steps:
     - name: Set up Ruby 2.6
@@ -73,26 +127,26 @@ jobs:
     - name: Download linux package
       uses: actions/download-artifact@v2
       with:
-        name: ${{github.event.release.tag_name}}-linux
+        name: ${{needs.vars.outputs.version}}-linux
 
     - name: Download macOS package
       uses: actions/download-artifact@v2
       with:
-        name: ${{github.event.release.tag_name}}-darwin
+        name: ${{needs.vars.outputs.version}}-darwin
 
     - name: Download gem
       uses: actions/download-artifact@v2
       with:
-        name: ${{github.event.release.tag_name}}-gem
+        name: ${{needs.vars.outputs.version}}-gem
 
     - name: Publish linux package
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ./licensed-${{github.event.release.tag_name}}-linux-x64.tar.gz
-        asset_name: licensed-${{github.event.release.tag_name}}-linux-x64.tar.gz
+        upload_url: ${{ needs.vars.outputs.upload_url }}
+        asset_path: ./licensed-${{needs.vars.outputs.version}}-linux-x64.tar.gz
+        asset_name: licensed-${{needs.vars.outputs.version}}-linux-x64.tar.gz
         asset_content_type: application/gzip
 
     - name: Publish mac package
@@ -100,9 +154,9 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ./licensed-${{github.event.release.tag_name}}-darwin-x64.tar.gz
-        asset_name: licensed-${{github.event.release.tag_name}}-darwin-x64.tar.gz
+        upload_url: ${{ needs.vars.outputs.upload_url }}
+        asset_path: ./licensed-${{needs.vars.outputs.version}}-darwin-x64.tar.gz
+        asset_name: licensed-${{needs.vars.outputs.version}}-darwin-x64.tar.gz
         asset_content_type: application/gzip
 
     - name: Publish gem to RubyGems
@@ -114,4 +168,4 @@ jobs:
         gem push $GEM
       env:
         RUBYGEMS_API_KEY: ${{secrets.RUBYGEMS_AUTH_TOKEN}}
-        GEM: licensed-${{github.event.release.tag_name}}.gem
+        GEM: licensed-${{needs.vars.outputs.version}}.gem

--- a/docker/Dockerfile.build-linux
+++ b/docker/Dockerfile.build-linux
@@ -12,3 +12,4 @@ RUN gem update --system && gem update bundler
 ENV CPPFLAGS="-P"
 ENV RUBYC="/usr/local/bin/rubyc"
 ENV LANG=C.UTF-8
+ENV SSL_CERT_DIR="/etc/ssl/certs"

--- a/script/packages/linux
+++ b/script/packages/linux
@@ -42,6 +42,7 @@ build_linux_local() {
   fi
 
   export CPPFLAGS="-P"
+  export SSL_CERT_DIR="/etc/ssl/certs"
   export RUBYC
   "$BASE_DIR"/script/packages/build
 }


### PR DESCRIPTION
This adds explicit setting of `SSL_CERT_DIR` when building packages for linux.  I'm not entirely sure what is causing the failure but a local build and install of the licensed gem that occurs in the linux executable build process is no longer able to access rubygems to download packages, due to an SSL cert error.

Both rubygems and bundler have put out new releases since the last licensed release occurred so it's possible the issue lies there, or maybe one of the packages that's installed from apt-get changed?  I'm not sure TBH but I was able to reproduce the issue locally using Dockerfile.build-linux.

I found that the error can be fixed by setting the SSL_CERT_DIR environment variable to `/etc/ssl/certs`, which should be an ok standard location to find certs.

I also updated the release workflow to allow for manual builds so I don't need to delete/recreate releases when errors occur.  I'm not entirely sure about the changes there, but I don't think I can test that without first pushing the changes to the default branch 🤷 