### PR TITLE
Prepend overwrite of materialize to handle missing bundler specs

### DIFF
--- a/lib/licensed/sources/bundler/missing_specification.rb
+++ b/lib/licensed/sources/bundler/missing_specification.rb
@@ -38,17 +38,20 @@ module Licensed
         "could not find #{name} (#{version}) in any sources"
       end
     end
+
+    module LazySpecification
+      def __materialize__
+        spec = super
+        return spec if spec
+
+        Licensed::Bundler::MissingSpecification.new(name: name, version: version, platform: platform, source: source)
+      end
+    end
   end
 end
 
 module Bundler
   class LazySpecification
-    alias_method :orig_materialize, :__materialize__
-    def __materialize__
-      spec = orig_materialize
-      return spec if spec
-
-      Licensed::Bundler::MissingSpecification.new(name: name, version: version, platform: platform, source: source)
-    end
+    prepend ::Licensed::Bundler::LazySpecification
   end
 end


### PR DESCRIPTION
This was found in an edge case where a separate override to `__materialize__` was being used. The combination of the override and the alias/overwrite that exists before this change led to infinite recursion and a stacktoodeep error.

Having the logic fully overwrite the base method using `prepend`, and using `super` to call into the original behavior fixes this scenario.