### PR TITLE
Ignore extraneous, missing npm dependencies

### DIFF
--- a/lib/licensed/sources/npm.rb
+++ b/lib/licensed/sources/npm.rb
@@ -69,6 +69,8 @@ module Licensed
         dependencies.each do |name, dependency|
           next if dependency["peerMissing"]
           next if yarn_lock_present && dependency["missing"]
+          next if dependency["extraneous"] && dependency["missing"]
+
           dependency["name"] = name
           (result[name] ||= []) << dependency
           recursive_dependencies(dependency["dependencies"] || {}, result)


### PR DESCRIPTION
I saw this in a project where two versions of react would have been installed based on direct and indirect dependency requirements. npm decided to only install one while labelling the other as both "extraneous" and "missing".  I'm not sure if there is more to this story but I think generally this is a case that would make sense to ignore as not installed in a project.

I tried to find a package that I could use to test this but had a hard time of it, but for some minimal verification I was able to build and run this change locally to verify it fixed the issue I was seeing in my project.