### PR TITLE
Fix the release scripting for mac builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,9 +93,9 @@ jobs:
         fetch-depth: 0
 
     - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: 2.6
 
     - name: Build package
       run: script/packages/linux
@@ -119,9 +119,9 @@ jobs:
         fetch-depth: 0
 
     - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: 2.6
 
     - name: Build package
       run: script/packages/mac
@@ -143,9 +143,9 @@ jobs:
         ref: ${{needs.vars.outputs.version}}
 
     - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: 2.6
 
     - name: Build gem
       run: gem build licensed.gemspec -o licensed-${{needs.vars.outputs.version}}.gem
@@ -162,9 +162,9 @@ jobs:
 
     steps:
     - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: 2.6
 
     - name: Download linux package
       uses: actions/download-artifact@v2

--- a/script/packages/build
+++ b/script/packages/build
@@ -51,8 +51,11 @@ cd $COPY_DIR
     trap "git checkout $CURRENT_BRANCH" EXIT
   fi
 
+  # get the openssl dir to use when building based on ruby's default ssl cert dir
+  OPENSSL_DIR="$(cd "$(ruby -e 'require "net/https"; puts OpenSSL::X509::DEFAULT_CERT_DIR')/.." && pwd)"
+
   # build the licensed rubyc executable
-  "$RUBYC" --clean-tmpdir -o "$BUILD_DIR/licensed" "$COPY_DIR/exe/licensed"
+  "$RUBYC" --openssl-dir "$OPENSSL_DIR" --clean-tmpdir -o "$BUILD_DIR/licensed" "$COPY_DIR/exe/licensed"
   chmod +x $BUILD_DIR/licensed
 )
 

--- a/script/packages/mac
+++ b/script/packages/mac
@@ -28,6 +28,9 @@ brew update
 brew list "squashfs" &>/dev/null || brew install "squashfs"
 brew list "pkg-config" &>/dev/null || brew install "pkg-config"
 
+gem update --system
+gem update bundler
+
 if [ ! -f "$RUBYC" ]; then
   mkdir -p "$(dirname "$RUBYC")"
   curl -L https://github.com/kontena/ruby-packer/releases/download/2.6.0-0.6.0/rubyc-2.6.0-0.6.0-osx-amd64.gz | gunzip > "$RUBYC"


### PR DESCRIPTION
This fixes the package build failures that were [called out](https://github.com/github/licensed/pull/335#issuecomment-776816271) on the 2.14.4 release issue.

A few changes were needed to fix SSL failures during the mac build process.  The SSL failures were not present on the build host, but were coming up during the build process.  The project uses https://github.com/kontena/ruby-packer to build the ruby code into a redistributable package, but the inner ruby build thats included in the package doesn't include certs by default as mentioned in the [README](https://github.com/kontena/ruby-packer#openssl).

I've done a few things here to fix the situation
1. Updated the release workflow to use `ruby/setup-ruby` instead of `actions/setup-ruby`, to make sure that the most recent and up to date ruby code was being brought onto the build host
1. Included `gem update --system` and `gem update bundler` in the mac build script, again to make sure that the most recent versions of each are being used in order to update any certificates or expectations related to certificates
1. Set the `--openssl-dir` argument when running rubyc to the parent directory of ruby's openssl default certificate directory.

With all of the above, I was able to successfully build both the linux and mac distributable exes which I minimally tested to ensure they were working.  I've attached those built packages to the [2.14.4 release](https://github.com/github/licensed/releases/tag/2.14.4) and released the built gem to rubygems