### PR TITLE
Fix linux package build + usability improvements to build action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.get_version.outputs.version }}
-      upload_url: ${{ steps.get_url.outputs.url }}
+      upload_url: ${{ steps.get_url.outputs.result }}
     steps:
       - id: get_version
         run: |
@@ -37,6 +37,7 @@ jobs:
         uses: actions/github-script@v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          result-encoding: string
           script: |
             let uploadUrl = "${{ github.event.release.upload_url}}"
             const tag = "${{ github.event.inputs.release_tag }}"
@@ -123,7 +124,7 @@ jobs:
         path: licensed-${{needs.vars.outputs.version}}.gem
 
   upload_packages:
-    if: ${{ needs.vars.outputs.upload_url }}
+    if: ${{ needs.vars.outputs.upload_url != '' }}
     runs-on: ubuntu-latest
     needs: [vars, package_linux, package_mac, build_gem]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
     outputs:
       version: ${{ steps.get_version.outputs.version }}
       upload_url: ${{ steps.get_url.outputs.result }}
+      ref: ${{ steps.get_ref.outputs.result }}
     steps:
       - id: get_version
         run: |
@@ -56,13 +57,33 @@ jobs:
 
             return uploadUrl
 
+      - id: get_ref
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          result-encoding: string
+          script: |
+            let ref = "${{ github.event.release.tag_name }}"
+            if (!ref) {
+              ref = "${{ github.event.ref }}".replace(/refs\/[^\/]+\//, '')
+
+              if (!ref) {
+                throw new Error("unable to find a ref for action")
+              }
+            }
+
+            return ref
+
   package_linux:
     needs: vars
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
       with:
-        ref: ${{needs.vars.outputs.version}}
+        # checkout at the ref for the action, separate from the target build version
+        # this allows running build scripts independent of the target version
+        ref: ${{needs.vars.outputs.ref}}
+        fetch-depth: 0
 
     - name: Set up Ruby 2.6
       uses: actions/setup-ruby@v1
@@ -85,7 +106,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        ref: ${{needs.vars.outputs.version}}
+        # checkout at the ref for the action, separate from the target build version
+        # this allows running build scripts independent of the target version
+        ref: ${{needs.vars.outputs.ref}}
+        fetch-depth: 0
 
     - name: Set up Ruby 2.6
       uses: actions/setup-ruby@v1
@@ -108,8 +132,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
+        # building a gem doesn't use a different ref from the version input
         ref: ${{needs.vars.outputs.version}}
-        
+
     - name: Set up Ruby 2.6
       uses: actions/setup-ruby@v1
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
       ref: ${{ steps.get_ref.outputs.result }}
     steps:
       - id: get_version
+        name: Get package version
         uses: actions/github-script@v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -39,6 +40,7 @@ jobs:
             return version
 
       - id: get_url
+        name: Get release upload url
         uses: actions/github-script@v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -62,6 +64,7 @@ jobs:
             return uploadUrl
 
       - id: get_ref
+        name: Get checkout ref for custom build scripts
         uses: actions/github-script@v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,23 +17,27 @@ jobs:
     name: "Gather values for remainder of steps"
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.get_version.outputs.version }}
+      version: ${{ steps.get_version.outputs.result }}
       upload_url: ${{ steps.get_url.outputs.result }}
       ref: ${{ steps.get_ref.outputs.result }}
     steps:
       - id: get_version
-        run: |
-          VERSION="${{ github.event.inputs.version }}"
-          if [ -z "$VERSION"  ]; then
-            VERSION="${{ github.event.release.tag_name }}"
-          fi
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          result-encoding: string
+          script: |
+            let version = "${{ github.event.release.tag_name }}"
+            if (!version) {
+              version = "${{ github.event.inputs.version }}"
+            }
 
-          if [ -z "$VERSION" ]; then
-            echo "could not find a version to build" >&2
-            exit 1
-          fi
+            if (!version) {
+              throw new Error("unable to find package build version")
+            }
 
-          echo "::set-output name=version::$VERSION"
+            return version
+
       - id: get_url
         uses: actions/github-script@v3
         with:
@@ -66,10 +70,10 @@ jobs:
             let ref = "${{ github.event.release.tag_name }}"
             if (!ref) {
               ref = "${{ github.event.ref }}".replace(/refs\/[^\/]+\//, '')
+            }
 
-              if (!ref) {
-                throw new Error("unable to find a ref for action")
-              }
+            if (!ref) {
+              throw new Error("unable to find a ref for action")
             }
 
             return ref

--- a/script/packages/linux
+++ b/script/packages/linux
@@ -34,6 +34,9 @@ build_linux_local() {
   sudo apt-get update
   sudo apt-get install -y --no-install-recommends cmake make gcc pkg-config squashfs-tools curl bison git rsync
 
+  sudo gem update --system
+  sudo gem update bundler
+
   RUBYC="$BASE_DIR/bin/rubyc-linux"
   if [ ! -f "$RUBYC" ]; then
     mkdir -p "$(dirname "$RUBYC")"


### PR DESCRIPTION
This fixes the linux package build script, as well as fixing some things in the build action and generally making it more usable.

The change needed to get the package build working was to update rubygems and bundler.

For the build action, I changed the vars gathering pre-job to all use actions/github-script and use string-encoded outputs.  I added another var for the ref to checkout for the build scripts, to separate between the version of the build scripts to use and the version of the package to build when the action is run manually and the user can choose which branch to run the action from.  Lastly I fixed some minor bugs in the script and added more step names to make the output a little clearer.

The changes in this branch were [manually run]((https://github.com/github/licensed/runs/1546300686?check_suite_focus=true)) to build and upload the release packages for the [2.14.3 release](https://github.com/github/licensed/releases/tag/2.14.3).