### PR TITLE
Track fixes to CI to account for update to ubuntu-latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -234,7 +234,7 @@ jobs:
         elixir: [1.8.x, 1.9.x]
     steps:
     - uses: actions/checkout@v2
-    - uses: erlef/setup-elixir@v1.6
+    - uses: erlef/setup-elixir@v1.6.0
       with:
         otp-version: ${{matrix.otp}}
         elixir-version: ${{matrix.elixir}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
       with:
         ruby-version: 2.6
     - name: Setup Haskell
-      uses: actions/setup-haskell@v1
+      uses: haskell/actions/setup@v1
       with:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: ${{ matrix.cabal }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,8 +60,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc: [ '8.2', '8.6', '8.8', '8.10', 'latest' ]
-        cabal: [ '2.4', '3.0', 'latest' ]
+        ghc: [ '8.2', '8.6', '8.8', '8.10' ]
+        cabal: [ '2.4', '3.0', '3.2' ]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -234,7 +234,7 @@ jobs:
         elixir: [1.8.x, 1.9.x]
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-elixir@v1.0.0
+    - uses: erlef/setup-elixir@v1.6
       with:
         otp-version: ${{matrix.otp}}
         elixir-version: ${{matrix.elixir}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,11 +89,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ '5.6', '7.1', '7.2', '7.3' ]
+        php: [ '7.3', '7.4' ]
     steps:
     - uses: actions/checkout@v2
     - name: Setup php
-      uses: nanasess/setup-php@v3.0.4
+      uses: nanasess/setup-php@v3.0.6
       with:
         php-version: ${{ matrix.php }}
     - name: Set up Ruby

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,9 @@ jobs:
     - name: Install Bower
       run: npm install -g bower
     - name: Set up Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: 2.6
     - run: bundle lock
     - uses: actions/cache@v1
       with:
@@ -37,9 +37,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: 2.6
     - name: Set up Bundler
       run: |
         yes | gem uninstall bundler --all
@@ -65,9 +65,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: 2.6
     - name: Setup Haskell
       uses: actions/setup-haskell@v1
       with:
@@ -97,9 +97,9 @@ jobs:
       with:
         php-version: ${{ matrix.php }}
     - name: Set up Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: 2.6
     - run: bundle lock
     - uses: actions/cache@v1
       with:
@@ -116,11 +116,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ 2.4.x, 2.5.x, 2.6.x, 2.7.x ]
+        ruby: [ 2.5, 2.6, 2.7 ]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{matrix.ruby}}
     - name: Set up Bundler
@@ -146,9 +146,9 @@ jobs:
       with:
         go-version: 1.10.x
     - name: Set up Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: 2.6
     - run: bundle lock
     - uses: actions/cache@v1
       with:
@@ -173,9 +173,9 @@ jobs:
       with:
         go-version: ${{ matrix.go }}
     - name: Set up Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: 2.6
     - run: bundle lock
     - uses: actions/cache@v1
       with:
@@ -193,9 +193,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: 2.6
     - run: bundle lock
     - uses: actions/cache@v1
       with:
@@ -213,9 +213,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: 2.6
     - run: bundle lock
     - uses: actions/cache@v1
       with:
@@ -239,9 +239,9 @@ jobs:
         otp-version: ${{matrix.otp}}
         elixir-version: ${{matrix.elixir}}
     - name: Set up Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: 2.6
     - run: bundle lock
     - uses: actions/cache@v1
       with:
@@ -266,9 +266,9 @@ jobs:
       with:
         node-version: ${{ matrix.node_version }}
     - name: Set up Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: 2.6
     - run: bundle lock
     - uses: actions/cache@v1
       with:
@@ -290,9 +290,9 @@ jobs:
       with:
         dotnet-version: 3.1.202
     - name: Set up Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: 2.6
     - run: bundle lock
     - uses: actions/cache@v1
       with:
@@ -318,9 +318,9 @@ jobs:
         python-version: ${{ matrix.python }}
         architecture: x64
     - name: Set up Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: 2.6
     - run: bundle lock
     - uses: actions/cache@v1
       with:
@@ -345,9 +345,9 @@ jobs:
         python-version: '3.x'
         architecture: x64
     - name: Set up Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: 2.6
     - run: bundle lock
     - uses: actions/cache@v1
       with:
