### PR TITLE
Release 3.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## 3.2.2
+
+2021-09-09
+
+### Fixed
+
+- Bundler source works properly again when used outside of `bundle exec` (https://github.com/github/licensed/pull/397)
+
 ## 3.2.1
 
 2021-09-06
@@ -480,4 +488,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Initial release :tada:
 
-[Unreleased]: https://github.com/github/licensed/compare/3.2.1...HEAD
+[Unreleased]: https://github.com/github/licensed/compare/3.2.2...HEAD

--- a/lib/licensed/version.rb
+++ b/lib/licensed/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Licensed
-  VERSION = "3.2.1".freeze
+  VERSION = "3.2.2".freeze
 
   def self.previous_major_versions
     major_version = Gem::Version.new(Licensed::VERSION).segments.first


### PR DESCRIPTION
## 3.2.2

2021-09-09

### Fixed

- Bundler source works properly again when used outside of `bundle exec` (https://github.com/github/licensed/pull/397)