### PR TITLE
Fix the "unreleased" link in the changelog for 3.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -466,4 +466,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Initial release :tada:
 
-[Unreleased]: https://github.com/github/licensed/compare/3.1.0...HEAD
+[Unreleased]: https://github.com/github/licensed/compare/3.2.0...HEAD


### PR DESCRIPTION
I missed updating this link when updating the version and changelog for the 3.2.0 release