### PR TITLE
Force linux packaging script onto 18.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
 
   package_linux:
     needs: vars
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
closes https://github.com/github/licensed/issues/337

It looks like the underlying issue is that the the version of ruby-packer I'm using to build the licensed executable packages may not be compatible with ubuntu-20.04.  I think this repo might have been affected early for the change of the `ubuntu-latest` host os in actions to run on 20 instead of 18.  I can't find any documentation about the general switch for ubuntu-latest to 20.04 so I'm not sure if it's happened for all repos.  This repo might have been affected sooner to beta test the changes due to being a GitHub property 🤷 

The package build is not the only thing affected either, many of the CI tests using actions are broken as well due to not finding packages or frameworks available no the new machine type.

I forced the linux packaging job back to using ubuntu-18.04 and tested the [built linux package](https://github.com/github/licensed/actions/runs/559467175).  Everything appeared to be working across multiple OS flavors, which was also [validated](https://github.com/github/licensed/issues/337#issuecomment-778139954) by @johlju who opened the linked issue.