### PR TITLE
More documentation and cleanup updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ See the [v2 migration documentation](./docs/migrations/v2.md) for more info on m
 
 Licensed uses the `libgit2` bindings for Ruby provided by `rugged`. `rugged` requires `cmake` and `pkg-config` which you may need to install before you can install Licensed.
 
-   >  Ubuntu
+```bash
+# Ubuntu
+sudo apt-get install cmake pkg-config
 
-    sudo apt-get install cmake pkg-config
-
-   >  OS X
-
-    brew install cmake pkg-config
+# macOS
+brew install cmake pkg-config
+```
 
 ### With a Gemfile
 
@@ -56,7 +56,7 @@ gem 'licensed', :group => 'development'
 And then execute:
 
 ```bash
-$ bundle
+$> bundle
 ```
 
 ### As an executable
@@ -64,25 +64,27 @@ $ bundle
 Download a package from GitHub and extract the executable.  Executable packages are available for each release starting with version 1.2.0.
 
 ```bash
-$ curl -sSL https://github.com/github/licensed/releases/download/<version>/licensed-<version>-<os>-x64.tar.gz > licensed.tar.gz
-$ tar -xzf licensed.tar.gz
-$ rm -f licensed.tar.gz
-$ ./licensed list
+$> curl -sSL https://github.com/github/licensed/releases/download/<version>/licensed-<version>-<os>-x64.tar.gz > licensed.tar.gz
+$> tar -xzf licensed.tar.gz
+$> rm -f licensed.tar.gz
+$> ./licensed list
 ```
 
 For system wide usage, install licensed to a location on `$PATH`, e.g. `/usr/local/bin`.
 
 ## Usage
 
-- `licensed list`: Output enumerated dependencies only.
-- `licensed cache`: Cache licenses and metadata.
-- `licensed status`: Check status of dependencies' cached licenses.
-- `licensed notices`: Write a `NOTICE` file for each application configuration.
-- `licensed version`: Show current installed version of Licensed. Aliases: `-v|--version`
-- `licensed env`: Output environment information from the licensed configuration.
-- `licensed migrate`: Migrate licensed configuration and cached files from a previous major version.
+### Available commands
 
-See the [commands documentation](./docs/commands) for additional documentation, or run `licensed -h` to see all of the current available commands.
+See the [commands documentation](./docs/commands) for documentation on available commands, or run `licensed -h` to see all of the current available commands.
+
+### Configuration options
+
+A configuration file is required for most commands.  See the [configuration file documentation](./docs/configuration.md) for more details on the configuration format and available configuration options.
+
+### Available dependency sources
+
+Licensed can enumerate dependency for many languages, package managers, and frameworks.  See the [sources documentation](./docs/sources) for the list of currently available sources.  Sources can be explicitly enabled and disabled as a [configuration option](./docs/configuration/sources.md).
 
 ### Automation
 
