### PR TITLE
Ensure ::Bundler.load is called before enumerating dependencies

### DIFF
--- a/lib/licensed/sources/bundler.rb
+++ b/lib/licensed/sources/bundler.rb
@@ -109,8 +109,10 @@ module Licensed
 
             # reset bundler to load from the current app's source path
             ::Bundler.reset!
-            ::Bundler.load
           end
+
+          # ensure the bundler environment is loaded before enumeration
+          ::Bundler.load
 
           yield
         end
@@ -119,8 +121,10 @@ module Licensed
           # restore bundler configuration
           ENV.replace(backup)
           ::Bundler.reset!
-          ::Bundler.load
         end
+
+        # reload the bundler environment after enumeration
+        ::Bundler.load
       end
 
       # Returns whether the current licensed execution is running ruby-packer


### PR DESCRIPTION
closes https://github.com/github/licensed/issues/396

The bug in the linked issue comes from installing licensed with `gem install` rather than being listed in a Gemfile, and not running it through `bundle exec licensed`.  In that scenario `::Bundler.load` was never called and as a result `::Bundler.configure` wasn't either.  In 3.2.0 and prior releases, this was accounted for in an equality check against `ENV["BUNDLE_GEMFILE"]` which would have been nil, triggering the configure call.

As a fix, the source now always calls `::Bundler.load` before enumerating dependencies.  The call is a no-op if the runtime is already loaded, so unless or until Bundler changes it's implementation this should be a safe change