### PR TITLE
Add support for Swift / Swift Package Manager

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -366,10 +366,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Setup Swift
-      uses: fwal/setup-swift@v1
-      with:
-        swift-version: "5.4"
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -362,6 +362,30 @@ jobs:
     - name: Run tests
       run: script/test pipenv
 
+  swift:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup Swift
+      uses: fwal/setup-swift@v1
+      with:
+        swift-version: "5.4"
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.6
+    - run: bundle lock
+    - uses: actions/cache@v1
+      with:
+        path: vendor/gems
+        key: ${{ runner.os }}-gem-2.6.x-${{ hashFiles('**/Gemfile.lock') }}
+    - name: Bootstrap
+      run: script/bootstrap
+    - name: Set up fixtures
+      run: script/source-setup/swift
+    - name: Run tests
+      run: script/test swift
+
   yarn:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -364,8 +364,15 @@ jobs:
 
   swift:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        swift: [ "5.4", "5.3" ]
     steps:
     - uses: actions/checkout@v2
+    - name: Setup Swift
+      uses: fwal/setup-swift@v1
+      with:
+        swift-version: ${{ matrix.swift }}
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Dependencies will be automatically detected for all of the following sources by 
 1. [NuGet](./docs/sources/nuget.md)
 1. [Pip](./docs/sources/pip.md)
 1. [Pipenv](./docs/sources/pipenv.md)
+1. [Swift](./docs/sources/swift.md)
 1. [Yarn](./docs/sources/yarn.md)
 
 You can disable any of them in the configuration file:

--- a/docs/sources/swift.md
+++ b/docs/sources/swift.md
@@ -1,0 +1,4 @@
+# Swift
+
+The Swift source uses `swift package` subcommands
+to enumerate dependencies and properties.

--- a/lib/licensed/sources.rb
+++ b/lib/licensed/sources.rb
@@ -14,6 +14,7 @@ module Licensed
     require "licensed/sources/nuget"
     require "licensed/sources/pip"
     require "licensed/sources/pipenv"
+    require "licensed/sources/swift"
     require "licensed/sources/gradle"
     require "licensed/sources/mix"
     require "licensed/sources/yarn"

--- a/lib/licensed/sources/swift.rb
+++ b/lib/licensed/sources/swift.rb
@@ -3,8 +3,6 @@ require "json"
 require "pathname"
 require "uri"
 
-require "licensed/sources/helpers/content_versioning"
-
 module Licensed
   module Sources
     class Swift < Source

