### PR TITLE
Release 2.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ## 2.15.0
+
+2021-03-24
+
+### Changed
+
+- The npm source will ignore dependencies that are marked as both extraneous and missing (https://github.com/github/licensed/pull/347)
+
+## 2.15.0
 2021-03-24
 
 ### Added
@@ -395,4 +403,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Initial release :tada:
 
-[Unreleased]: https://github.com/github/licensed/compare/2.15.0...HEAD
+[Unreleased]: https://github.com/github/licensed/compare/2.15.1...HEAD

--- a/lib/licensed/version.rb
+++ b/lib/licensed/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Licensed
-  VERSION = "2.15.0".freeze
+  VERSION = "2.15.1".freeze
 
   def self.previous_major_versions
     major_version = Gem::Version.new(Licensed::VERSION).segments.first


### PR DESCRIPTION
## 2.15.0

2021-03-24

### Changed

- The npm source will ignore dependencies that are marked as both extraneous and missing (https://github.com/github/licensed/pull/347)