### PR TITLE
Check for manifest file existence based on absolute paths

### DIFF
--- a/lib/licensed/sources/manifest.rb
+++ b/lib/licensed/sources/manifest.rb
@@ -170,7 +170,7 @@ module Licensed
       def all_files
         # remove files if they are tracked but don't exist on the file system
         @all_files ||= Set.new(Licensed::Git.files || [])
-                          .delete_if { |f| !File.exist?(f) }
+                          .delete_if { |f| !File.exist?(File.join(Licensed::Git.repository_root, f)) }
       end
 
       class Dependency < Licensed::Dependency

--- a/test/sources/manifest_test.rb
+++ b/test/sources/manifest_test.rb
@@ -267,4 +267,13 @@ describe Licensed::Sources::Manifest do
       assert_equal Pathname.new(manifest_path), source.manifest_path
     end
   end
+
+  describe "all_files" do
+    it "checks for files from the git repository root" do
+      Dir.chdir fixtures do
+        # file paths will include the entire path from the root of the repo
+        assert_includes source.all_files, "test/fixtures/manifest/manifest.yml"
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is a small fix to the manifest source that is caused from the path format of `Licensed::Git.files`.

That function returns the contents from `git ls-files --full-name --recurse-submodules`, which includes the relative path of files from the repository root.  The updated check here validates that files exist on the local system because they may have been deleted locally but not deleted from the git index.  The error occurs because this check is done from the context of the application's source path, and will only succeed when the application's source path is also the repository root.

e.g. if this command is run in a folder `foo/bar`, `Git.files` will return file paths `foo/bar/file1.rb`.  This fails because there is no file at `foo/bar/file.rb` relative to the current working directory `foo/bar`.

The fix is to check for existence of absolute paths that are rooted at the detected git repository root.