@@ -96,76 +98,22 @@ The [licensed-ci](https://github.com/marketplace/actions/licensed-ci) GitHub Act
 
 The [setup-licensed](https://github.com/marketplace/actions/setup-github-licensed) GitHub Action installs `licensed` to the workflow environment.  See the linked actions for usage and details.
 
-### Configuration
-
-All commands, except `version`, accept a `-c|--config` option to specify a path to a configuration file or directory.
-
-If a directory is specified, `licensed` will look in that directory for a file named (in order of preference):
-1. `.licensed.yml`
-2. `.licensed.yaml`
-3. `.licensed.json`
-
-If the option is not specified, the value will be set to the current directory.
-
-See the [configuration file documentation](./docs/configuration.md) for more details on the configuration format.
-
-### Sources
-
-Dependencies will be automatically detected for all of the following sources by default.
-1. [Bower](./docs/sources/bower.md)
-1. [Bundler](./docs/sources/bundler.md)
-1. [Cabal](./docs/sources/cabal.md)
-1. [Composer](./docs/sources/composer.md)
-1. [Git Submodules (git_submodule)](./docs/sources/git_submodule.md)
-1. [Go](./docs/sources/go.md)
-1. [Go Dep (dep)](./docs/sources/dep.md)
-1. [Gradle](./docs/sources/gradle.md)
-1. [Manifest lists (manifests)](./docs/sources/manifests.md)
-1. [Mix](./docs/sources/mix.md)
-1. [npm](./docs/sources/npm.md)
-1. [NuGet](./docs/sources/nuget.md)
-1. [Pip](./docs/sources/pip.md)
-1. [Pipenv](./docs/sources/pipenv.md)
-1. [Swift](./docs/sources/swift.md)
-1. [Yarn](./docs/sources/yarn.md)
-
-You can disable any of them in the configuration file:
-
-```yml
-sources:
-  bundler: false
-  npm: false
-  bower: false
-  cabal: false
-```
-
 ## Development
 
 To get started after checking out the repo, run
+
 1. `script/bootstrap` to install dependencies
 2. `script/setup` to setup test fixtures.
   - `script/setup -f` will force a clean test fixture environment
-3. `script/cibuild` to run the tests.
+3. `script/cibuild` to run the tests
 
 You can also run `script/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
-#### Adding sources
+### Adding a new source
 
-When adding new dependency sources, ensure that `script/bootstrap` scripting and tests are only run if the required tooling is available on the development machine.
-
-* See `script/bootstrap` for examples of gating scripting based on whether tooling executables are found.
-* Use `Licensed::Shell.tool_available?` when writing test files to gate running a test suite when tooling executables aren't available.
-```ruby
-if Licensed::Shell.tool_available?('bundle')
-  describe Licensed::Source::Bundler do
-    ...
-  end
-end
-```
-
-See the [documentation on adding new sources](./docs/adding_a_new_source.md) for more information.
+See the [documentation on adding new sources](./docs/adding_a_new_source.md) for detailed information on what's required to add a new dependency source enumerator.
 
 ## Contributing
 

--- a/docs/adding_a_new_source.md
+++ b/docs/adding_a_new_source.md
@@ -4,13 +4,15 @@
 
 Dependency enumerators inherit and override the [`Licensed::Sources::Source`](../lib/licensed/sources/source.rb) class.
 
-#### Required method overrides
+### Required method overrides
+
 1. `Licensed::Sources::Source#enabled?`
    - Returns whether dependencies can be enumerated in the current environment.
 2. `Licensed::Sources::Source#enumerate_dependencies`
    - Returns an enumeration of `Licensed::Dependency` objects found which map to the dependencies of the current project.
 
-#### Optional method overrides
+### Optional method overrides
+
 1. `Licensed::Sources::Source.type`
    - Returns the name of the current dependency enumerator as it is found in a licensed configuration file.
 
@@ -22,12 +24,13 @@ whether `Licensed::Source::Sources#enumerate_dependencies` should be called on t
 Determining whether dependencies should be enumerated depends on whether all the tools or files needed to find dependencies are present.
 For example, to enumerate `npm` dependencies the `npm` CLI tool must be found with `Licensed::Shell.tool_available?` and a `package.json` file needs to exist in the licensed app's configured [`source_path`](./configuration.md#configuration-paths).
 
-#### Gating functionality when required tools are not available.
+### Gating functionality when required tools are not available.
 
 When adding new dependency sources, ensure that `script/bootstrap` scripting and tests are only run if the required tooling is available on the development machine.
 
-* See `script/bootstrap` for examples of gating scripting based on whether tooling executables are found.
-* Use `Licensed::Shell.tool_available?` when writing test files to gate running a test suite when tooling executables aren't available.
+- See `script/bootstrap` for examples of gating scripting based on whether tooling executables are found.
+- Use `Licensed::Shell.tool_available?` when writing test files to gate running a test suite when tooling executables aren't available.
+
 ```ruby
 if Licensed::Shell.tool_available?('bundle')
   describe Licensed::Source::Bundler do
@@ -47,11 +50,11 @@ Relying on external tools always has a risk that the tool could change.  It's ge
 or other implementation details as these could change over time.  CLI tools that provides the necessary information are generally preferred
 as they will more likely have requirements for backwards compatibility.
 
-#### Creating dependency objects
+### Creating dependency objects
 
 Creating a new `Licensed::Dependency` object requires name, version, and path arguments.  Dependency objects optionally accept a path to use as search root when finding licenses along with any other metadata that is useful to identify the dependency.
 
-##### `Licensed::Dependency` arguments
+#### `Licensed::Dependency` arguments
 
 1. name (required)
    - The name of the dependency. Together with the version, this should uniquely identify the dependency.
@@ -71,7 +74,7 @@ Creating a new `Licensed::Dependency` object requires name, version, and path ar
 6. errors (optional)
   - Any errors found when loading dependency information.
 
-##### Creating specialized Dependency objects
+#### Creating specialized Dependency objects
 
 `Licensed::Dependency` objects inherit from `Licensee::Projects::FsProject` and can override or extend the default `Licensee` behavior to find files for a dependency.
 

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -10,6 +10,14 @@ Run `licensed -h` to see help content for running licensed commands.
 - [status](status.md)
 - [version](verison.md)
 
+Most commands accept a `-c`/`--config` option to specify a path to a configuration file or directory. If a directory is specified, `licensed` will look in that directory for a file named (in order of preference):
+
+1. `.licensed.yml`
+2. `.licensed.yaml`
+3. `.licensed.json`
+
+If the option is not specified, the value will be set to the current directory.
+
 ## Adding a new command
 
 ### Implement new `Command` class

--- a/docs/commands/status.md
+++ b/docs/commands/status.md
@@ -34,3 +34,40 @@ The following data is reported for each dependency when the YAML or JSON report 
 - license: the dependency's SPDX license identifier
 - filename: the full path on disk to the dependency's cached metadata file, if available
 - errors: any error messages from failed status checks, if available
+
+## Status errors and resolutions
+
+### cached dependency record not found
+
+**Cause:** A dependency was found while running `licensed status` that does not have a corresponding cached metadata file
+**Resolution:** Run `licensed cache` to update the metadata cache and create the missing metadata file
+
+### cached dependency record out of date
+
+**Cause:** A dependency was found while running `licensed status` with a different version than is contained in the dependency's cached metadata file
+**Resolution:** Run `licensed cache` to update the out-of-date metadata files
+
+### missing license text
+
+**Cause:** A license file was found or a license determination was otherwise made, but the files contained no usable text
+**Resolution:** Manually verify whether the dependency includes a file containing license text.  If the dependency code that was downloaded locally does not contain the license text, please check the dependency source at the version listed in the dependency's cached metadata file to see if there is license text that can be used.
+
+If the dependency does not include license text but does specify that it uses a specific license, please copy the standard license text from a [well known source](https://opensource.org/licenses).
+
+### license text has changed and needs re-review. if the new text is ok, remove the `review_changed_license` flag from the cached record
+
+**Cause:** A dependency that is set as [reviewed] in the licensed configuration file has substantially changed and should be re-reviewed.
+**Resolution:** Review the changes to the license text and classification, along with other metadata contained in the cached file for the dependency.  If the dependency is still allowable for use in your project, remove the `review_changed_license` key from the cached record file.
+
+### license needs review
+
+**Cause:** A dependency is using a license that is not in the configured [allowed list of licenses][allowed], and the dependency has not been marked [ignored] or [reviewed].
+**Resolution:** Review the dependency's usage and specified license with someone familiar with OSS licensing and compliance rules to determine whether the dependency is allowable.  Some common resolutions:
+
+1. The dependency might need to be marked as [ignored] or [reviewed] if either of those scenarios are applicable.
+1. The dependency's specified license text differed enough from the standard license text that it was not recognized and classified as `other`.  If, with human review, the license text is recognizable then update the `license: other` value in the cached metadata file to the correct license.
+1. If the used license is allowable, ensure that the license SPDX is set as [allowed] in the licensed configuration file.
+
+[allowed]: ../configuration/allowed_licenses.md
+[ignored]: ../configuration/ignoring_dependencies.md
+[reviewed]: ../configuration/reviewing_dependencies.md

--- a/docs/commands/status.md
+++ b/docs/commands/status.md
@@ -49,7 +49,7 @@ The following data is reported for each dependency when the YAML or JSON report 
 
 ### missing license text
 
-**Cause:** A license file was found or a license determination was otherwise made, but the files contained no usable text
+**Cause:** A license determination was made, e.g. from package metadata, but no license text was found.
 **Resolution:** Manually verify whether the dependency includes a file containing license text.  If the dependency code that was downloaded locally does not contain the license text, please check the dependency source at the version listed in the dependency's cached metadata file to see if there is license text that can be used.
 
 If the dependency does not include license text but does specify that it uses a specific license, please copy the standard license text from a [well known source](https://opensource.org/licenses).
@@ -64,9 +64,9 @@ If the dependency does not include license text but does specify that it uses a 
 **Cause:** A dependency is using a license that is not in the configured [allowed list of licenses][allowed], and the dependency has not been marked [ignored] or [reviewed].
 **Resolution:** Review the dependency's usage and specified license with someone familiar with OSS licensing and compliance rules to determine whether the dependency is allowable.  Some common resolutions:
 
-1. The dependency might need to be marked as [ignored] or [reviewed] if either of those scenarios are applicable.
 1. The dependency's specified license text differed enough from the standard license text that it was not recognized and classified as `other`.  If, with human review, the license text is recognizable then update the `license: other` value in the cached metadata file to the correct license.
-1. If the used license is allowable, ensure that the license SPDX is set as [allowed] in the licensed configuration file.
+1. The dependency might need to be marked as [ignored] or [reviewed] if either of those scenarios are applicable.
+1. If the used license should be allowable without review (if your entity has a legal team, they may want to review this assessment), ensure the license SPDX is set as [allowed] in the licensed configuration file.
 
 [allowed]: ../configuration/allowed_licenses.md
 [ignored]: ../configuration/ignoring_dependencies.md


### PR DESCRIPTION
A few updates here to increase documentation coverage and make things a bit more readable.

1. Pushing content from README into linked docs.
1. Fixing some linter errors
1. Adding some content to the `status` command documentation for the errors that can be returned for dependencies and common resolutions.