@@ -379,9 +379,9 @@ jobs:
       env:
         YARN_VERSION: ${{ matrix.yarn_version }}
     - name: Set up Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: 2.6
     - run: bundle lock
     - uses: actions/cache@v1
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -230,8 +230,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        otp: [21.x, 22.x]
-        elixir: [1.8.x, 1.9.x]
+        otp: [21.x, 22.x, 23.x]
+        elixir: [ 1.10.x, 1.11.x ]
     steps:
     - uses: actions/checkout@v2
     - uses: erlef/setup-elixir@v1.6.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,8 +60,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc: [ '8.2.2', '8.6.5' ]
-        cabal: [ '2.2', '2.4', '3.0', 'latest' ]
+        ghc: [ '8.2', '8.6', '8.8', '8.10', 'latest' ]
+        cabal: [ '2.4', '3.0', 'latest' ]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby

--- a/lib/licensed/sources/cabal.rb
+++ b/lib/licensed/sources/cabal.rb
@@ -222,13 +222,24 @@ module Licensed
 
       # Returns a package info structure with an error set
       def missing_package(id)
-        name, _, version = if id.index(/\s/).nil?
-          id.rpartition("-") # e.g. to match the right-most dash from ipid fused-effects-1.0.0.0
-        else
-          id.partition(/\s/) # e.g. to match the left-most space from constraint fused-effects > 1.0.0.0
-        end
-
+        name, version = package_id_name_version(id)
         { "name" => name, "version" => version, "error" => "package not found" }
+      end
+
+      # Parses the name and version pieces from an id or package requirement string
+      def package_id_name_version(id)
+        name, version = id.split(" ", 2)
+        return [name, version] if version
+
+        # split by dashes, find the rightmost thing that looks like an
+        parts = id.split("-")
+        version_start_index = parts.rindex { |part| part.match?(/^[\d\.]+$/) }
+        return [id, nil] if version_start_index.nil?
+
+        [
+          parts[0...version_start_index].join("-"),
+          parts[version_start_index..-1].join("-")
+        ]
       end
     end
   end

--- a/test/fixtures/cabal/app.cabal
+++ b/test/fixtures/cabal/app.cabal
@@ -15,5 +15,5 @@ library
 executable app
   hs-source-dirs:      app
   main-is:             Main.hs
-  build-depends:       base, semilattices
+  build-depends:       base, semilattices == 0.0.0.4
   default-language:    Haskell2010

--- a/test/fixtures/cabal/app.cabal
+++ b/test/fixtures/cabal/app.cabal
@@ -9,14 +9,11 @@ cabal-version:       >=1.10
 
 library
   hs-source-dirs:      .
-  build-depends:       unliftio-core < 0.2.0.0,
-                       fused-effects == 0.4.0.0
+  build-depends:       fused-effects
   default-language:    Haskell2010
 
 executable app
   hs-source-dirs:      app
   main-is:             Main.hs
-  build-depends:       unliftio-core < 0.2.0.0,
-                       base,
-                       semilattices == 0.0.0.4
+  build-depends:       base, semilattices
   default-language:    Haskell2010

--- a/test/sources/cabal_test.rb
+++ b/test/sources/cabal_test.rb
@@ -43,7 +43,7 @@ if Licensed::Shell.tool_available?("ghc")
           dep = source.dependencies.detect { |d| d.name == "fused-effects" }
           assert dep
           assert_equal "cabal", dep.record["type"]
-          assert_equal "0.4.0.0", dep.version
+          assert dep.version
           assert dep.record["summary"]
         end
       end
@@ -54,7 +54,7 @@ if Licensed::Shell.tool_available?("ghc")
           dep = source.dependencies.detect { |d| d.name == "semilattices" }
           assert dep
           assert_equal "cabal", dep.record["type"]
-          assert_equal "0.0.0.4", dep.version
+          assert dep.version
           assert dep.record["summary"]
         end
       end


### PR DESCRIPTION
closes https://github.com/github/licensed/issues/339

This is updating the test actions workflow to get things running again.  Along the way I've been doing some quick audits for whether actions that are used have been updated, and whether the listed versions of languages/frameworks/package managers are still relevant.