### PR TITLE
Add configurable property for nuget project obj path

### DIFF
--- a/lib/licensed/sources/nuget.rb
+++ b/lib/licensed/sources/nuget.rb
@@ -164,12 +164,16 @@ module Licensed
       end
 
       def project_assets_file_path
-        File.join(config.pwd, "project.assets.json")
+        File.join(config.pwd, nuget_obj_path, "project.assets.json")
       end
 
       def project_assets_file
         return @project_assets_file if defined?(@project_assets_file)
         @project_assets_file = File.read(project_assets_file_path)
+      end
+
+      def nuget_obj_path
+        config.dig("nuget", "obj_path") || ""
       end
 
       def enabled?

--- a/test/sources/nuget_test.rb
+++ b/test/sources/nuget_test.rb
@@ -39,6 +39,18 @@ if Licensed::Shell.tool_available?("dotnet")
           assert_equal "https://www.newtonsoft.com/json", dep.record["homepage"]
         end
       end
+
+      it "finds dependendencies under a configured obj path" do
+        Dir.chdir File.join(fixtures, "..") do
+          config["nuget"] = { "obj_path" => "obj" }
+          dep = source.dependencies.detect { |d| d.name == "Newtonsoft.Json-12.0.3" }
+          assert dep
+          assert_equal "nuget", dep.record["type"]
+          assert_equal "Newtonsoft.Json", dep.record["name"]
+          assert_equal "12.0.3", dep.record["version"]
+          assert_equal "https://www.newtonsoft.com/json", dep.record["homepage"]
+        end
+      end
     end
 
     describe "license expressions" do


### PR DESCRIPTION
closes https://github.com/github/licensed/issues/355

This adds an `obj_path` property for the nuget source that should make it easier/possible to specify nuget sources with a glob source path.  Specifically as mentioned in [this comment](https://github.com/github/licensed/issues/355#issuecomment-822647991), the nuget source can be configured with the following to enable glob patterns.

```
source_path: some/path/*
nuget:
  obj_path: obj
```

/cc @JanMattner FYI as issue author

/cc @zarenner 👋 as being involved with the original nuget source implementation.  It's been a _long_ time since I've worked with .Net and C#, but I do recall the default project structure for obj folders being `project/obj/...`.  I think it would make sense to make the above "obj" value the default for `obj_path` in the next breaking major version release, and allow this to be overridden for other project structures.  WDYT?