--- a/lib/licensed/sources/swift.rb
+++ b/lib/licensed/sources/swift.rb
@@ -13,11 +13,12 @@ module Licensed
 
       def enumerate_dependencies
         pins.map { |pin|
+          name = pin["package"]
+          version = pin.dig("state", "version")
+          path = nil
           errors = []
 
           begin
-            name = pin["package"]
-            version = pin.dig("state", "version")
             path = dependency_path_for_url(pin["repositoryURL"])
           rescue => e
             errors << e

--- a/lib/licensed/sources/swift.rb
+++ b/lib/licensed/sources/swift.rb
@@ -1,74 +1,46 @@
 # frozen_string_literal: true
 require "json"
 require "pathname"
+require "uri"
+
 require "licensed/sources/helpers/content_versioning"
 
 module Licensed
   module Sources
     class Swift < Source
-      include Licensed::Sources::ContentVersioning
-
-      class Dependency < Licensed::Dependency
-        attr_reader :url
-
-        def initialize(name:, url:, version:, path:, search_root: nil, errors: [], metadata: {})
-          @url = url
-          super name: name, version: version, path: path, errors: errors, metadata: metadata, search_root: search_root
-        end
-      end
-
       def enabled?
-        Licensed::Shell.tool_available?("swift") && swift_package?
+        return unless Licensed::Shell.tool_available?("swift") && swift_package?
+        File.exist?(package_resolved_file_path)
       end
 
       def enumerate_dependencies
-        Hash[declarations.map { |d| [d.url, d] }]
-          .merge(Hash[pins.map { |d| [d.url, d] }])
-          .values
+        pins.map { |pin|
+          Dependency.new(
+            name: pin["package"],
+            path: dependency_path_for_url(pin["repositoryURL"]),
+            version: pin.dig("state", "version")
+          )
+        }
       end
 
       private
-
-      def declarations
-        return @declarations if defined?(@declarations)
-
-        @declarations = begin
-          json = JSON.parse(dump_package_command)
-          json["dependencies"].map do |dependency|
-            Dependency.new(
-              name: dependency["name"],
-              url: dependency["url"],
-              path: "/Package.swift",
-              version: dependency.dig("requirement", "exact") ||
-                        dependency.dig("requirement", "range")&.first&.fetch("lowerBound") ||
-                        dependency.dig("requirement", "range")&.first&.fetch("upperBound")
-            )
-          end
-        end || []
-      end
 
       def pins
         return @pins if defined?(@pins)
 
         @pins = begin
-          file = "Package.resolved"
-          return unless File.exist?(file)
-
-          json = JSON.parse(File.read(file))
-          json.dig("object", "pins").map do |pin|
-            Dependency.new(
-              name: pin["package"],
-              url: pin["repositoryURL"],
-              path: "/Package.resolved",
-              version: pin.dig("state", "version")
-            )
-          end
-        end || []
+          json = JSON.parse(File.read(package_resolved_file_path))
+          json.dig("object", "pins")
+        end
       end
 
-      def dump_package_command
-        args = %w(--skip-update)
-        Licensed::Shell.execute("swift", "package", "dump-package", *args)
+      def dependency_path_for_url(url)
+        last_path_component = URI(url).path.split('/').last.sub(/\.git$/, '')
+        File.join(config.pwd, ".build", "checkouts", last_path_component)
+      end
+
+      def package_resolved_file_path
+        File.join(config.pwd, "Package.resolved")
       end
 
       def swift_package?

--- a/lib/licensed/sources/swift.rb
+++ b/lib/licensed/sources/swift.rb
@@ -31,6 +31,9 @@ module Licensed
         @pins = begin
           json = JSON.parse(File.read(package_resolved_file_path))
           json.dig("object", "pins")
+        rescue JSON::ParserError => e
+          message = "Licensed was unable to parse the Package.resolved file'. JSON Error: #{e.message}"
+          raise Licensed::Sources::Source::Error, message
         end
       end
 

--- a/lib/licensed/sources/swift.rb
+++ b/lib/licensed/sources/swift.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+require "json"
+require "pathname"
+require "licensed/sources/helpers/content_versioning"
+
+module Licensed
+  module Sources
+    class Swift < Source
+      include Licensed::Sources::ContentVersioning
+
+      class Dependency < Licensed::Dependency
+        attr_reader :url
+
+        def initialize(name:, url:, version:, path:, search_root: nil, errors: [], metadata: {})
+          @url = url
+          super name: name, version: version, path: path, errors: errors, metadata: metadata, search_root: search_root
+        end
+      end
+
+      def enabled?
+        Licensed::Shell.tool_available?("swift") && swift_package?
+      end
+
+      def enumerate_dependencies
+        Hash[declarations.map { |d| [d.url, d] }]
+          .merge(Hash[pins.map { |d| [d.url, d] }])
+          .values
+      end
+
+      private
+
+      def declarations
+        return @declarations if defined?(@declarations)
+
+        @declarations = begin
+          json = JSON.parse(dump_package_command)
+          json["dependencies"].map do |dependency|
+            Dependency.new(
+              name: dependency["name"],
+              url: dependency["url"],
+              path: "/Package.swift",
+              version: dependency.dig("requirement", "exact") ||
+                        dependency.dig("requirement", "range")&.first&.fetch("lowerBound") ||
+                        dependency.dig("requirement", "range")&.first&.fetch("upperBound")
+            )
+          end
+        end || []
+      end
+
+      def pins
+        return @pins if defined?(@pins)
+
+        @pins = begin
+          file = "Package.resolved"
+          return unless File.exist?(file)
+
+          json = JSON.parse(File.read(file))
+          json.dig("object", "pins").map do |pin|
+            Dependency.new(
+              name: pin["package"],
+              url: pin["repositoryURL"],
+              path: "/Package.resolved",
+              version: pin.dig("state", "version")
+            )
+          end
+        end || []
+      end
+
+      def dump_package_command
+        args = %w(--skip-update)
+        Licensed::Shell.execute("swift", "package", "dump-package", *args)
+      end
+
+      def swift_package?
+        Licensed::Shell.success?("swift", "package", "describe")
+      end
+    end
+  end
+end

--- a/lib/licensed/sources/swift.rb
+++ b/lib/licensed/sources/swift.rb
@@ -32,13 +32,13 @@ module Licensed
           json = JSON.parse(File.read(package_resolved_file_path))
           json.dig("object", "pins")
         rescue JSON::ParserError => e
-          message = "Licensed was unable to parse the Package.resolved file'. JSON Error: #{e.message}"
+          message = "Licensed was unable to parse the Package.resolved file. JSON Error: #{e.message}"
           raise Licensed::Sources::Source::Error, message
         end
       end
 
       def dependency_path_for_url(url)
-        last_path_component = URI(url).path.split('/').last.sub(/\.git$/, '')
+        last_path_component = URI(url).path.split("/").last.sub(/\.git$/, "")
         File.join(config.pwd, ".build", "checkouts", last_path_component)
       end
 

--- a/script/source-setup/swift
+++ b/script/source-setup/swift
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+if [ -z "$(which swift)" ]; then
+  echo "A local swift installation is required for swift development." >&2
+  exit 127
+fi
+
+swift --version

--- a/script/source-setup/swift
+++ b/script/source-setup/swift
@@ -7,3 +7,13 @@ if [ -z "$(which swift)" ]; then
 fi
 
 swift --version
+
+if [ "$1" == "-f" ]; then
+  find . -not -regex "\.*" \
+    -and -not -path "*/Package.swift" \
+    -and -not -path "*/Sources*" \
+    -and -not -path "*/Tests*" \
+    -print0 | xargs -0 rm -rf
+fi
+
+swift package resolve

--- a/script/source-setup/swift
+++ b/script/source-setup/swift
@@ -8,6 +8,9 @@ fi
 
 swift --version
 
+BASE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd $BASE_PATH/test/fixtures/swift
+
 if [ "$1" == "-f" ]; then
   find . -not -regex "\.*" \
     -and -not -path "*/Package.swift" \

--- a/test/fixtures/command/swift.yml
+++ b/test/fixtures/command/swift.yml
@@ -1,0 +1,5 @@
+expected_dependency: LinkedList
+source_path: test/fixtures/swift
+cache_path: test/fixtures/swift/.licenses
+sources:
+  swift: true

--- a/test/fixtures/command/swift.yml
+++ b/test/fixtures/command/swift.yml
@@ -1,4 +1,4 @@
-expected_dependency: LinkedList
+expected_dependency: DeckOfPlayingCards
 source_path: test/fixtures/swift
 cache_path: test/fixtures/swift/.licenses
 sources:

--- a/test/fixtures/swift/Package.resolved
+++ b/test/fixtures/swift/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "LinkedList",
+        "repositoryURL": "https://github.com/mona/LinkedList.git",
+        "state": {
+          "branch": null,
+          "revision": "cfdacae39417d7a987f63a0ea5335a80b16d4659",
+          "version": "1.2.1"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/test/fixtures/swift/Package.resolved
+++ b/test/fixtures/swift/Package.resolved
@@ -2,12 +2,30 @@
   "object": {
     "pins": [
       {
-        "package": "LinkedList",
-        "repositoryURL": "https://github.com/mona/LinkedList.git",
+        "package": "DeckOfPlayingCards",
+        "repositoryURL": "https://github.com/apple/example-package-deckofplayingcards.git",
         "state": {
           "branch": null,
-          "revision": "cfdacae39417d7a987f63a0ea5335a80b16d4659",
-          "version": "1.2.1"
+          "revision": "2c0e5ac3e10216151fc78ac1ec6bd9c2c0111a3a",
+          "version": "3.0.4"
+        }
+      },
+      {
+        "package": "FisherYates",
+        "repositoryURL": "https://github.com/apple/example-package-fisheryates.git",
+        "state": {
+          "branch": null,
+          "revision": "e729f197bbc3831b9a3005fa71ad6f38c1e7e17e",
+          "version": "2.0.6"
+        }
+      },
+      {
+        "package": "PlayingCard",
+        "repositoryURL": "https://github.com/apple/example-package-playingcard.git",
+        "state": {
+          "branch": null,
+          "revision": "39ddabb01e8102ab548a8c6bb3eb20b15f3b4fbc",
+          "version": "3.0.5"
         }
       }
     ]

--- a/test/fixtures/swift/Package.swift
+++ b/test/fixtures/swift/Package.swift
@@ -1,0 +1,28 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Fixtures",
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: "Fixtures",
+            targets: ["Fixtures"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        .package(url: "https://github.com/mona/LinkedList.git", from: "1.2.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(
+            name: "Fixtures",
+            dependencies: []),
+        .testTarget(
+            name: "FixturesTests",
+            dependencies: ["Fixtures"]),
+    ]
+)

--- a/test/fixtures/swift/Package.swift
+++ b/test/fixtures/swift/Package.swift
@@ -12,15 +12,18 @@ let package = Package(
             targets: ["Fixtures"]),
     ],
     dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/mona/LinkedList.git", from: "1.2.0"),
+        .package(name: "DeckOfPlayingCards",
+                 url: "https://github.com/apple/example-package-deckofplayingcards.git", 
+                 from: "3.0.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "Fixtures",
-            dependencies: []),
+            dependencies: [
+                .product(name: "DeckOfPlayingCards", package: "DeckOfPlayingCards")
+            ]),
         .testTarget(
             name: "FixturesTests",
             dependencies: ["Fixtures"]),

