### PR TITLE
Fix spelling of npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Dependencies will be automatically detected for all of the following sources by 
 1. [Gradle](./docs/sources/gradle.md)
 1. [Manifest lists (manifests)](./docs/sources/manifests.md)
 1. [Mix](./docs/sources/mix.md)
-1. [NPM](./docs/sources/npm.md)
+1. [npm](./docs/sources/npm.md)
 1. [NuGet](./docs/sources/nuget.md)
 1. [Pip](./docs/sources/pip.md)
 1. [Pipenv](./docs/sources/pipenv.md)

--- a/docs/sources/npm.md
+++ b/docs/sources/npm.md
@@ -1,4 +1,4 @@
-# NPM
+# npm
 
 The npm source will detect dependencies `package.json` is found at an apps `source_path`.  It uses `npm list` to enumerate dependencies and metadata.
 

--- a/lib/licensed/sources/npm.rb
+++ b/lib/licensed/sources/npm.rb
@@ -83,7 +83,7 @@ module Licensed
       rescue JSON::ParserError => e
         message = "Licensed was unable to parse the output from 'npm list'. JSON Error: #{e.message}"
         npm_error = package_metadata_error
-        message = "#{message}. NPM Error: #{npm_error}" if npm_error
+        message = "#{message}. npm Error: #{npm_error}" if npm_error
         raise Licensed::Sources::Source::Error, message
       end
 


### PR DESCRIPTION
See https://github.com/npm/cli#is-it-npm-or-npm-or-npm 🙂 

I thought about also renaming the class but lowercase classnames are also odd in Ruby, so being pragmatic there 😄 