### PR TITLE
Add more output options for list and cache commands

### DIFF
--- a/lib/licensed/cli.rb
+++ b/lib/licensed/cli.rb
@@ -12,9 +12,11 @@ module Licensed
       desc: "Path to licensed configuration file"
     method_option :sources, aliases: "-s", type: :array,
       desc: "Individual source(s) to evaluate.  Must also be enabled via configuration."
+    method_option :format, aliases: "-f", enum: ["yaml", "json"],
+      desc: "Output format"
     def cache
       run Licensed::Commands::Cache.new(config: config),
-          force: options[:force], sources: options[:sources]
+          force: options[:force], sources: options[:sources], reporter: options[:format]
     end
 
     desc "status", "Check status of dependencies' cached licenses"
@@ -33,8 +35,10 @@ module Licensed
       desc: "Path to licensed configuration file"
     method_option :sources, aliases: "-s", type: :array,
       desc: "Individual source(s) to evaluate.  Must also be enabled via configuration."
+    method_option :format, aliases: "-f", enum: ["yaml", "json"],
+      desc: "Output format"
     def list
-      run Licensed::Commands::List.new(config: config), sources: options[:sources]
+      run Licensed::Commands::List.new(config: config), sources: options[:sources], reporter: options[:format]
     end
 
     desc "notices", "Generate a NOTICE file from cached records"

--- a/lib/licensed/cli.rb
+++ b/lib/licensed/cli.rb
@@ -37,8 +37,10 @@ module Licensed
       desc: "Individual source(s) to evaluate.  Must also be enabled via configuration."
     method_option :format, aliases: "-f", enum: ["yaml", "json"],
       desc: "Output format"
+    method_option :licenses, aliases: "-l", type: :boolean,
+      desc: "Include detected licenses in output"
     def list
-      run Licensed::Commands::List.new(config: config), sources: options[:sources], reporter: options[:format]
+      run Licensed::Commands::List.new(config: config), sources: options[:sources], reporter: options[:format], licenses: options[:licenses]
     end
 
     desc "notices", "Generate a NOTICE file from cached records"

--- a/lib/licensed/commands/list.rb
+++ b/lib/licensed/commands/list.rb
@@ -41,6 +41,13 @@ module Licensed
       #
       # Returns true.
       def evaluate_dependency(app, source, dependency, report)
+        report["dependency"] = dependency.name
+        report["version"] = dependency.version
+
+        if options[:licenses]
+          report["license"] = dependency.license_key
+        end
+
         true
       end
     end

--- a/lib/licensed/reporters/list_reporter.rb
+++ b/lib/licensed/reporters/list_reporter.rb
@@ -75,7 +75,9 @@ module Licensed
       def report_dependency(dependency)
         super do |report|
           result = yield report
-          shell.info "    #{dependency.name} (#{dependency.version})"
+          info = "#{dependency.name} (#{dependency.version})"
+          info = "#{info}: #{report["license"]}" if report["license"]
+          shell.info "    #{info}"
 
           result
         end

--- a/test/commands/list_test.rb
+++ b/test/commands/list_test.rb
@@ -103,4 +103,24 @@ describe Licensed::Commands::List do
       end
     end
   end
+
+  it "sets the dependency version in dependency reports" do
+    run_command
+    dependencies = reporter.report.all_reports.select { |r| r.target.is_a?(Licensed::Dependency) }
+    assert dependencies.all? { |dependency| dependency["version"] }
+  end
+
+  describe "detected license key" do
+    it "is not included in dependency reports by default" do
+      run_command
+      dependencies = reporter.report.all_reports.select { |r| r.target.is_a?(Licensed::Dependency) }
+      refute dependencies.any? { |dependency| dependency["license"] }
+    end
+
+    it "is included in depenency reports if the license CLI flag is set" do
+      run_command(licenses: true)
+      dependencies = reporter.report.all_reports.select { |r| r.target.is_a?(Licensed::Dependency) }
+      assert dependencies.all? { |dependency| dependency["license"] }
+    end
+  end
 end

--- a/test/reporters/list_reporter_test.rb
+++ b/test/reporters/list_reporter_test.rb
@@ -188,14 +188,30 @@ describe Licensed::Reporters::ListReporter do
       end
     end
 
-    it "prints an informative messages for a cached dependency to the shell" do
+    it "prints an informative messages to the shell" do
       reporter.report_run(command) do
         reporter.report_app(app) do
           reporter.report_source(source) do
-            reporter.report_dependency(dependency) { |report| report["cached"] = true }
+            reporter.report_dependency(dependency) {}
             assert_includes shell.messages,
                             {
                                message: "    #{dependency.name} (#{dependency.version})",
+                               newline: true,
+                               style: :info
+                            }
+          end
+        end
+      end
+    end
+
+    it "includes the license in output to shell if license is set" do
+      reporter.report_run(command) do
+        reporter.report_app(app) do
+          reporter.report_source(source) do
+            reporter.report_dependency(dependency) { |report| report["license"] = dependency.license_key }
+            assert_includes shell.messages,
+                            {
+                               message: "    #{dependency.name} (#{dependency.version}): #{dependency.license_key}",
                                newline: true,
                                style: :info
                             }


### PR DESCRIPTION
This branch makes a few relatively small changes as followup to some quick exploration while looking at an [issue report](https://github.com/github/licensed/issues/333#issuecomment-772891527)

> This got me curious and I've put together a quick change locally that could give something like the above output by (1) extending licensed list to support different output formats and (2) including more information in the output. That unfortunately has some performance implications to that command so I'd need to review and see how to make the new functionality available without degrading general usage.

1. Adds the "format" CLI flag to the list and cache commands and passes the flag into each commands' `run` call.  Usage of the flag is already handled by the base command class so no further changes are needed to support JSON and YML output
2. Sets some dependency metadata into the `list` commands report object to be included in JSON/YML output
3. Adds a new CLI flag `-l/--licenses` to the list command that includes the detected license key in the output.
   - the default list output will look like `name (version): license`
   - included in json and YML as the `license` key on each dependency
   
/cc @lowlighter FYI