### PR TITLE
ci(workflow): run core first

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on: pull_request
 jobs:
   bower:
     runs-on: ubuntu-latest
+    needs: core
     steps:
     - uses: actions/checkout@v2
     - name: Setup node
@@ -34,6 +35,7 @@ jobs:
 
   bundler:
     runs-on: ubuntu-latest
+    needs: core
     strategy:
       matrix:
         bundler: [ '~> 1.17.0', '~> 2.0.0', '~> 2.1.0', '~> 2.2.0' ]
@@ -64,6 +66,7 @@ jobs:
 
   cabal:
     runs-on: ubuntu-latest
+    needs: core
     strategy:
       matrix:
         ghc: [ '8.6', '8.8', '8.10', '9.0' ]
@@ -105,6 +108,7 @@ jobs:
 
   composer:
     runs-on: ubuntu-latest
+    needs: core
     strategy:
       matrix:
         php: [ '7.4', '8.0' ]
@@ -163,6 +167,7 @@ jobs:
 
   dep:
     runs-on: ubuntu-latest
+    needs: core
     steps:
     - uses: actions/checkout@v2
     - name: Setup go
@@ -190,6 +195,7 @@ jobs:
 
   go:
     runs-on: ubuntu-latest
+    needs: core
     strategy:
       matrix:
         go: [ '1.12.x', '1.13.x', '1.14.x', '1.15.x', '1.16.x' ]
@@ -231,6 +237,7 @@ jobs:
 
   gradle:
     runs-on: ubuntu-latest
+    needs: core
     strategy:
       matrix:
         # TODO: the reporting plugin used to gather data is not yet fully compatible with
@@ -275,6 +282,7 @@ jobs:
 
   manifest:
     runs-on: ubuntu-latest
+    needs: core
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
@@ -296,6 +304,7 @@ jobs:
 
   mix:
     runs-on: ubuntu-latest
+    needs: core
     strategy:
       matrix:
         otp: [22.x, 23.x, 24.x]
@@ -327,6 +336,7 @@ jobs:
 
   npm:
     runs-on: ubuntu-latest
+    needs: core
     strategy:
       matrix:
         node_version: [ 12, 14, 16 ]
@@ -357,6 +367,7 @@ jobs:
 
   nuget:
     runs-on: ubuntu-latest
+    needs: core
     strategy:
       matrix:
         dotnet: [ '3.1.x', '5.x' ]
@@ -387,6 +398,7 @@ jobs:
 
   pip:
     runs-on: ubuntu-latest
+    needs: core
     strategy:
       matrix:
         python: [ '3.6', '3.7', '3.8', '3.9' ]
@@ -427,6 +439,7 @@ jobs:
 
   pipenv:
     runs-on: ubuntu-latest
+    needs: core
     steps:
     - uses: actions/checkout@v2
     - name: Setup python
@@ -457,6 +470,7 @@ jobs:
 
   swift:
     runs-on: ubuntu-latest
+    needs: core
     strategy:
       matrix:
         swift: [ "5.4", "5.3" ]
@@ -494,6 +508,7 @@ jobs:
 
   yarn:
     runs-on: ubuntu-latest
+    needs: core
     strategy:
       matrix:
         # not using 1.0.0 because it doesn't support `yarn list --production`


### PR DESCRIPTION
Run core first to benefits from it's cache in case of success or fail fast in case of failure on the core