--- a/test/fixtures/swift/Sources/Fixtures/Fixture.swift
+++ b/test/fixtures/swift/Sources/Fixtures/Fixture.swift
@@ -1,0 +1,3 @@
+public struct Fixture {
+    public init() {}
+}

--- a/test/fixtures/swift/Tests/FixturesTests/FixturesTests.swift
+++ b/test/fixtures/swift/Tests/FixturesTests/FixturesTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+import Fixtures
+
+class FixturesTests: XCTestCase {
+    func testFixtures() {
+        XCTAssertNotNil(Fixture())
+    }
+}

--- a/test/sources/swift_test.rb
+++ b/test/sources/swift_test.rb
@@ -32,10 +32,17 @@ if Licensed::Shell.tool_available?("swift")
 
       it "finds dependencies from path sources" do
         Dir.chdir(fixtures) do
-          dep = source.enumerate_dependencies.find { |d| d.name == "LinkedList" }
+          dep = source.enumerate_dependencies.find { |d| d.name == "DeckOfPlayingCards" }
           assert dep
-          assert_equal "1.2.1", dep.version
-          assert_equal "https://github.com/mona/LinkedList.git", dep.url
+          assert_equal "3.0.4", dep.version
+
+          dep = source.enumerate_dependencies.find { |d| d.name == "FisherYates" }
+          assert dep
+          assert_equal "2.0.6", dep.version
+
+          dep = source.enumerate_dependencies.find { |d| d.name == "PlayingCard" }
+          assert dep
+          assert_equal "3.0.5", dep.version
 
           dep = source.enumerate_dependencies.find { |d| d.name == "Invalid" }
           refute dep

