### PR TITLE
Release licensed 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## 3.0.0
+
+2021-04-27
+
+**This is a major release and includes potentially breaking changes to bundler dependency enumeration.**
+
+### Changed
+
+- The bundler source will return an error when run from an executable.  Please install licensed as a gem to continue using the bundler source.  Please see the [v3 migration document](./docs/migrations/v3.md) for full details and migration strategies.
+
 ## 2.15.2
 
 2021-04-06
@@ -411,4 +421,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Initial release :tada:
 
-[Unreleased]: https://github.com/github/licensed/compare/2.15.2...HEAD
+[Unreleased]: https://github.com/github/licensed/compare/3.0.0...HEAD

--- a/README.md
+++ b/README.md
@@ -12,12 +12,24 @@ Licensed is **not** a complete open source license compliance solution. Please u
 
 Licensed is in active development and currently used at GitHub.  See the [open issues](https://github.com/github/licensed/issues) for a list of potential work.
 
+## Licensed v3
+
+Licensed v3 includes a breaking change if both of the following are true:
+
+1. a project uses bundler to manage ruby dependencies
+2. a project uses the self-contained executable build of licensed
+
+All other usages of licensed should not encounter any major changes migrating from the latest 2.x build to 3.0.  
+
+See [CHANGELOG.md](./CHANGELOG.md) for more details on what's changed.
+See the [v3 migration documentation](./docs/migrations/v3.md) for more info on migrating to v3.
+
 ## Licensed v2
 
 Licensed v2 includes many internal changes intended to make licensed more extensible and easier to update in the future.  While not too much has changed externally, v2 is incompatible with configuration files and cached records from previous versions.  Fortunately, migrating is easy using the `licensed migrate` command.
 
 See [CHANGELOG.md](./CHANGELOG.md) for more details on what's changed.
-See the [migration documentation](./docs/migrating_to_newer_versions.md) for more info on migrating to v2, or run `licensed help migrate`.
+See the [v2 migration documentation](./docs/migrations/v2.md) for more info on migrating to v2, or run `licensed help migrate`.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ The [bundler-licensed plugin](https://github.com/sergey-alekseev/bundler-license
 The [licensed-ci](https://github.com/marketplace/actions/licensed-ci) GitHub Action runs `licensed` as part of an opinionated CI workflow and can be configured to run on any GitHub Action event.  See the linked actions for usage and details.
 
 The [setup-licensed](https://github.com/marketplace/actions/setup-github-licensed) GitHub Action installs `licensed` to the workflow environment.  See the linked actions for usage and details.
-   - This action is intended for projects that don't have a ruby installation setup.  If your workflow has ruby setup please install `licensed` via `Gemfile` + `bundle install` or with `gem install`.
 
 ### Configuration
 

--- a/docs/migrations/v2.md
+++ b/docs/migrations/v2.md
@@ -1,3 +1,3 @@
-# Migrating your licensed configuration and cached records to the latest version of licensed
+# Migrating your licensed configuration and cached records to licensed v2
 
 Licensed v2+ ships with an additional executable, `licensed-migrator`, that can be used to update your licensed files to the format expected by the currently installed version.  To run, execute `licensed migrate --from v1 -c <path to licensed configuration file>`, replacing `v1` with the major version of licensed to migrate from.

--- a/docs/migrations/v3.md
+++ b/docs/migrations/v3.md
@@ -1,0 +1,109 @@
+# Breaking changes to bundler dependency enumeration in v3
+
+**NOTE** If you are migrating from a version earlier than v2, please first [migrate to v2](./v2.md) before continuing.
+
+Licensed v3 includes a breaking change to bundler dependency enumeration when using the executable form of licensed.  Bundler dependency enumeration will no longer work with the licensed executable as of 3.0.0.
+
+**If your project does not use bundler, or if you already install the licensed gem, you are not affected by this breaking change.**
+
+## Migrating bundler enumeration for v3
+
+When using licensed v3 with bundler dependencies, licensed must be installed from its [gem](https://rubygems.org/gems/licensed).  This can be accomplished with `gem install`, or by adding licensed to a bundler gem file.
+
+### Usage in a GitHub Actions workflow
+
+Using licensed to enumerate bundler dependencies in a GitHub Actions workflow will require ruby to be available in the actions VM environment.  Ruby can be setup in an actions workflow using [ruby/setup-ruby](https://github.com/ruby/setup-ruby)(preferred) or [actions/setup-ruby](https://github.com/actions/setup-ruby)(deprecated).
+
+If you are using licensed in a GitHub Actions workflow, [jonabc/setup-licensed](https://github.com/jonabc/setup-licensed) has been updated according to this breaking change.  `setup-licensed` will install the licensed gem when ruby is available, or the licensed executable when ruby is not available.  Alternatively, you can `gem install` licensed directly as an actions step.
+
+This is an example workflow definition that runs [jonabc/licensed-ci](https://github.com/jonabc/licensed-ci)'s opinionated license compliance workflow in CI.  It includes jobs that demonstrate installing licensed using 
+- `gem install`
+- [jonabc/setup-licensed](https://github.com/jonabc/setup-licensed)
+- installing when included in a bundler gem file
+
+```yml
+name: Cache and verify dependency license metadata
+
+on:
+  # run when PRs are opened, reopened or updated
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+  # run on demand
+  workflow_dispatch:
+
+jobs:
+  # install licensed with setup-licensed
+  licensed-ci-setup-licensed:
+    runs-on: ubuntu-latest
+
+    steps:
+      # checkout the repo
+      - uses: actions/checkout@v1
+      
+      # install ruby
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.0"
+
+      # install licensed gem using setup-licensed
+      - uses: jonabc/setup-licensed@v1
+        with:
+          version: '3.x'
+
+      # install dependencies in CI environment
+      - run: bundle install
+
+      # run licensed-ci to cache any metadata changes and verify compliance
+      - uses: jonabc/licensed-ci@v1
+
+  # OR 
+  
+  # install licensed using gem install
+  licensed-ci-gem:
+    runs-on: ubuntu-latest
+
+    steps:
+      # checkout the repo
+      - uses: actions/checkout@v1
+      
+      # install ruby and bundler
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.0"
+
+      # install licensed gem using setup-licensed
+      - run: gem install licensed -v '~> 3.0'
+
+      # install dependencies in CI environment
+      - run: bundle install
+
+      # run licensed-ci to cache any metadata changes and verify compliance
+      - uses: jonabc/licensed-ci@v1
+
+  # OR
+
+  # install licensed as part of bundle installation
+  licensed-ci-bundle:
+    runs-on: ubuntu-latest
+
+    steps:
+      # checkout the repo
+      - uses: actions/checkout@v1
+      
+      # install ruby and bundler
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.0"
+
+      # install licensed and other dependencies in CI environment
+      - run: bundle install
+
+      # run licensed-ci to cache any metadata changes and verify compliance
+      - uses: jonabc/licensed-ci@v1
+        with:
+          command: 'bundle exec licensed' # run licensed within the bundler context
+```

--- a/lib/licensed/cli.rb
+++ b/lib/licensed/cli.rb
@@ -74,11 +74,14 @@ module Licensed
     method_option :from, aliases: "-f", type: :string, required: true,
       desc: "Licensed version to migrate from - #{Licensed.previous_major_versions.map { |major| "v#{major}" }.join(", ")}"
     def migrate
+      shell = Thor::Base.shell.new
       case options["from"]
       when "v1"
         Licensed::Migrations::V2.migrate(options["config"])
+      when "v2"
+        shell.say "No configuration or cached file migration needed."
+        shell.say "Please see the documentation at https://github.com/github/licensed/tree/master/docs/migrations/v3.md for details."
       else
-        shell = Thor::Base.shell.new
         shell.say "Unrecognized option from=#{options["from"]}", :red
         CLI.command_help(shell, "migrate")
         exit 1

--- a/lib/licensed/version.rb
+++ b/lib/licensed/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Licensed
-  VERSION = "2.15.2".freeze
+  VERSION = "3.0.0".freeze
 
   def self.previous_major_versions
     major_version = Gem::Version.new(Licensed::VERSION).segments.first


### PR DESCRIPTION
## 3.0.0

2021-04-27

**This is a major release and includes potentially breaking changes to bundler dependency enumeration.**

### Changed

- The bundler source will return an error when run from an executable.  Please install licensed as a gem to continue using the bundler source.  Please see the [v3 migration document](./docs/migrations/v3.md) for full details and migration strategies.