### PR TITLE
fix broken link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ A configuration file is required for most commands.  See the [configuration file
 
 ### Available dependency sources
 
-Licensed can enumerate dependency for many languages, package managers, and frameworks.  See the [sources documentation](./docs/sources) for the list of currently available sources.  Sources can be explicitly enabled and disabled as a [configuration option](./docs/configuration/sources.md).
+Licensed can enumerate dependency for many languages, package managers, and frameworks.  See the [sources documentation](./docs/sources) for the list of currently available sources.  Sources can be explicitly enabled and disabled as a [configuration option](./docs/configuration/dependency_source_enumerators.md.md).
 
 ### Automation
 


### PR DESCRIPTION
closes https://github.com/github/licensed/issues/386

A quick readme update to fix a broken link.  Thanks @MrCull for the report