### PR TITLE
Disable bundler source when running under ruby packer

### DIFF
--- a/docs/sources/bundler.md
+++ b/docs/sources/bundler.md
@@ -2,17 +2,7 @@
 
 The bundler source will detect dependencies `Gemfile` and `Gemfile.lock` files are found at an apps `source_path`.  The source uses the `Bundler` API to enumerate dependencies from `Gemfile` and `Gemfile.lock`.
 
-### Enumerating bundler dependencies when using the licensed executable
-
-**Note** this content only applies to running licensed from an executable.  It does not apply when using licensed as a gem.
-
-_It is required that the ruby runtime is available when running the licensed executable._
-
-The licensed executable contains and runs a version of ruby.  When using the Bundler APIs, a mismatch between the version of ruby built into the licensed executable and the version of licensed used during `bundle install` can occur.  This mismatch can lead to licensed raising errors due to not finding dependencies.
-
-For example, if `bundle install` was run with ruby 2.5.0 then the bundler specification path would be `<bundle path>/ruby/2.5.0/specifications`.  However, if the licensed executable contains ruby 2.4.0, then licensed will be looking for specifications at `<bundle path>/ruby/2.4.0/specifications`.  That path may not exist, or it may contain invalid or stale content.
-
-To prevent confusion, licensed uses the local ruby runtime to determine the ruby version for local gems during `bundle install`.  If bundler is also available, then the ruby command will be run from a `bundle exec` context.
+**Note** The bundler source cannot be used when running the [packaged licensed executable](../packaging.md)
 
 ### Excluding gem groups
 

--- a/lib/licensed/sources/bundler.rb
+++ b/lib/licensed/sources/bundler.rb
@@ -2,56 +2,19 @@
 require "delegate"
 begin
   require "bundler"
+  require "licensed/sources/bundler/missing_specification"
 rescue LoadError
 end
 
 module Licensed
   module Sources
     class Bundler < Source
-      class MissingSpecification < Gem::BasicSpecification
-        attr_reader :name, :requirement
-        alias_method :version, :requirement
-        def initialize(name:, requirement:)
-          @name = name
-          @requirement = requirement
-        end
-
-        def dependencies
-          []
-        end
-
-        def source
-          nil
-        end
-
-        def platform; end
-        def gem_dir; end
-        def gems_dir
-          Gem.dir
-        end
-        def summary; end
-        def homepage; end
-
-        def error
-          "could not find #{name} (#{requirement}) in any sources"
-        end
-      end
-
-      class BundlerSpecification < ::SimpleDelegator
-        def gem_dir
-          dir = super
-          return dir if File.exist?(dir)
-
-          File.join(Gem.dir, "gems", full_name)
-        end
-      end
-
       class Dependency < Licensed::Dependency
         attr_reader :loaded_from
 
-        def initialize(name:, version:, path:, loaded_from:, errors: [], metadata: {})
+        def initialize(name:, version:, path:, loaded_from:, search_root:, errors: [], metadata: {})
           @loaded_from = loaded_from
-          super name: name, version: version, path: path, errors: errors, metadata: metadata
+          super name: name, version: version, path: path, errors: errors, metadata: metadata, search_root: search_root
         end
 
         # Load a package manager file from the base Licensee::Projects::FsProject
@@ -90,12 +53,16 @@ module Licensed
 
         with_local_configuration do
           specs.map do |spec|
