### PR TITLE
Do not delete skipped sources' cache

### DIFF
--- a/lib/licensed/commands/cache.rb
+++ b/lib/licensed/commands/cache.rb
@@ -39,11 +39,13 @@ module Licensed
       #
       # Returns whether the command succeeded for the dependency source enumerator
       def run_source(app, source, report)
+        result = super
+
         # add the full cache path to the list of cache paths
         # that should be cleaned up after the command run
-        cache_paths << app.cache_path.join(source.class.type)
+        cache_paths << app.cache_path.join(source.class.type) unless result == :skipped
 
-        super
+        result
       end
 
       # Cache dependency record data.

--- a/lib/licensed/commands/command.rb
+++ b/lib/licensed/commands/command.rb
@@ -121,13 +121,16 @@ module Licensed
       # source - A dependency source enumerator
       # report - A report object for this source
       #
-      # Returns whether the command succeeded for the dependency source enumerator
+      # Returns whether the command succeeded, failed, or was skipped for the dependency source enumerator
       def run_source(app, source, report)
         reporter.begin_report_source(source, report)
 
         if !sources_overrides.empty? && !sources_overrides.include?(source.class.type)
           report.warnings << "skipped source"
-          return true
+
+          # return a symbol to speficy the source was skipped.
+          # This is truthy and will result in the source being considered successful
+          return :skipped
         end
 
         dependencies = source.dependencies.sort_by { |dependency| dependency.name }

--- a/test/commands/cache_test.rb
+++ b/test/commands/cache_test.rb
@@ -99,6 +99,19 @@ describe Licensed::Commands::Cache do
     end
   end
 
+  it "does not clean up dependencies from skipped sources" do
+    config.apps.each do |app|
+      FileUtils.mkdir_p app.cache_path.join("test")
+      File.write app.cache_path.join("test/dependency.#{Licensed::DependencyRecord::EXTENSION}"), ""
+    end
+
+    run_command(sources: ["other"])
+
+    config.apps.each do |app|
+      assert app.cache_path.join("test/dependency.#{Licensed::DependencyRecord::EXTENSION}").exist?
+    end
+  end
+
   it "uses cached record if license text does not change" do
     run_command
 


### PR DESCRIPTION
In a recent refactor I introduced a bug where setting `licensed cache --source <source>` would unintentionally delete the cached files from all other sources 🤦 .

The underlying issue came from moving the check on whether a source was skipped into the base command class.  When the check was moved there was no longer any indication that the cache path shouldn't be cleaned for unused dependencies, and because no dependencies from the source were evaluated they are all determined to be unused.

This change has the base command implementation return a symbol `:skipped` instead of true, so that sources extending the default behavior are aware of this case.  The symbol is truthy and will result in the source evaluation being considered a success