### PR TITLE
Add available metadata to swift dependencies

### DIFF
--- a/lib/licensed/sources/swift.rb
+++ b/lib/licensed/sources/swift.rb
@@ -15,7 +15,8 @@ module Licensed
         pins.map { |pin|
           name = pin["package"]
           version = pin.dig("state", "version")
-          url = pin["repositoryURL"].sub(/\.git$/, "")
+          url = pin["repositoryURL"]
+          homepage = url.sub(/\.git$/, "")
           path = nil
           errors = []
 
@@ -32,7 +33,7 @@ module Licensed
             errors: errors,
             metadata: {
               "type"      => Swift.type,
-              "homepage"  => url
+              "homepage"  => homepage
             }
           )
         }

--- a/lib/licensed/sources/swift.rb
+++ b/lib/licensed/sources/swift.rb
@@ -54,7 +54,7 @@ module Licensed
       end
 
       def dependency_path_for_url(url)
-        last_path_component = URI(url).path.split("/").last
+        last_path_component = URI(url).path.split("/").last.sub(/\.git$/, "")
         File.join(config.pwd, ".build", "checkouts", last_path_component)
       end
 

--- a/lib/licensed/sources/swift.rb
+++ b/lib/licensed/sources/swift.rb
@@ -15,11 +15,12 @@ module Licensed
         pins.map { |pin|
           name = pin["package"]
           version = pin.dig("state", "version")
+          url = pin["repositoryURL"].sub(/\.git$/, "")
           path = nil
           errors = []
 
           begin
-            path = dependency_path_for_url(pin["repositoryURL"])
+            path = dependency_path_for_url(url)
           rescue => e
             errors << e
           end
@@ -28,7 +29,11 @@ module Licensed
             name: name,
             path: path,
             version: version,
-            errors: errors
+            errors: errors,
+            metadata: {
+              "type"      => Swift.type,
+              "homepage"  => url
+            }
           )
         }
       end
@@ -48,7 +53,7 @@ module Licensed
       end
 
       def dependency_path_for_url(url)
-        last_path_component = URI(url).path.split("/").last.sub(/\.git$/, "")
+        last_path_component = URI(url).path.split("/").last
         File.join(config.pwd, ".build", "checkouts", last_path_component)
       end
 

--- a/test/sources/swift_test.rb
+++ b/test/sources/swift_test.rb
@@ -36,6 +36,7 @@ if Licensed::Shell.tool_available?("swift")
           dep = source.enumerate_dependencies.find { |d| d.name == "DeckOfPlayingCards" }
           assert dep
           assert_equal "3.0.4", dep.version
+          assert_equal "https://github.com/apple/example-package-deckofplayingcards", dep.record["homepage"]
 
           dep = source.enumerate_dependencies.find { |d| d.name == "FisherYates" }
           assert dep


### PR DESCRIPTION
:wave: @mattt it's been awhile since a new dependency source has been added to licensed and I missed that there is some metadata content that is nice to include if/when it's available.

"type" is another indicator of the source of the dependency.  This can also be found from the path to the cached metadata, but 🤷 including it here will put that value into the cached file for a little added helpfulness with minimal overhead.

"homepage" is useful for someone to track the dependency back to its source, and in this case should _usually_ be available from the git url.  It's not a 100% guarantee that taking ".git" off of the "repositoryURL" field will result in a valid URL, however there's a pretty good chance it'll work and it's a low cost addition.

The last piece of common metadata that is included if it's available is a summary or description of the dependency package.  It doesn't look like that's available from the information here, at least from the test project.  Is a description included in any distributed content in swift's package management?

Can you take a look and let me know if you see anything off or wrong about these changes?