+            next if spec.name == "bundler" && !include_bundler?
+            next if spec.name == config["name"]
+
             error = spec.error if spec.respond_to?(:error)
             Dependency.new(
               name: spec.name,
               version: spec.version.to_s,
               path: spec.gem_dir,
               loaded_from: spec.loaded_from,
+              search_root: spec_root(spec),
               errors: Array(error),
               metadata: {
                 "type"     => Bundler.type,
@@ -109,137 +76,31 @@ module Licensed
 
       # Returns an array of Gem::Specifications for all gem dependencies
       def specs
-        # get the specifications for all dependencies in a Gemfile
-        root_dependencies = definition.dependencies.select { |d| include?(d, nil) }
-        root_specs = specs_for_dependencies(root_dependencies, nil).compact
-
-        # recursively find the remaining specifications
-        all_specs = recursive_specs(root_specs)
-
-        # delete any specifications loaded from a gemspec
-        all_specs.delete_if { |s| s.source.is_a?(::Bundler::Source::Gemspec) }
+        @specs ||= definition.specs_for(groups)
       end
 
-      # Recursively finds the dependencies for Gem specifications.
-      # Returns a `Set` containing the package names for all dependencies
-      def recursive_specs(specs, results = Set.new)
-        return [] if specs.nil? || specs.empty?
-
-        new_specs = Set.new(specs) - results.to_a
-        return [] if new_specs.empty?
-
-        results.merge new_specs
-
-        dependency_specs = new_specs.flat_map { |s| specs_for_dependencies(s.dependencies, s.source) }
-
-        return results if dependency_specs.empty?
-
-        results.merge recursive_specs(dependency_specs, results)
-      end
-
-      # Returns the specs for dependencies that pass the checks in `include?`.
-      # Returns a `MissingSpecification` if a gem specification isn't found.
-      def specs_for_dependencies(dependencies, source)
-        included_dependencies = dependencies.select { |d| include?(d, source) }
-        included_dependencies.map do |dep|
-          gem_spec(dep) || MissingSpecification.new(name: dep.name, requirement: dep.requirement)
+      # Returns whether to include bundler as a listed dependency of the project
+      def include_bundler?
+        @include_bundler ||= begin
+          # include if bundler is listed as a direct dependency that should be included
+          requested_dependencies = definition.dependencies.select { |d| (d.groups & groups).any? && d.should_include? }
+          return true if requested_dependencies.any? { |d| d.name == "bundler" }
+          # include if bundler is an indirect dependency
+          return true if specs.flat_map(&:dependencies).any? { |d| d.name == "bundler" }
+          false
         end
       end
 
-      # Returns a Gem::Specification for the provided gem argument.
-      def gem_spec(dependency)
-        return unless dependency
+      # Returns a search root for a specification, one of:
+      # - the local bundler gem location
+      # - the system rubygems install gem location
+      # - nil
+      def spec_root(spec)
+        return if spec.gem_dir.nil?
+        root = [Gem.default_dir, Gem.dir].find { |dir| spec.gem_dir.start_with?(dir) }
+        return unless root
 
-        # find a specifiction from the resolved ::Bundler::Definition specs
-        spec = definition.resolve.find { |s| s.satisfies?(dependency) }
-
-        # a nil spec should be rare, generally only seen from bundler
-        return matching_spec(dependency) || bundle_exec_gem_spec(dependency.name, dependency.requirement) if spec.nil?
-
-        # try to find a non-lazy specification that matches `spec`
-        # spec.source.specs gives access to specifications with more
-        # information than spec itself, including platform-specific gems.
-        # these objects should have all the information needed to detect license metadata
-        source_spec = spec.source.specs.find { |s| s.name == spec.name && s.version == spec.version }
-        return source_spec if source_spec
-
-        # look for a specification at the bundler specs path
-        spec_path = ::Bundler.specs_path.join("#{spec.full_name}.gemspec")
-        return Gem::Specification.load(spec_path.to_s) if File.exist?(spec_path.to_s)
-
-        # if the specification file doesn't exist, get the specification using
-        # the bundler and gem CLI
-        bundle_exec_gem_spec(dependency.name, dependency.requirement)
-      end
-
-      # Returns whether a dependency should be included in the final
-      def include?(dependency, source)
-        # ::Bundler::Dependency has an extra `should_include?`
-        return false unless dependency.should_include? if dependency.respond_to?(:should_include?)
-
-        # Don't return gems added from `add_development_dependency` in a gemspec
-        # if the :development group is excluded
-        gemspec_source = source.is_a?(::Bundler::Source::Gemspec)
-        return false if dependency.type == :development && (!gemspec_source || exclude_development_dependencies?)
-
-        # Gem::Dependency don't have groups - in our usage these objects always
-        # come as child-dependencies and are never directly from a Gemfile.
-        # We assume that all Gem::Dependencies are ok at this point
-        return true if dependency.groups.nil?
-
-        # check if the dependency is in any groups we're interested in
-        (dependency.groups & groups).any?
-      end
-
-      # Returns whether development dependencies should be excluded
-      def exclude_development_dependencies?
-        @include_development ||= begin
-          # check whether the development dependency group is explicitly removed
-          # or added via bundler and licensed configurations
-          groups = [:development] - Array(::Bundler.settings[:without]) + Array(::Bundler.settings[:with]) - exclude_groups
-          !groups.include?(:development)
-        end
-      end
-
-      # Load a gem specification from the YAML returned from `gem specification`
-      # This is a last resort when licensed can't obtain a specification from other means
-      def bundle_exec_gem_spec(name, requirement)
-        # `gem` must be available to run `gem specification`
-        return unless Licensed::Shell.tool_available?("gem")
-
-        # use `gem specification` with a clean ENV and clean Gem.dir paths
-        # to get gem specification at the right directory
-        begin
-          ::Bundler.with_original_env do
-            ::Bundler.rubygems.clear_paths
-            yaml = Licensed::Shell.execute(*ruby_command_args("gem", "specification", name, "-v", requirement.to_s))
-            spec = Gem::Specification.from_yaml(yaml)
-            # this is horrible, but it will cache the gem_dir using the clean env
-            # so that it can be used outside of this block when running from
-            # the ruby packer executable environment
-            spec.gem_dir if ruby_packer?
-            spec
-          end
-        rescue Licensed::Shell::Error
-          # return nil
-        ensure
-          ::Bundler.configure
-        end
-      end
-
-      # Loads a dependency specification using rubygems' built-in
-      # `Dependency#matching_specs` and `Dependency#to_spec`, from the original
-      # gem environment
-      def matching_spec(dependency)
-        begin
-          ::Bundler.with_original_env do
-            ::Bundler.rubygems.clear_paths
-            return unless dependency.matching_specs(true).any?
-            BundlerSpecification.new(dependency.to_spec)
-          end
-        ensure
-          ::Bundler.configure
-        end
+        "#{root}/gems/#{spec.full_name}"
       end
 
       # Build the bundler definition
@@ -286,29 +147,15 @@ module Licensed
         @lockfile_path ||= gemfile_path.dirname.join(GEMFILES[gemfile_path.basename.to_s])
       end
 
-      # Returns the configured bundler executable to use, or "bundle" by default.
-      def bundler_exe
-        @bundler_exe ||= begin
-          exe = config.dig("bundler", "bundler_exe")
-          return "bundle" unless exe
-          return exe if Licensed::Shell.tool_available?(exe)
-          config.root.join(exe)
-        end
-      end
-
-      # Determines if the configured bundler executable is available and returns
-      # shell command args with or without `bundle exec` depending on availability.
-      def ruby_command_args(*args)
-        return Array(args) unless Licensed::Shell.tool_available?(bundler_exe)
-        [bundler_exe, "exec", *args]
-      end
-
       private
 
       # helper to clear all bundler environment around a yielded block
       def with_local_configuration
         # force bundler to use the local gem file
         original_bundle_gemfile, ENV["BUNDLE_GEMFILE"] = ENV["BUNDLE_GEMFILE"], gemfile_path.to_s
+
+        # silence any bundler warnings while running licensed
+        bundler_ui, ::Bundler.ui = ::Bundler.ui, ::Bundler::UI::Silent.new
 
         # reset all bundler configuration
         ::Bundler.reset!
@@ -318,8 +165,9 @@ module Licensed
         yield
       ensure
         ENV["BUNDLE_GEMFILE"] = original_bundle_gemfile
+        ::Bundler.ui = bundler_ui
+
         # restore bundler configuration
-        ::Bundler.reset!
         ::Bundler.configure
       end
 

--- a/lib/licensed/sources/bundler/missing_specification.rb
+++ b/lib/licensed/sources/bundler/missing_specification.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "bundler/match_platform"
+
+# Bundler normally raises a "GemNotFound" error when a specification
+# can't be materialized which halts bundler dependency enumeration.
+
+# This monkey patch instead creates MissingSpecification objects to
+# identify missing specs without raising errors and halting enumeration.
+# It was the most minimal-touch solution I could think of that should reliably
+# work across many bundler versions
+
+module Licensed
+  module Bundler
+    class MissingSpecification < Gem::BasicSpecification
+      include ::Bundler::MatchPlatform
+
+      attr_reader :name, :version, :platform, :source
+      def initialize(name:, version:, platform:, source:)
+        @name = name
+        @version = version
+        @platform = platform
+        @source = source
+      end
+
+      def dependencies
+        []
+      end
+
+      def gem_dir; end
+      def gems_dir
+        Gem.dir
+      end
+      def summary; end
+      def homepage; end
+
+      def error
+        "could not find #{name} (#{version}) in any sources"
+      end
+    end
+  end
+end
+
+module Bundler
+  class LazySpecification
+    alias_method :orig_materialize, :__materialize__
+    def __materialize__
+      spec = orig_materialize
+      return spec if spec
+
+      Licensed::Bundler:: MissingSpecification.new(name: name, version: version, platform: platform, source: source)
+    end
+  end
+end

--- a/test/fixtures/bundler/Gemfile
+++ b/test/fixtures/bundler/Gemfile
@@ -27,7 +27,7 @@ gem "pathed-gem-fixture", path: "pathed-gem-fixture"
 
 # verify https://github.com/github/licensed/issues/71
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
-gem "mini_racer"
+gem "mini_racer", "0.3.1"
 
 # verify https://github.com/github/licensed/issues/153
 gem "aws-sdk-core", "3.39.0"

--- a/test/sources/bundler_test.rb
+++ b/test/sources/bundler_test.rb
@@ -283,5 +283,26 @@ if Licensed::Shell.tool_available?("bundle")
         end
       end
     end
+
+    describe "when run in ruby packer runtime" do
+      top_dir = RbConfig::TOPDIR
+      before do
+        RbConfig.send(:remove_const, "TOPDIR")
+        RbConfig.const_set("TOPDIR", "__enclose_io_memfs__")
+      end
+
+      after do
+        RbConfig.send(:remove_const, "TOPDIR")
+        RbConfig.const_set("TOPDIR", top_dir)
+      end
+
+      it "raises an error" do
+        Dir.chdir(fixtures) do
+          assert_raises Licensed::Sources::Source::Error do
+            source.dependencies
+          end
+        end
+      end
+    end
   end
 end

--- a/test/sources/bundler_test.rb
+++ b/test/sources/bundler_test.rb
@@ -6,16 +6,8 @@ if Licensed::Shell.tool_available?("bundle")
   describe Licensed::Sources::Bundler do
     let(:fixtures) { File.expand_path("../../fixtures/bundler", __FILE__) }
     let(:source_config) { Hash.new }
-    let(:config) { Licensed::AppConfiguration.new({ "source_path" => Dir.pwd }, "bundler" => source_config) }
+    let(:config) { Licensed::AppConfiguration.new({ "name" => "bundler_test", "source_path" => Dir.pwd }, "bundler" => source_config) }
     let(:source) { Licensed::Sources::Bundler.new(config) }
-
-    before do
-      @original_bundle_gemfile = ENV["BUNDLE_GEMFILE"]
-    end
-
-    after do
-      ENV["BUNDLE_GEMFILE"] = @original_bundle_gemfile
-    end
 
     describe "enabled?" do
       it "is true if Gemfile.lock exists" do
@@ -120,6 +112,12 @@ if Licensed::Shell.tool_available?("bundle")
     end
 
     describe "dependencies" do
+      it "does not include the source project" do
+        Dir.chdir(fixtures) do
+          config["name"] = "semantic"
+          refute source.dependencies.find { |d| d.name == "semantic" }
+      end
+
       it "finds dependencies from Gemfile" do
         Dir.chdir(fixtures) do
           dep = source.dependencies.find { |d| d.name == "semantic" }
@@ -143,6 +141,12 @@ if Licensed::Shell.tool_available?("bundle")
       end
 
       describe "when bundler is a listed dependency" do
+        it "include_bundler? is true" do
+          Dir.chdir(fixtures) do
+            assert source.include_bundler?
+          end
+        end
+
         it "includes bundler as a dependency" do
           Dir.chdir(fixtures) do
             assert source.dependencies.find { |d| d.name == "bundler" }
@@ -152,6 +156,12 @@ if Licensed::Shell.tool_available?("bundle")
 
       describe "when bundler is not explicitly listed as a dependency" do
         let(:source_config) { { "without" => "bundler" } }
+
+        it "include_bundler? is false" do
+          Dir.chdir(fixtures) do
+            refute source.include_bundler?
+          end
+        end
 
         it "does not include bundler as a dependency" do
           Dir.chdir(fixtures) do
@@ -201,7 +211,6 @@ if Licensed::Shell.tool_available?("bundle")
       end
 
       it "ignores local gemspecs" do
-        fixtures = File.expand_path("../../fixtures/bundler", __FILE__)
         Dir.chdir(fixtures) do
           assert_nil source.dependencies.find { |d| d.name == "licensed" }
         end
@@ -212,10 +221,11 @@ if Licensed::Shell.tool_available?("bundle")
           FileUtils.cp_r(fixtures, dir)
           dir = File.join(dir, "bundler")
           FileUtils.rm_rf(File.join(dir, "vendor"))
+
           Dir.chdir(dir) do
             dep = source.dependencies.find { |d| d.name == "semantic" }
             assert dep
-            assert_includes dep.errors, "could not find semantic (= 1.6.0) in any sources"
+            assert_includes dep.errors, "could not find semantic (1.6.0) in any sources"
           end
         end
       end
@@ -228,58 +238,19 @@ if Licensed::Shell.tool_available?("bundle")
           assert_equal "apache-2.0", dep.license_key
         end
       end
-    end
 
-    describe "bundler_exe" do
-
-      it "returns bundle if not configured" do
-        assert_equal "bundle", source.bundler_exe
-      end
-
-      it "returns the configured value if specifying an available tool" do
-        (config["bundler"] ||= {})["bundler_exe"] = "ruby"
-        assert_equal "ruby", source.bundler_exe
-      end
-
-      it "returns the configured value relative to the configuration root" do
-        (config["bundler"] ||= {})["bundler_exe"] = "lib/licensed.rb"
-        assert_equal config.root.join("lib/licensed.rb"), source.bundler_exe
-      end
-    end
-
-    describe "ruby_command_args" do
-      it "returns 'bundle exec args' when bundler exe is available'" do
-        Licensed::Shell.stub(:tool_available?, true) do
-          assert_equal "bundle exec test", source.ruby_command_args("test").join(" ")
-        end
-      end
-
-      it "returns args when bundler exe is not available'" do
-        Licensed::Shell.stub(:tool_available?, false) do
-          assert_equal "test", source.ruby_command_args("test").join(" ")
-        end
-      end
-    end
-
-    describe "bundle_exec_gem_spec" do
-      it "gets a gem specification for a version" do
+      it "sets a search root relative to the bundler gem dir for bundled gems" do
         Dir.chdir(fixtures) do
-          version = source.dependencies.find { |d| d.name == "bundler" }.version
-          assert source.bundle_exec_gem_spec("bundler", version)
+          dep = source.dependencies.find { |d| d.name == "semantic" }
+          assert_equal "#{Gem.dir}/gems/#{dep.name}-#{dep.version}", dep.instance_variable_get("@root")
         end
       end
 
-      it "gets a gem specification for a requirement" do
+      it "sets a search root relative to the system gem dir for system gems" do
         Dir.chdir(fixtures) do
-          version = source.dependencies.find { |d| d.name == "bundler" }.version
-          assert source.bundle_exec_gem_spec("bundler", Gem::Requirement.new(">= #{version}"))
-        end
-      end
-
-      it "returns nil if a gem specification isn't found" do
-        Dir.chdir(fixtures) do
-          version = source.dependencies.find { |d| d.name == "bundler" }.version
-          refute source.bundle_exec_gem_spec("bundler", version.to_f - 1)
+          dep = source.dependencies.find { |d| d.name == "bundler" }
+          assert dep
+          assert_equal "#{Gem.default_dir}/gems/#{dep.name}-#{dep.version}", dep.instance_variable_get("@root")
         end
       end
     end

--- a/test/sources/bundler_test.rb
+++ b/test/sources/bundler_test.rb
@@ -116,6 +116,7 @@ if Licensed::Shell.tool_available?("bundle")
         Dir.chdir(fixtures) do
           config["name"] = "semantic"
           refute source.dependencies.find { |d| d.name == "semantic" }
+        end
       end
 
       it "finds dependencies from Gemfile" do


### PR DESCRIPTION
This PR restricts the bundler source to run only when run as a gem installed on a host machine.  If the bundler source is used from the distributed executables built using ruby-packer, an error will be given to the user.  In the process I've been able to make better use of bundler's high level APIs and significantly reduce the size and complexity of the code in this project.

To support bundler dependency enumeration from the ruby-packer based executable,  I ended up having to write a slimmed-down approximation of bundlers internal logic for enumerating dependencies and matching them up to gem specifications where available.  This has been a source of many bugs and unhandled edge cases, the most recent of which is https://github.com/github/licensed/issues/353.

Keeping the bundler source working has been challenging to say the least due to needing the source to work from both a gem installation in a ruby environment and from within the ruby_packer environment of the distributable licensed exe files that are built and attached to releases.

Enabling bundler dependency enumeration from the distributable licensed exe is mostly for convenience.  If someone is enumerating bundler dependencies then it's not a stretch to assume they have a working ruby installation.  This tool requires that dependencies have been installed locally, and it seems like a far edge case for anyone to install gems on a system then uninstall ruby 🤷 

The core of the problem with using licensed's bundler source from the distributed exe is that there are effectively two pairs of ruby and bundler that are running at the time - one on the host machine and one inside the distributed executable.  Bundler was not built to support the use case of having two concurrently running ruby and bundler environments because of course it isn't, why would that ever be needed 😆 .  However licensed does need to run in that environment and because it's using bundlers internal objects it needs to trick bundler into doing the same.

Enough is enough, it shouldn't be too much to ask to run `gem install licensed` if a user is going to be enumerating bundler dependencies 😆 