### PR TITLE
Validate git based ruby gems work with bundler source

### DIFF
--- a/lib/licensed/sources/bundler.rb
+++ b/lib/licensed/sources/bundler.rb
@@ -12,9 +12,9 @@ module Licensed
       class Dependency < Licensed::Dependency
         attr_reader :loaded_from
 
-        def initialize(name:, version:, path:, loaded_from:, search_root:, errors: [], metadata: {})
+        def initialize(name:, version:, path:, loaded_from:, errors: [], metadata: {})
           @loaded_from = loaded_from
-          super name: name, version: version, path: path, errors: errors, metadata: metadata, search_root: search_root
+          super name: name, version: version, path: path, errors: errors, metadata: metadata
         end
 
         # Load a package manager file from the base Licensee::Projects::FsProject
@@ -62,7 +62,6 @@ module Licensed
               version: spec.version.to_s,
               path: spec.gem_dir,
               loaded_from: spec.loaded_from,
-              search_root: spec_root(spec),
               errors: Array(error),
               metadata: {
                 "type"     => Bundler.type,
@@ -89,20 +88,6 @@ module Licensed
           return true if specs.flat_map(&:dependencies).any? { |d| d.name == "bundler" }
           false
         end
-      end
-
-      # Returns a search root for a specification, one of:
-      # - the local bundler gem location
-      # - the system rubygems install gem location
-      # - nil
-      def spec_root(spec)
-        return if spec.gem_dir.nil?
-        root = [Gem.default_dir, Gem.dir].find { |dir| spec.gem_dir.start_with?(dir) }
-        return unless root
-
-        path = "#{root}/gems/#{spec.full_name}"
-        return unless File.exist?(path)
-        path
       end
 
       # Build the bundler definition

--- a/lib/licensed/sources/bundler.rb
+++ b/lib/licensed/sources/bundler.rb
@@ -100,7 +100,9 @@ module Licensed
         root = [Gem.default_dir, Gem.dir].find { |dir| spec.gem_dir.start_with?(dir) }
         return unless root
 
-        "#{root}/gems/#{spec.full_name}"
+        path = "#{root}/gems/#{spec.full_name}"
+        return unless File.exist?(path)
+        path
       end
 
       # Build the bundler definition

--- a/lib/licensed/sources/bundler.rb
+++ b/lib/licensed/sources/bundler.rb
@@ -60,7 +60,7 @@ module Licensed
             Dependency.new(
               name: spec.name,
               version: spec.version.to_s,
-              path: spec.gem_dir,
+              path: spec.full_gem_path,
               loaded_from: spec.loaded_from,
               errors: Array(error),
               metadata: {

--- a/test/fixtures/bundler/Gemfile
+++ b/test/fixtures/bundler/Gemfile
@@ -31,3 +31,5 @@ gem "mini_racer", "0.3.1"
 
 # verify https://github.com/github/licensed/issues/153
 gem "aws-sdk-core", "3.39.0"
+
+gem "thor", git: "https://github.com/erikhuda/thor"

--- a/test/sources/bundler_test.rb
+++ b/test/sources/bundler_test.rb
@@ -141,6 +141,12 @@ if Licensed::Shell.tool_available?("bundle")
         end
       end
 
+      it "finds dependencies from git sources" do
+        Dir.chdir(fixtures) do
+          assert source.dependencies.find { |d| d.name == "thor" }
+        end
+      end
+
       describe "when bundler is a listed dependency" do
         it "include_bundler? is true" do
           Dir.chdir(fixtures) do
@@ -221,9 +227,12 @@ if Licensed::Shell.tool_available?("bundle")
         Dir.mktmpdir do |dir|
           FileUtils.cp_r(fixtures, dir)
           dir = File.join(dir, "bundler")
-          FileUtils.rm_rf(File.join(dir, "vendor"))
 
           Dir.chdir(dir) do
+            Dir["**/*semantic*"].each do |path|
+              FileUtils.rm_rf(path)
+            end
+
             dep = source.dependencies.find { |d| d.name == "semantic" }
             assert dep
             assert_includes dep.errors, "could not find semantic (1.6.0) in any sources"

--- a/test/sources/bundler_test.rb
+++ b/test/sources/bundler_test.rb
@@ -147,33 +147,16 @@ if Licensed::Shell.tool_available?("bundle")
         end
       end
 
-      describe "when bundler is a listed dependency" do
-        it "include_bundler? is true" do
-          Dir.chdir(fixtures) do
-            assert source.include_bundler?
-          end
-        end
-
-        it "includes bundler as a dependency" do
-          Dir.chdir(fixtures) do
-            assert source.dependencies.find { |d| d.name == "bundler" }
-          end
+      it "includes bundler as a dependency when explicitly listed" do
+        Dir.chdir(fixtures) do
+          assert source.dependencies.find { |d| d.name == "bundler" }
         end
       end
 
-      describe "when bundler is not explicitly listed as a dependency" do
-        let(:source_config) { { "without" => "bundler" } }
-
-        it "include_bundler? is false" do
-          Dir.chdir(fixtures) do
-            refute source.include_bundler?
-          end
-        end
-
-        it "does not include bundler as a dependency" do
-          Dir.chdir(fixtures) do
-            assert_nil source.dependencies.find { |d| d.name == "bundler" }
-          end
+      it "does not include bundler as a dependency when not explicitly listed" do
+        source_config["without"] = "bundler"
+        Dir.chdir(fixtures) do
+          assert_nil source.dependencies.find { |d| d.name == "bundler" }
         end
       end
 
@@ -227,12 +210,11 @@ if Licensed::Shell.tool_available?("bundle")
         Dir.mktmpdir do |dir|
           FileUtils.cp_r(fixtures, dir)
           dir = File.join(dir, "bundler")
+          Dir[File.join(dir, "**/*semantic*")].each do |path|
+            FileUtils.rm_rf(path)
+          end
 
           Dir.chdir(dir) do
-            Dir["**/*semantic*"].each do |path|
-              FileUtils.rm_rf(path)
-            end
-
             dep = source.dependencies.find { |d| d.name == "semantic" }
             assert dep
             assert_includes dep.errors, "could not find semantic (1.6.0) in any sources"

--- a/test/sources/bundler_test.rb
+++ b/test/sources/bundler_test.rb
@@ -248,21 +248,6 @@ if Licensed::Shell.tool_available?("bundle")
           assert_equal "apache-2.0", dep.license_key
         end
       end
-
-      it "sets a search root relative to the bundler gem dir for bundled gems" do
-        Dir.chdir(fixtures) do
-          dep = source.dependencies.find { |d| d.name == "semantic" }
-          assert_equal "#{Gem.dir}/gems/#{dep.name}-#{dep.version}", dep.instance_variable_get("@root")
-        end
-      end
-
-      it "sets a search root relative to the system gem dir for system gems" do
-        Dir.chdir(fixtures) do
-          dep = source.dependencies.find { |d| d.name == "bundler" }
-          assert dep
-          assert_equal "#{Gem.default_dir}/gems/#{dep.name}-#{dep.version}", dep.instance_variable_get("@root")
-        end
-      end
     end
 
     describe "when run in ruby packer runtime" do


### PR DESCRIPTION
closes https://github.com/github/licensed/issues/359

The issue here is that the path construction for the search root results in a path that doesn't exist and is not an ancestor for gems pulled via a "git" directive in bundlers gemfile.  The change in this PR ensures that the root path exists before it's returned.  This should be ok for the case given but doesn't fully address the use case for git sourced bundler dependencies and may need to be further addressed in the future.  For now, this is a small change that is good to have regardless.

I validated this change originally using the `gem` line shared in the related issue, but opted to use a smaller gem that pulls in fewer dependencies and is not a fork in the checked in test fixture

cc clinejj