### PR TITLE
Enforce that the bundler spec file is an actual file

### DIFF
--- a/lib/licensed/sources/bundler.rb
+++ b/lib/licensed/sources/bundler.rb
@@ -29,7 +29,7 @@ module Licensed
         # `loaded_from` if available.
         def spec_file
           return @spec_file if defined?(@spec_file)
-          return @spec_file = nil unless loaded_from && File.exist?(loaded_from)
+          return @spec_file = nil unless loaded_from && File.file?(loaded_from)
           @spec_file = begin
             file = { name: File.basename(loaded_from), dir: File.dirname(loaded_from) }
             Licensee::ProjectFiles::PackageManagerFile.new(File.read(loaded_from), file)


### PR DESCRIPTION
Updates a check that a detected bundler spec file is an actual file.  It's possible that this could be a directory, in which case an error is raised.  This is observable by running licensed on itself, with the bundler dependency causing an error in this scenario :/