### PR TITLE
Release 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## 3.2.0
+
+2021-08-19
+
+### Added
+
+- Application names can be dynamically generated based on the path to the application source  (https://github.com/github/licensed/pull/375)
+
+### Changed
+
+- Updated command documentation (https://github.com/github/licensed/pull/378, https://github.com/github/licensed/pull/380/files)
+- Updated configuration documentation (https://github.com/github/licensed/pull/375)
+- Cache and status commands give additional diagnostic output when using JSON and YAML formatters (https://github.com/github/licensed/pull/378)
+- Status command will give users a link to documentation when compliance checks fail (https://github.com/github/licensed/pull/381)
+
+### Fixed
+
+- The bundler source correctly checks that the path bundler specifies a gem is loaded from is a file (https://github.com/github/licensed/pull/379)
+
 ## 3.1.0
 
 2021-06-16

--- a/lib/licensed/version.rb
+++ b/lib/licensed/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Licensed
-  VERSION = "3.1.0".freeze
+  VERSION = "3.2.0".freeze
 
   def self.previous_major_versions
     major_version = Gem::Version.new(Licensed::VERSION).segments.first


### PR DESCRIPTION
## 3.2.0

2021-08-19

### Added

- Application names can be dynamically generated based on the path to the application source  (https://github.com/github/licensed/pull/375)

### Changed

- Updated command documentation (https://github.com/github/licensed/pull/378, https://github.com/github/licensed/pull/380/files)
- Updated configuration documentation (https://github.com/github/licensed/pull/375)
- Cache and status commands give additional diagnostic output when using JSON and YAML formatters (https://github.com/github/licensed/pull/378)
- Status command will give users a link to documentation when compliance checks fail (https://github.com/github/licensed/pull/381)

### Fixed

- The bundler source correctly checks that the path bundler specifies a gem is loaded from is a file (https://github.com/github/licensed/pull/379)