### PR TITLE
Find packages from Nuget fallback folders if possible

### DIFF
--- a/lib/licensed/sources/nuget.rb
+++ b/lib/licensed/sources/nuget.rb
@@ -178,7 +178,7 @@ module Licensed
         message = "Licensed was unable to read the project.assets.json file. Error: #{e.message}"
         raise Licensed::Sources::Source::Error, message
       end
-      
+
       def nuget_obj_path
         config.dig("nuget", "obj_path") || ""
       end

--- a/lib/licensed/sources/nuget.rb
+++ b/lib/licensed/sources/nuget.rb
@@ -195,7 +195,7 @@ module Licensed
 
           path = full_dependency_path(reference_key)
           error = "Package #{id} not found at any project package folder" if path.nil?
-          
+
           NuGetDependency.new(
             name: id,
             version: version,

--- a/lib/licensed/sources/nuget.rb
+++ b/lib/licensed/sources/nuget.rb
@@ -198,7 +198,7 @@ module Licensed
           id = "#{name}-#{version}"
 
           path = full_dependency_path(reference_key)
-          error = "Package #{id} not found at any project package folder" if path.nil?
+          error = "Package #{id} path was not found in project.assets.json, or does not exist on disk at any project package folder" if path.nil?
 
           NuGetDependency.new(
             name: id,

--- a/lib/licensed/sources/nuget.rb
+++ b/lib/licensed/sources/nuget.rb
@@ -172,6 +172,13 @@ module Licensed
         @project_assets_file = File.read(project_assets_file_path)
       end
 
+      def project_assets_json
+        @project_assets_json ||= JSON.parse(project_assets_file)
+      rescue JSON::ParserError => e
+        message = "Licensed was unable to read the project.assets.json file. Error: #{e.message}"
+        raise Licensed::Sources::Source::Error, message
+      end
+
       def enabled?
         File.exist?(project_assets_file_path)
       end
@@ -180,32 +187,51 @@ module Licensed
       # Ideally we'd use `dotnet list package` instead, but its output isn't
       # easily machine readable and doesn't contain everything we need.
       def enumerate_dependencies
-        json = JSON.parse(project_assets_file)
-        nuget_packages_dir = json["project"]["restore"]["packagesPath"]
-        json["targets"].each_with_object({}) do |(_, target), dependencies|
-          target.each do |reference_key, reference|
-            # Ignore project references
-            next unless reference["type"] == "package"
-            package_id_parts = reference_key.partition("/")
-            name = package_id_parts[0]
-            version = package_id_parts[-1]
-            id = "#{name}-#{version}"
+        reference_keys.map do |reference_key|
+          package_id_parts = reference_key.partition("/")
+          name = package_id_parts[0]
+          version = package_id_parts[-1]
+          id = "#{name}-#{version}"
 
-            # Already know this package from another target
-            next if dependencies.key?(id)
+          path = full_dependency_path(reference_key)
+          error = "Package #{id} not found at any project package folder" if path.nil?
+          
+          NuGetDependency.new(
+            name: id,
+            version: version,
+            path: path,
+            errors: Array(error),
+            metadata: {
+              "type" => NuGet.type,
+              "name" => name
+            }
+          )
+        end
+      end
 
-            path = File.join(nuget_packages_dir, json["libraries"][reference_key]["path"])
-            dependencies[id] = NuGetDependency.new(
-              name: id,
-              version: version,
-              path: path,
-              metadata: {
-                "type" => NuGet.type,
-                "name" => name
-              }
-            )
-          end
-        end.values
+      # Returns a unique set of the package reference keys used across all target groups
+      def reference_keys
+        all_reference_keys = project_assets_json["targets"].flat_map do |_, references|
+          references.select { |key, reference| reference["type"] == "package" }
+                    .keys
+        end
+
+        Set.new(all_reference_keys)
+      end
+
+      # Returns a dependency's path, if it exists, in one of the project's global or fallback package folders
+      def full_dependency_path(reference_key)
+        dependency_path = project_assets_json.dig("libraries", reference_key, "path")
+        return unless dependency_path
+
+        nuget_package_dirs = [
+          project_assets_json.dig("project", "restore", "packagesPath"),
+          *Array(project_assets_json.dig("project", "restore", "fallbackFolders"))
+        ].compact
+
+        nuget_package_dirs.map { |dir| File.join(dir, dependency_path) }
+                          .select { |path| File.directory?(path) }
+                          .first
       end
     end
   end

--- a/test/sources/nuget_test.rb
+++ b/test/sources/nuget_test.rb
@@ -74,7 +74,7 @@ if Licensed::Shell.tool_available?("dotnet")
 
           Dir.chdir(dir) do
             dep = source.dependencies.detect { |d| d.name == "Newtonsoft.Json-12.0.3" }
-            assert_equal ["Package Newtonsoft.Json-12.0.3 not found at any project package folder"],
+            assert_equal ["Package Newtonsoft.Json-12.0.3 path was not found in project.assets.json, or does not exist on disk at any project package folder"],
                          dep.errors
           end
         end

--- a/test/sources/nuget_test.rb
+++ b/test/sources/nuget_test.rb
@@ -39,6 +39,60 @@ if Licensed::Shell.tool_available?("dotnet")
           assert_equal "https://www.newtonsoft.com/json", dep.record["homepage"]
         end
       end
+
+      it "find dependencies from fallback folders" do
+        Dir.mktmpdir do |dir|
+          FileUtils.cp_r(fixtures, dir)
+          dir = File.join(dir, "obj")
+          assets_json_path = File.join(dir, "project.assets.json")
+          assets_json = JSON.parse(File.read(assets_json_path))
+          assets_json["project"]["restore"]["fallbackFolders"] = [
+            assets_json.dig("project", "restore", "packagesPath")
+          ]
+          assets_json["project"]["restore"]["packagesPath"] = ""
+          File.write(assets_json_path, JSON.pretty_generate(assets_json))
+
+          Dir.chdir(dir) do
+            dep = source.dependencies.detect { |d| d.name == "Newtonsoft.Json-12.0.3" }
+            assert dep
+            assert_equal "nuget", dep.record["type"]
+            assert_equal "Newtonsoft.Json", dep.record["name"]
+            assert_equal "12.0.3", dep.record["version"]
+            assert_equal "https://www.newtonsoft.com/json", dep.record["homepage"]
+          end
+        end
+      end
+
+      it "sets a dependency error if a project isn't found" do
+        Dir.mktmpdir do |dir|
+          FileUtils.cp_r(fixtures, dir)
+          dir = File.join(dir, "obj")
+          assets_json_path = File.join(dir, "project.assets.json")
+          assets_json = JSON.parse(File.read(assets_json_path))
+          assets_json["project"]["restore"]["packagesPath"] = ""
+          File.write(assets_json_path, JSON.pretty_generate(assets_json))
+
+          Dir.chdir(dir) do
+            dep = source.dependencies.detect { |d| d.name == "Newtonsoft.Json-12.0.3" }
+            assert_equal ["Package Newtonsoft.Json-12.0.3 not found at any project package folder"],
+                         dep.errors
+          end
+        end
+      end
+
+      it "raises an error if project.assets.json can't be parsed" do
+        Dir.mktmpdir do |dir|
+          assets_json_path = File.join(dir, "project.assets.json")
+          File.write(assets_json_path, "invalid json")
+
+          Dir.chdir(dir) do
+            assert_raises ::Licensed::Sources::Source::Error do
+              source.dependencies
+            end
+          end
+        end
+      end
+
     end
 
     describe "license expressions" do


### PR DESCRIPTION
closes https://github.com/github/licensed/issues/352

This gives an alternate solution to https://github.com/github/licensed/pull/273. I opted to start a new branch because that PR/branch had become stale and it was a bit quicker to build on the ideas rather than building directly on the code.

I've given attribution to @paveliak in the commit comment, and here as well I guess 😄 .  @paveliak if there's another way you'd like me to represent your input in these changes please let me know 🙏 !

Some other changes that came along as I better understood the json file format and the code here:
1. raising a `Licensed::Sources::Source::Error` error if the json file can't be parsed.  This is a special error class that signals a source enumerator-wide error.
2. setting a custom error message on the dependency if a path isn't found. a default error is set if a path is given but doesn't exist on disk, however in this case the path would be `nil`, which doesn't work with the default scenario.
3. I refactored the code around finding reference keys to (I hope) simplify the code readability just a little bit.  I'm using a `Set` to enforce uniqueness, though now the uniqueness is enforced for `reference_key` values and not computed `id` values.
