### PR TITLE
pip: fix regex: match packages with dots in name

### DIFF
--- a/lib/licensed/sources/pip.rb
+++ b/lib/licensed/sources/pip.rb
@@ -8,7 +8,7 @@ module Licensed
   module Sources
     class Pip < Source
       VERSION_OPERATORS = %w(< > <= >= == !=).freeze
-      PACKAGE_REGEX = /^([\w-]+)(#{VERSION_OPERATORS.join("|")})?/
+      PACKAGE_REGEX = /^([\w\.-]+)(#{VERSION_OPERATORS.join("|")})?/
 
       def enabled?
         return unless virtual_env_pip && Licensed::Shell.tool_available?(virtual_env_pip)

--- a/test/fixtures/pip/requirements.txt
+++ b/test/fixtures/pip/requirements.txt
@@ -10,3 +10,4 @@ numpy!=1.16.1
 botocore == 1.12.91
 boto3>=1.0,<=2.0
 lazy-object-proxy==1.4.0
+backports.shutil-get-terminal-size==1.0.0

--- a/test/sources/pip_test.rb
+++ b/test/sources/pip_test.rb
@@ -124,6 +124,16 @@ if Licensed::Shell.tool_available?("pip")
           assert dep.record["summary"]
         end
       end
+
+      it "detects dependencies with dots in package name" do
+        Dir.chdir fixtures do
+          dep = source.dependencies.detect { |d| d.name == "backports.shutil-get-terminal-size" }
+          assert dep
+          assert_equal "pip", dep.record["type"]
+          assert dep.record["homepage"]
+          assert dep.record["summary"]
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Ran into this in a python-2.7 pipeline:

https://github.com/bcskda/anytask/runs/2280835856