--- a/test/sources/swift_test.rb
+++ b/test/sources/swift_test.rb
@@ -67,7 +67,7 @@ if Licensed::Shell.tool_available?("swift")
         assert dep
         assert dep.errors
       end
-      
+
       it "handles invalid Package.resolved file" do
         Dir.mktmpdir do |dir|
           FileUtils.cp_r(fixtures, dir)

--- a/test/sources/swift_test.rb
+++ b/test/sources/swift_test.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+require "test_helper"
+require "tmpdir"
+
+if Licensed::Shell.tool_available?("swift")
+  describe Licensed::Sources::Swift do
+    let(:fixtures) { File.expand_path("../../fixtures/swift", __FILE__) }
+    let(:config) { Licensed::AppConfiguration.new({ "source_path" => Dir.pwd }) }
+    let(:source) { Licensed::Sources::Swift.new(config) }
+
+    describe "enabled?" do
+      it "is true if Swift package exists" do
+        Dir.chdir(fixtures) do
+          assert source.enabled?
+        end
+      end
+
+      it "is false if Swift package doesn't exist" do
+        Dir.chdir(Dir.tmpdir) do
+          refute source.enabled?
+        end
+      end
+    end
+
+    describe "enumerate_dependencies" do
+      it "does not include the source project" do
+        Dir.chdir(fixtures) do
+          config["name"] = "Fixtures"
+          refute source.enumerate_dependencies.find { |d| d.name == "Fixtures" }
+        end
+      end
+
+      it "finds dependencies from path sources" do
+        Dir.chdir(fixtures) do
+          dep = source.enumerate_dependencies.find { |d| d.name == "LinkedList" }
+          assert dep
+          assert_equal "1.2.1", dep.version
+          assert_equal "https://github.com/mona/LinkedList.git", dep.url
+
+          dep = source.enumerate_dependencies.find { |d| d.name == "Invalid" }
+          refute dep
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds support for [Swift Package Manager](https://swift.org/package-manager/) to Licensed.

This will need to be updated once the [Swift package registry](https://github.com/apple/swift-evolution/blob/main/proposals/0292-package-registry-service.md) is implemented. But for now, it works with existing URL-based dependency declarations.
