### PR TITLE
Make go local package checks case insensitive

### DIFF
--- a/lib/licensed/sources/go.rb
+++ b/lib/licensed/sources/go.rb
@@ -98,7 +98,7 @@ module Licensed
       # Returns whether the package is local to the current project
       def local_package?(package)
         return false unless package && package["Dir"]
-        return false unless File.fnmatch?("#{config.root.to_s}*", package["Dir"])
+        return false unless File.fnmatch?("#{config.root.to_s}*", package["Dir"], File::FNM_CASEFOLD)
         vendored_path_parts(package).nil?
       end
 

--- a/test/fixtures/go/src/test/pkg/world/hello.go
+++ b/test/fixtures/go/src/test/pkg/world/hello.go
@@ -1,0 +1,9 @@
+package world
+
+import (
+	"fmt"
+)
+
+func HelloWorld() {
+	fmt.Println("hello world")
+}

--- a/test/fixtures/go/src/test/test.go
+++ b/test/fixtures/go/src/test/test.go
@@ -1,18 +1,20 @@
 package test
 
 import (
-  lru "github.com/hashicorp/golang-lru"
-  ctx "github.com/gorilla/context"
-  "golang.org/x/net/http2/hpack"
-  "github.com/davecgh/go-spew/spew"
-  "test/internal/fakevendor/github.com/owner/repo"
+	"github.com/davecgh/go-spew/spew"
+	ctx "github.com/gorilla/context"
+	lru "github.com/hashicorp/golang-lru"
+	"golang.org/x/net/http2/hpack"
+	"test/internal/fakevendor/github.com/owner/repo"
+	"test/pkg/world"
 )
 
 func main() {
-  lru.New(1)
-  ctx.Purge(0)
-  _ = hpack.ErrInvalidHuffman
-  i := 1
-  spew.Dump(i)
-  testpackage.HelloWorld()
+	lru.New(1)
+	ctx.Purge(0)
+	_ = hpack.ErrInvalidHuffman
+	i := 1
+	spew.Dump(i)
+	testpackage.HelloWorld()
+	world.HelloWorld()
 }

--- a/test/sources/go_test.rb
+++ b/test/sources/go_test.rb
@@ -84,6 +84,19 @@ if Licensed::Shell.tool_available?("go")
         end
       end
 
+      it "does not include any local, non vendored packages" do
+        Dir.chdir fixtures do
+          refute source.dependencies.detect { |d| d.name == "github.com/github/test/pkg/world" }
+        end
+      end
+
+      it "uses case insensitive matching to determine local package paths" do
+        fixtures = File.join(gopath, "src/github.com/github/tesT")
+        Dir.chdir fixtures do
+          refute source.dependencies.detect { |d| d.name == "github.com/github/test/pkg/world" }
+        end
+      end
+
       it "includes direct dependencies" do
         Dir.chdir fixtures do
           dep = source.dependencies.detect { |d| d.name == "github.com/hashicorp/golang-lru" }

--- a/test/sources/go_test.rb
+++ b/test/sources/go_test.rb
@@ -86,14 +86,14 @@ if Licensed::Shell.tool_available?("go")
 
       it "does not include any local, non vendored packages" do
         Dir.chdir fixtures do
-          refute source.dependencies.detect { |d| d.name == "github.com/github/test/pkg/world" }
+          refute source.dependencies.detect { |d| d.name == "test/pkg/world" }
         end
       end
 
       it "uses case insensitive matching to determine local package paths" do
-        fixtures = File.join(gopath, "src/github.com/github/tesT")
+        fixtures = File.join(gopath, "src/tesT")
         Dir.chdir fixtures do
-          refute source.dependencies.detect { |d| d.name == "github.com/github/test/pkg/world" }
+          refute source.dependencies.detect { |d| d.name == "test/pkg/world" }
         end
       end
 

--- a/test/sources/go_test.rb
+++ b/test/sources/go_test.rb
@@ -90,13 +90,6 @@ if Licensed::Shell.tool_available?("go")
         end
       end
 
-      it "uses case insensitive matching to determine local package paths" do
-        fixtures = File.join(gopath, "src/tesT")
-        Dir.chdir fixtures do
-          refute source.dependencies.detect { |d| d.name == "test/pkg/world" }
-        end
-      end
-
       it "includes direct dependencies" do
         Dir.chdir fixtures do
           dep = source.dependencies.detect { |d| d.name == "github.com/hashicorp/golang-lru" }


### PR DESCRIPTION
Fixes https://github.com/github/licensed/issues/369

This is a pretty small change to make path matching case-insensitive by adding the `File::FNM_CASEFOLD` flag to the `File.fnmatch?` call.  I was unable to reproduce the linked issue in my local dev environment, and the unix CI environment with case-sensitive pathnames at the system level prevents the issue from occurring altogether as evidenced by the two failing commits where I tried to add a test that would reproduce the failure scenario.