### PR TITLE
Remove an extraneous space

### DIFF
--- a/lib/licensed/sources/bundler/missing_specification.rb
+++ b/lib/licensed/sources/bundler/missing_specification.rb
@@ -48,7 +48,7 @@ module Bundler
       spec = orig_materialize
       return spec if spec
 
-      Licensed::Bundler:: MissingSpecification.new(name: name, version: version, platform: platform, source: source)
+      Licensed::Bundler::MissingSpecification.new(name: name, version: version, platform: platform, source: source)
     end
   end
 end


### PR DESCRIPTION
Saw this randomly while debugging some related code.  Good to know that spaces in a full class name don't break anything 🤷 