### PR TITLE
Don't include miscellaneous files in released gem

### DIFF
--- a/licensed.gemspec
+++ b/licensed.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/github/licensed"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test/|script/|docker/|\..+)}) }
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]


### PR DESCRIPTION
This change removes miscellaneous dotfiles, scripts, and docker files that aren't needed at runtime.  It shouldn't change gem size much, but limits the amount of "extra" that anyone would need to look through if or when debugging licensed failures.