### PR TITLE
Do not reset bundler environment if unneeded

### DIFF
--- a/lib/licensed/sources/bundler.rb
+++ b/lib/licensed/sources/bundler.rb
@@ -156,6 +156,7 @@ module Licensed
           ENV["BUNDLE_GEMFILE"] = original_bundle_gemfile
 
           # restore bundler configuration
+          ::Bundler.reset!
           ::Bundler.configure
         end
 

--- a/test/sources/bundler_test.rb
+++ b/test/sources/bundler_test.rb
@@ -252,5 +252,35 @@ if Licensed::Shell.tool_available?("bundle")
         end
       end
     end
+
+    describe "#with_local_configuration" do
+      it "resets the Bundler environment" do
+        begin
+          original_gem_home, ENV["GEM_HOME"] = ENV["GEM_HOME"], "foo"
+          Dir.chdir(fixtures) do
+            source.with_local_configuration do
+              refute_equal "foo", ENV["GEM_HOME"]
+            end
+          end
+        ensure
+          ENV["GEM_HOME"] = original_gem_home
+        end
+      end
+
+      it "does not reset Bundler environment when the correct environment is already set" do
+        begin
+          original_gem_home, ENV["GEM_HOME"] = ENV["GEM_HOME"], "foo"
+          original_bundle_gemfile, ENV["BUNDLE_GEMFILE"] = ENV["BUNDLE_GEMFILE"], source.gemfile_path.to_s
+          Dir.chdir(fixtures) do
+            source.with_local_configuration do
+              assert_equal "foo", ENV["GEM_HOME"]
+            end
+          end
+        ensure
+          ENV["BUNDLE_GEMFILE"] = original_bundle_gemfile
+          ENV["GEM_HOME"] = original_gem_home
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This should fix an edge case I saw in a project that uses a custom bundler and ruby build, where licensed was installed in a `Gemfile` and run with `bundle exec licensed ...`.  In the target scenario, the bundler reset calls in `with_local_configuration` were causing the environment to no longer represent the `bundle exec` environment, and platform-specific dependencies weren't being found.

`with_local_configuration` is meant to support running licensed as a standalone tool outside of `bundle exec`  where a bundler environment has already been loaded and `ENV["BUNDLE_GEMFILE"]` should already be set to the expected gemfile path.  The change checks whether the ENV var matches the expected local gemfile path, in which case the assumption is that the correct bundler environment is already loaded and the tool shouldn't reset anything.