### PR TITLE
Add license caching action workflow

### DIFF
--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -27,7 +27,7 @@ jobs:
       # set up tooling
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.x
+          ruby-version: 2.7
       - uses: actions/cache@v2
         name: cache gem dependencies
         with:

--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -1,0 +1,65 @@
+name: Verify cached license metadata
+
+on:
+  # run on pushes to the default branch
+  push:
+    branches:
+      - master
+  # run on all pull request events
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+  # run on demand
+  workflow_dispatch:
+
+jobs:
+  licensed:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      # checkout the repo
+      - uses: actions/checkout@v2
+
+      # set up tooling
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7.x
+      - uses: actions/cache@v2
+        name: cache gem dependencies
+        with:
+          path: vendor/gems
+          key: ${{ runner.os }}-gem-2.6-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gem-2.6-
+      - name: Bootstrap
+        run: script/bootstrap
+
+      # run licensed
+      - uses: jonabc/licensed-ci@v1
+        with:
+          # override the command to use licensed built from this repo
+          command: bundle exec licensed
+          
+          # changes made using GITHUB_TOKEN will not re-trigger this action.
+          # set a custom token so that added or changed cached license files
+          # will cause this workflow to run and validate cached contents
+          #
+          # see https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
+          # for additional details on GITHUB_TOKEN not re-triggering this action
+          github_token: ${{ secrets.LICENSED_CI_TOKEN }}
+          
+          # the "push" workflow updates license metadata files on the branch being examined.
+          # e.g. when the action is run on main, changes are pushed to main
+
+          # the "branch" workflow creates a new branch for license file updates.
+          # e.g. when the action is run on main, changes are pushed to a new "main-licenses" branch
+
+          # see https://github.com/jonabc/licensed-ci for more details
+          workflow: branch
+        env:
+          GOPRIVATE: "*github.com/github/*"
+          GOPROXY: "direct"

--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,7 @@ test/fixtures/cargo/*
 !test/fixtures/cargo/src
 
 vendor/licenses
-.licenses
+.licenses_test
 *.gem
 vendor/gems
 .byebug_history

--- a/.licensed.test.yml
+++ b/.licensed.test.yml
@@ -1,0 +1,10 @@
+sources:
+  bundler: true
+
+allowed:
+  - mit
+  - apache-2.0
+
+reviewed:
+  bundler:
+    - pathname-common_prefix

--- a/.licensed.yml
+++ b/.licensed.yml
@@ -1,3 +1,6 @@
+sources:
+  bundler: true
+
 allowed:
   - mit
   - apache-2.0

--- a/.licensed.yml
+++ b/.licensed.yml
@@ -8,3 +8,6 @@ allowed:
 reviewed:
   bundler:
     - pathname-common_prefix
+    - racc
+    - reverse_markdown
+    - ruby2_keywords

--- a/.licenses/bundler/addressable.dep.yml
+++ b/.licenses/bundler/addressable.dep.yml
@@ -1,0 +1,213 @@
+---
+name: addressable
+version: 2.8.0
+type: bundler
+summary: URI Implementation
+homepage: https://github.com/sporkmonger/addressable
+license: apache-2.0
+licenses:
+- sources: LICENSE.txt
+  text: |2
+
+                                  Apache License
+                            Version 2.0, January 2004
+                         http://www.apache.org/licenses/
+
+    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+    1. Definitions.
+
+       "License" shall mean the terms and conditions for use, reproduction,
+       and distribution as defined by Sections 1 through 9 of this document.
+
+       "Licensor" shall mean the copyright owner or entity authorized by
+       the copyright owner that is granting the License.
+
+       "Legal Entity" shall mean the union of the acting entity and all
+       other entities that control, are controlled by, or are under common
+       control with that entity. For the purposes of this definition,
+       "control" means (i) the power, direct or indirect, to cause the
+       direction or management of such entity, whether by contract or
+       otherwise, or (ii) ownership of fifty percent (50%) or more of the
+       outstanding shares, or (iii) beneficial ownership of such entity.
+
+       "You" (or "Your") shall mean an individual or Legal Entity
+       exercising permissions granted by this License.
+
+       "Source" form shall mean the preferred form for making modifications,
+       including but not limited to software source code, documentation
+       source, and configuration files.
+
+       "Object" form shall mean any form resulting from mechanical
+       transformation or translation of a Source form, including but
+       not limited to compiled object code, generated documentation,
+       and conversions to other media types.
+
+       "Work" shall mean the work of authorship, whether in Source or
+       Object form, made available under the License, as indicated by a
+       copyright notice that is included in or attached to the work
+       (an example is provided in the Appendix below).
+
+       "Derivative Works" shall mean any work, whether in Source or Object
+       form, that is based on (or derived from) the Work and for which the
+       editorial revisions, annotations, elaborations, or other modifications
+       represent, as a whole, an original work of authorship. For the purposes
+       of this License, Derivative Works shall not include works that remain
+       separable from, or merely link (or bind by name) to the interfaces of,
+       the Work and Derivative Works thereof.
+
+       "Contribution" shall mean any work of authorship, including
+       the original version of the Work and any modifications or additions
+       to that Work or Derivative Works thereof, that is intentionally
+       submitted to Licensor for inclusion in the Work by the copyright owner
+       or by an individual or Legal Entity authorized to submit on behalf of
+       the copyright owner. For the purposes of this definition, "submitted"
+       means any form of electronic, verbal, or written communication sent
+       to the Licensor or its representatives, including but not limited to
+       communication on electronic mailing lists, source code control systems,
+       and issue tracking systems that are managed by, or on behalf of, the
+       Licensor for the purpose of discussing and improving the Work, but
+       excluding communication that is conspicuously marked or otherwise
+       designated in writing by the copyright owner as "Not a Contribution."
+
+       "Contributor" shall mean Licensor and any individual or Legal Entity
+       on behalf of whom a Contribution has been received by Licensor and
+       subsequently incorporated within the Work.
+
+    2. Grant of Copyright License. Subject to the terms and conditions of
+       this License, each Contributor hereby grants to You a perpetual,
+       worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+       copyright license to reproduce, prepare Derivative Works of,
+       publicly display, publicly perform, sublicense, and distribute the
+       Work and such Derivative Works in Source or Object form.
+
+    3. Grant of Patent License. Subject to the terms and conditions of
+       this License, each Contributor hereby grants to You a perpetual,
+       worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+       (except as stated in this section) patent license to make, have made,
+       use, offer to sell, sell, import, and otherwise transfer the Work,
+       where such license applies only to those patent claims licensable
+       by such Contributor that are necessarily infringed by their
+       Contribution(s) alone or by combination of their Contribution(s)
+       with the Work to which such Contribution(s) was submitted. If You
+       institute patent litigation against any entity (including a
+       cross-claim or counterclaim in a lawsuit) alleging that the Work
+       or a Contribution incorporated within the Work constitutes direct
+       or contributory patent infringement, then any patent licenses
+       granted to You under this License for that Work shall terminate
+       as of the date such litigation is filed.
+
+    4. Redistribution. You may reproduce and distribute copies of the
+       Work or Derivative Works thereof in any medium, with or without
+       modifications, and in Source or Object form, provided that You
+       meet the following conditions:
+
+       (a) You must give any other recipients of the Work or
+           Derivative Works a copy of this License; and
+
+       (b) You must cause any modified files to carry prominent notices
+           stating that You changed the files; and
+
+       (c) You must retain, in the Source form of any Derivative Works
+           that You distribute, all copyright, patent, trademark, and
+           attribution notices from the Source form of the Work,
+           excluding those notices that do not pertain to any part of
+           the Derivative Works; and
+
+       (d) If the Work includes a "NOTICE" text file as part of its
+           distribution, then any Derivative Works that You distribute must
+           include a readable copy of the attribution notices contained
+           within such NOTICE file, excluding those notices that do not
+           pertain to any part of the Derivative Works, in at least one
+           of the following places: within a NOTICE text file distributed
+           as part of the Derivative Works; within the Source form or
+           documentation, if provided along with the Derivative Works; or,
+           within a display generated by the Derivative Works, if and
+           wherever such third-party notices normally appear. The contents
+           of the NOTICE file are for informational purposes only and
+           do not modify the License. You may add Your own attribution
+           notices within Derivative Works that You distribute, alongside
+           or as an addendum to the NOTICE text from the Work, provided
+           that such additional attribution notices cannot be construed
+           as modifying the License.
+
+       You may add Your own copyright statement to Your modifications and
+       may provide additional or different license terms and conditions
+       for use, reproduction, or distribution of Your modifications, or
+       for any such Derivative Works as a whole, provided Your use,
+       reproduction, and distribution of the Work otherwise complies with
+       the conditions stated in this License.
+
+    5. Submission of Contributions. Unless You explicitly state otherwise,
+       any Contribution intentionally submitted for inclusion in the Work
+       by You to the Licensor shall be under the terms and conditions of
+       this License, without any additional terms or conditions.
+       Notwithstanding the above, nothing herein shall supersede or modify
+       the terms of any separate license agreement you may have executed
+       with Licensor regarding such Contributions.
+
+    6. Trademarks. This License does not grant permission to use the trade
+       names, trademarks, service marks, or product names of the Licensor,
+       except as required for reasonable and customary use in describing the
+       origin of the Work and reproducing the content of the NOTICE file.
+
+    7. Disclaimer of Warranty. Unless required by applicable law or
+       agreed to in writing, Licensor provides the Work (and each
+       Contributor provides its Contributions) on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+       implied, including, without limitation, any warranties or conditions
+       of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+       PARTICULAR PURPOSE. You are solely responsible for determining the
+       appropriateness of using or redistributing the Work and assume any
+       risks associated with Your exercise of permissions under this License.
+
+    8. Limitation of Liability. In no event and under no legal theory,
+       whether in tort (including negligence), contract, or otherwise,
+       unless required by applicable law (such as deliberate and grossly
+       negligent acts) or agreed to in writing, shall any Contributor be
+       liable to You for damages, including any direct, indirect, special,
+       incidental, or consequential damages of any character arising as a
+       result of this License or out of the use or inability to use the
+       Work (including but not limited to damages for loss of goodwill,
+       work stoppage, computer failure or malfunction, or any and all
+       other commercial damages or losses), even if such Contributor
+       has been advised of the possibility of such damages.
+
+    9. Accepting Warranty or Additional Liability. While redistributing
+       the Work or Derivative Works thereof, You may choose to offer,
+       and charge a fee for, acceptance of support, warranty, indemnity,
+       or other liability obligations and/or rights consistent with this
+       License. However, in accepting such obligations, You may act only
+       on Your own behalf and on Your sole responsibility, not on behalf
+       of any other Contributor, and only if You agree to indemnify,
+       defend, and hold each Contributor harmless for any liability
+       incurred by, or claims asserted against, such Contributor by reason
+       of your accepting any such warranty or additional liability.
+
+    END OF TERMS AND CONDITIONS
+
+    APPENDIX: How to apply the Apache License to your work.
+
+       To apply the Apache License to your work, attach the following
+       boilerplate notice, with the fields enclosed by brackets "[]"
+       replaced with your own identifying information. (Don't include
+       the brackets!)  The text should be enclosed in the appropriate
+       comment syntax for the file format. We also recommend that a
+       file or class name and description of purpose be included on the
+       same "printed page" as the copyright notice for easier
+       identification within third-party archives.
+
+    Copyright [yyyy] [name of copyright owner]
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+notices: []

--- a/.licenses/bundler/bundler.dep.yml
+++ b/.licenses/bundler/bundler.dep.yml
@@ -1,0 +1,35 @@
+---
+name: bundler
+version: 2.2.32
+type: bundler
+summary: The best way to manage your application's dependencies
+homepage: https://bundler.io
+license: mit
+licenses:
+- sources: LICENSE.md
+  text: |
+    The MIT License
+
+    Portions copyright (c) 2010-2019 André Arko
+    Portions copyright (c) 2009 Engine Yard
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+- sources: README.md
+  text: Bundler is available under an [MIT License](https://github.com/rubygems/rubygems/blob/master/bundler/LICENSE.md).
+notices: []

--- a/.licenses/bundler/dotenv.dep.yml
+++ b/.licenses/bundler/dotenv.dep.yml
@@ -1,0 +1,33 @@
+---
+name: dotenv
+version: 2.7.6
+type: bundler
+summary: Loads environment variables from `.env`.
+homepage: https://github.com/bkeepers/dotenv
+license: mit
+licenses:
+- sources: LICENSE
+  text: |-
+    Copyright (c) 2012 Brandon Keepers
+
+    MIT License
+
+    Permission is hereby granted, free of charge, to any person obtaining
+    a copy of this software and associated documentation files (the
+    "Software"), to deal in the Software without restriction, including
+    without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to
+    permit persons to whom the Software is furnished to do so, subject to
+    the following conditions:
+
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+    LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+    OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+    WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+notices: []

--- a/.licenses/bundler/faraday-em_http.dep.yml
+++ b/.licenses/bundler/faraday-em_http.dep.yml
@@ -1,0 +1,34 @@
+---
+name: faraday-em_http
+version: 1.0.0
+type: bundler
+summary: Faraday adapter for Em::Http
+homepage: https://github.com/lostisland/faraday-em_http
+license: mit
+licenses:
+- sources: LICENSE.md
+  text: |
+    The MIT License (MIT)
+
+    Copyright (c) 2020 Jan van der Pas
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+- sources: README.md
+  text: The gem is available as open source under the terms of the [license][license].
+notices: []

--- a/.licenses/bundler/faraday-em_synchrony.dep.yml
+++ b/.licenses/bundler/faraday-em_synchrony.dep.yml
@@ -1,0 +1,34 @@
+---
+name: faraday-em_synchrony
+version: 1.0.0
+type: bundler
+summary: Faraday adapter for EM::Synchrony
+homepage: https://github.com/lostisland/faraday-em_synchrony
+license: mit
+licenses:
+- sources: LICENSE.md
+  text: |
+    The MIT License (MIT)
+
+    Copyright (c) 2020 Jan van der Pas
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+- sources: README.md
+  text: The gem is available as open source under the terms of the [license][license].
+notices: []

--- a/.licenses/bundler/faraday-excon.dep.yml
+++ b/.licenses/bundler/faraday-excon.dep.yml
@@ -1,0 +1,34 @@
+---
+name: faraday-excon
+version: 1.1.0
+type: bundler
+summary: Faraday adapter for Excon
+homepage: https://github.com/lostisland/faraday-excon
+license: mit
+licenses:
+- sources: LICENSE.md
+  text: |
+    The MIT License (MIT)
+
+    Copyright (c) 2020 Jan van der Pas
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+- sources: README.md
+  text: The gem is available as open source under the terms of the [license][license].
+notices: []

--- a/.licenses/bundler/faraday-httpclient.dep.yml
+++ b/.licenses/bundler/faraday-httpclient.dep.yml
@@ -1,0 +1,34 @@
+---
+name: faraday-httpclient
+version: 1.0.1
+type: bundler
+summary: Faraday adapter for HTTPClient
+homepage: https://github.com/lostisland/faraday-httpclient
+license: mit
+licenses:
+- sources: LICENSE.md
+  text: |
+    The MIT License (MIT)
+
+    Copyright (c) 2020 Jan van der Pas
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+- sources: README.md
+  text: The gem is available as open source under the terms of the [license][license].
+notices: []

--- a/.licenses/bundler/faraday-net_http.dep.yml
+++ b/.licenses/bundler/faraday-net_http.dep.yml
@@ -1,0 +1,34 @@
+---
+name: faraday-net_http
+version: 1.0.1
+type: bundler
+summary: Faraday adapter for Net::HTTP
+homepage: https://github.com/lostisland/faraday-net_http
+license: mit
+licenses:
+- sources: LICENSE.md
+  text: |
+    The MIT License (MIT)
+
+    Copyright (c) 2020 Jan van der Pas
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+- sources: README.md
+  text: The gem is available as open source under the terms of the [license][license].
+notices: []

--- a/.licenses/bundler/faraday-net_http_persistent.dep.yml
+++ b/.licenses/bundler/faraday-net_http_persistent.dep.yml
@@ -1,0 +1,34 @@
+---
+name: faraday-net_http_persistent
+version: 1.2.0
+type: bundler
+summary: Faraday adapter for NetHttpPersistent
+homepage: https://github.com/lostisland/faraday-net_http_persistent
+license: mit
+licenses:
+- sources: LICENSE.md
+  text: |
+    The MIT License (MIT)
+
+    Copyright (c) 2020 Jan van der Pas
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+- sources: README.md
+  text: The gem is available as open source under the terms of the [MIT License][mit-license].
+notices: []

--- a/.licenses/bundler/faraday-patron.dep.yml
+++ b/.licenses/bundler/faraday-patron.dep.yml
@@ -1,0 +1,34 @@
+---
+name: faraday-patron
+version: 1.0.0
+type: bundler
+summary: Faraday adapter for Patron
+homepage: https://github.com/lostisland/faraday-patron
+license: mit
+licenses:
+- sources: LICENSE.md
+  text: |
+    The MIT License (MIT)
+
+    Copyright (c) 2020 Jan van der Pas
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+- sources: README.md
+  text: The gem is available as open source under the terms of the [license][license].
+notices: []

--- a/.licenses/bundler/faraday-rack.dep.yml
+++ b/.licenses/bundler/faraday-rack.dep.yml
@@ -1,0 +1,34 @@
+---
+name: faraday-rack
+version: 1.0.0
+type: bundler
+summary: Faraday adapter for Rack
+homepage: https://github.com/lostisland/faraday-rack
+license: mit
+licenses:
+- sources: LICENSE.md
+  text: |
+    The MIT License (MIT)
+
+    Copyright (c) 2020 Jan van der Pas
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+- sources: README.md
+  text: The gem is available as open source under the terms of the [license][license].
+notices: []

--- a/.licenses/bundler/faraday.dep.yml
+++ b/.licenses/bundler/faraday.dep.yml
@@ -1,0 +1,31 @@
+---
+name: faraday
+version: 1.8.0
+type: bundler
+summary: HTTP/REST API client library.
+homepage: https://lostisland.github.io/faraday
+license: mit
+licenses:
+- sources: LICENSE.md
+  text: |
+    Copyright (c) 2009-2020 Rick Olson, Zack Hobson
+
+    Permission is hereby granted, free of charge, to any person obtaining
+    a copy of this software and associated documentation files (the
+    "Software"), to deal in the Software without restriction, including
+    without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to
+    permit persons to whom the Software is furnished to do so, subject to
+    the following conditions:
+
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+    LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+    OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+    WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+notices: []

--- a/.licenses/bundler/licensee.dep.yml
+++ b/.licenses/bundler/licensee.dep.yml
@@ -1,0 +1,32 @@
+---
+name: licensee
+version: 9.15.1
+type: bundler
+summary: A Ruby Gem to detect open source project licenses
+homepage: https://github.com/benbalter/licensee
+license: mit
+licenses:
+- sources: LICENSE.md
+  text: |
+    MIT License
+
+    Copyright (c) 2014-2021 Ben Balter and Licensee contributors
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+notices: []

--- a/.licenses/bundler/multipart-post.dep.yml
+++ b/.licenses/bundler/multipart-post.dep.yml
@@ -1,0 +1,48 @@
+---
+name: multipart-post
+version: 2.1.1
+type: bundler
+summary: A multipart form post accessory for Net::HTTP.
+homepage: https://github.com/nicksieger/multipart-post
+license: mit
+licenses:
+- sources: LICENSE
+  text: |
+    Copyright (c) 2007-2013 Nick Sieger nick@nicksieger.com
+    Copyright, 2017, by Samuel G. D. Williams.
+
+    MIT license.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of
+    this software and associated documentation files (the "Software"), to deal in
+    the Software without restriction, including without limitation the rights to
+    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+    the Software, and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+- sources: README.md
+  text: "Released under the MIT license.\n\nCopyright (c) 2007-2013 Nick Sieger <nick@nicksieger.com>
+    \ \nCopyright, 2017, by [Samuel G. D. Williams](http://www.codeotaku.com/samuel-williams).\n\nPermission
+    is hereby granted, free of charge, to any person obtaining a copy\nof this software
+    and associated documentation files (the \"Software\"), to deal\nin the Software
+    without restriction, including without limitation the rights\nto use, copy, modify,
+    merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and
+    to permit persons to whom the Software is\nfurnished to do so, subject to the
+    following conditions:\n\nThe above copyright notice and this permission notice
+    shall be included in\nall copies or substantial portions of the Software.\n\nTHE
+    SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED,
+    INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A
+    PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT
+    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION
+    OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE
+    SOFTWARE OR THE USE OR OTHER DEALINGS IN\nTHE SOFTWARE."
+notices: []

--- a/.licenses/bundler/nokogiri.dep.yml
+++ b/.licenses/bundler/nokogiri.dep.yml
@@ -1,0 +1,1325 @@
+---
+name: nokogiri
+version: 1.12.5
+type: bundler
+summary: Nokogiri (鋸) makes it easy and painless to work with XML and HTML from Ruby.
+homepage: https://nokogiri.org
+license: other
+licenses:
+- sources: LICENSE.md
+  text: |
+    The MIT License
+
+    Copyright 2008 -- 2021 by Mike Dalessio, Aaron Patterson, Yoko Harada, Akinori MUSHA, John Shahid, Karol Bucek, Sam Ruby, Craig Barnes, Stephen Checkoway, Lars Kanis, Sergio Arbeo, Timothy Elliott, Nobuyoshi Nakada, Charles Nutter, Patrick Mahoney.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+- sources: LICENSE-DEPENDENCIES.md
+  text: "# Vendored Dependency Licenses\n\nNokogiri ships with some third party dependencies,
+    which are listed here along with their licenses.\n\nNote that this document is
+    broken into multiple sections, each of which describes the dependencies of a different
+    \"platform release\" of Nokogiri.\n\n<!-- regenerate TOC with `markdown-toc -i`
+    -->\n\n<!-- toc -->\n\n- [Platform Releases](#platform-releases)\n  * [Default
+    platform release (\"ruby\")](#default-platform-release-ruby)\n  * [Native LinuxⓇ
+    platform releases (\"x86_64-linux\" and \"arm64-linux\")](#native-linux%E2%93%A1-platform-releases-x86_64-linux-and-arm64-linux)\n
+    \ * [Native Darwin (macOSⓇ) platform releases (\"x86_64-darwin\" and \"arm64-darwin\")](#native-darwin-macos%E2%93%A1-platform-releases-x86_64-darwin-and-arm64-darwin)\n
+    \ * [Native WindowsⓇ platform releases (\"x86-mingw32\" and \"x64-mingw32\")](#native-windows%E2%93%A1-platform-releases-x86-mingw32-and-x64-mingw32)\n
+    \ * [JavaⓇ (JRuby) platform release (\"java\")](#java%E2%93%A1-jruby-platform-release-java)\n-
+    [Appendix: Dependencies' License Texts](#appendix-dependencies-license-texts)\n
+    \ * [libgumbo and nokogumbo](#libgumbo-and-nokogumbo)\n  * [libxml2](#libxml2)\n
+    \ * [libxslt](#libxslt)\n  * [zlib](#zlib)\n  * [libiconv](#libiconv)\n  * [isorelax](#isorelax)\n
+    \ * [jing](#jing)\n  * [nekodtd](#nekodtd)\n  * [nekohtml](#nekohtml)\n  * [xalan](#xalan)\n
+    \ * [xerces](#xerces)\n  * [xml-apis](#xml-apis)\n\n<!-- tocstop -->\n\nAnyone
+    consuming this file via license-tracking software should endeavor to understand
+    which gem file you're downloading and using, so as not to misinterpret the contents
+    of this file and the licenses of the software being distributed.\n\nYou can double-check
+    the dependencies in your gem file by examining the output of `nokogiri -v` after
+    installation, which will emit the complete set of libraries in use (for versions
+    `>= 1.11.0.rc4`).\n\nIn particular, I'm sure somebody's lawyer, somewhere, is
+    going to freak out that the LGPL appears in this file; and so I'd like to take
+    special note that the dependency covered by LGPL, `libiconv`, is only being redistributed
+    in the native Windows and native Darwin platform releases. It's not present in
+    default, JavaⓇ, or native LinuxⓇ releases.\n\n\n## Platform Releases\n\n### Default
+    platform release (\"ruby\")\n\nThe default platform release distributes the following
+    dependencies in source form:\n\n- [libxml2](#libxml2)\n- [libxslt](#libxslt)\n-
+    [libgumbo and nokogumbo](#libgumbo-and-nokogumbo)\n\nThis distribution can be
+    identified by inspecting the included Gem::Specification, which will have the
+    value \"ruby\" for its \"platform\" attribute.\n\n\n### Native LinuxⓇ platform
+    releases (\"x86_64-linux\" and \"arm64-linux\")\n\nThe native LinuxⓇ platform
+    release distributes the following dependencies in source form:\n\n- [libxml2](#libxml2)\n-
+    [libxslt](#libxslt)\n- [libgumbo and nokogumbo](#libgumbo-and-nokogumbo)\n- [zlib](#zlib)\n\nThis
+    distribution can be identified by inspecting the included Gem::Specification,
+    which will have a value similar to \"x86_64-linux\" or \"x86-linux\" for its \"platform.cpu\"
+    attribute.\n\n\n### Native Darwin (macOSⓇ) platform releases (\"x86_64-darwin\"
+    and \"arm64-darwin\")\n\nThe native Darwin platform release distributes the following
+    dependencies in source form:\n\n- [libxml2](#libxml2)\n- [libxslt](#libxslt)\n-
+    [libgumbo and nokogumbo](#libgumbo-and-nokogumbo)\n- [zlib](#zlib)\n- [libiconv](#libiconv)\n\nThis
+    distribution can be identified by inspecting the included Gem::Specification,
+    which will have a value similar to \"x86_64-darwin\" or \"arm64-darwin\" for its
+    \"platform.cpu\" attribute. Darwin is also known more familiarly as \"OSX\" or
+    \"macOSⓇ\" and is the operating system for many AppleⓇ computers.\n\n\n### Native
+    WindowsⓇ platform releases (\"x86-mingw32\" and \"x64-mingw32\")\n\nThe native
+    WindowsⓇ platform release distributes the following dependencies in source form:\n\n-
+    [libxml2](#libxml2)\n- [libxslt](#libxslt)\n- [libgumbo and nokogumbo](#libgumbo-and-nokogumbo)\n-
+    [zlib](#zlib)\n- [libiconv](#libiconv)\n\nThis distribution can be identified
+    by inspecting the included Gem::Specification, which will have a value similar
+    to \"x64-mingw32\" or \"x86-mingw32\" for its \"platform.cpu\" attribute.\n\n\n###
+    JavaⓇ (JRuby) platform release (\"java\")\n\nThe Java platform release distributes
+    the following dependencies as compiled jar files:\n\n- [isorelax](#isorelax)\n-
+    [jing](#jing)\n- [nekodtd](#nekodtd)\n- [nekohtml](#nekohtml)\n- [xalan](#xalan)\n-
+    [xerces](#xerces)\n- [xml-apis](#xml-apis)\n\nThis distribution can be identified
+    by inspecting the included Gem::Specification, which will have the value \"java\"
+    for its \"platform.os\" attribute.\n\n\n## Appendix: Dependencies' License Texts\n\nThis
+    section contains a subsection for each potentially-distributed dependency, which
+    includes the name of the license and the license text.\n\nPlease see previous
+    sections to understand which of these potential dependencies is actually distributed
+    in the gem file you're downloading and using.\n\n\n### libgumbo and nokogumbo\n\nApache
+    2.0\n\nhttps://github.com/rubys/nokogumbo/blob/f6a7412/LICENSE.txt\n\n\n                                     Apache
+    License\n                               Version 2.0, January 2004\n                            http://www.apache.org/licenses/\n
+    \   \n       TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n    \n
+    \      1. Definitions.\n    \n          \"License\" shall mean the terms and conditions
+    for use, reproduction,\n          and distribution as defined by Sections 1 through
+    9 of this document.\n    \n          \"Licensor\" shall mean the copyright owner
+    or entity authorized by\n          the copyright owner that is granting the License.\n
+    \   \n          \"Legal Entity\" shall mean the union of the acting entity and
+    all\n          other entities that control, are controlled by, or are under common\n
+    \         control with that entity. For the purposes of this definition,\n          \"control\"
+    means (i) the power, direct or indirect, to cause the\n          direction or
+    management of such entity, whether by contract or\n          otherwise, or (ii)
+    ownership of fifty percent (50%) or more of the\n          outstanding shares,
+    or (iii) beneficial ownership of such entity.\n    \n          \"You\" (or \"Your\")
+    shall mean an individual or Legal Entity\n          exercising permissions granted
+    by this License.\n    \n          \"Source\" form shall mean the preferred form
+    for making modifications,\n          including but not limited to software source
+    code, documentation\n          source, and configuration files.\n    \n          \"Object\"
+    form shall mean any form resulting from mechanical\n          transformation or
+    translation of a Source form, including but\n          not limited to compiled
+    object code, generated documentation,\n          and conversions to other media
+    types.\n    \n          \"Work\" shall mean the work of authorship, whether in
+    Source or\n          Object form, made available under the License, as indicated
+    by a\n          copyright notice that is included in or attached to the work\n
+    \         (an example is provided in the Appendix below).\n    \n          \"Derivative
+    Works\" shall mean any work, whether in Source or Object\n          form, that
+    is based on (or derived from) the Work and for which the\n          editorial
+    revisions, annotations, elaborations, or other modifications\n          represent,
+    as a whole, an original work of authorship. For the purposes\n          of this
+    License, Derivative Works shall not include works that remain\n          separable
+    from, or merely link (or bind by name) to the interfaces of,\n          the Work
+    and Derivative Works thereof.\n    \n          \"Contribution\" shall mean any
+    work of authorship, including\n          the original version of the Work and
+    any modifications or additions\n          to that Work or Derivative Works thereof,
+    that is intentionally\n          submitted to Licensor for inclusion in the Work
+    by the copyright owner\n          or by an individual or Legal Entity authorized
+    to submit on behalf of\n          the copyright owner. For the purposes of this
+    definition, \"submitted\"\n          means any form of electronic, verbal, or
+    written communication sent\n          to the Licensor or its representatives,
+    including but not limited to\n          communication on electronic mailing lists,
+    source code control systems,\n          and issue tracking systems that are managed
+    by, or on behalf of, the\n          Licensor for the purpose of discussing and
+    improving the Work, but\n          excluding communication that is conspicuously
+    marked or otherwise\n          designated in writing by the copyright owner as
+    \"Not a Contribution.\"\n    \n          \"Contributor\" shall mean Licensor and
+    any individual or Legal Entity\n          on behalf of whom a Contribution has
+    been received by Licensor and\n          subsequently incorporated within the
+    Work.\n    \n       2. Grant of Copyright License. Subject to the terms and conditions
+    of\n          this License, each Contributor hereby grants to You a perpetual,\n
+    \         worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n          copyright
+    license to reproduce, prepare Derivative Works of,\n          publicly display,
+    publicly perform, sublicense, and distribute the\n          Work and such Derivative
+    Works in Source or Object form.\n    \n       3. Grant of Patent License. Subject
+    to the terms and conditions of\n          this License, each Contributor hereby
+    grants to You a perpetual,\n          worldwide, non-exclusive, no-charge, royalty-free,
+    irrevocable\n          (except as stated in this section) patent license to make,
+    have made,\n          use, offer to sell, sell, import, and otherwise transfer
+    the Work,\n          where such license applies only to those patent claims licensable\n
+    \         by such Contributor that are necessarily infringed by their\n          Contribution(s)
+    alone or by combination of their Contribution(s)\n          with the Work to which
+    such Contribution(s) was submitted. If You\n          institute patent litigation
+    against any entity (including a\n          cross-claim or counterclaim in a lawsuit)
+    alleging that the Work\n          or a Contribution incorporated within the Work
+    constitutes direct\n          or contributory patent infringement, then any patent
+    licenses\n          granted to You under this License for that Work shall terminate\n
+    \         as of the date such litigation is filed.\n    \n       4. Redistribution.
+    You may reproduce and distribute copies of the\n          Work or Derivative Works
+    thereof in any medium, with or without\n          modifications, and in Source
+    or Object form, provided that You\n          meet the following conditions:\n
+    \   \n          (a) You must give any other recipients of the Work or\n              Derivative
+    Works a copy of this License; and\n    \n          (b) You must cause any modified
+    files to carry prominent notices\n              stating that You changed the files;
+    and\n    \n          (c) You must retain, in the Source form of any Derivative
+    Works\n              that You distribute, all copyright, patent, trademark, and\n
+    \             attribution notices from the Source form of the Work,\n              excluding
+    those notices that do not pertain to any part of\n              the Derivative
+    Works; and\n    \n          (d) If the Work includes a \"NOTICE\" text file as
+    part of its\n              distribution, then any Derivative Works that You distribute
+    must\n              include a readable copy of the attribution notices contained\n
+    \             within such NOTICE file, excluding those notices that do not\n              pertain
+    to any part of the Derivative Works, in at least one\n              of the following
+    places: within a NOTICE text file distributed\n              as part of the Derivative
+    Works; within the Source form or\n              documentation, if provided along
+    with the Derivative Works; or,\n              within a display generated by the
+    Derivative Works, if and\n              wherever such third-party notices normally
+    appear. The contents\n              of the NOTICE file are for informational purposes
+    only and\n              do not modify the License. You may add Your own attribution\n
+    \             notices within Derivative Works that You distribute, alongside\n
+    \             or as an addendum to the NOTICE text from the Work, provided\n              that
+    such additional attribution notices cannot be construed\n              as modifying
+    the License.\n    \n          You may add Your own copyright statement to Your
+    modifications and\n          may provide additional or different license terms
+    and conditions\n          for use, reproduction, or distribution of Your modifications,
+    or\n          for any such Derivative Works as a whole, provided Your use,\n          reproduction,
+    and distribution of the Work otherwise complies with\n          the conditions
+    stated in this License.\n    \n       5. Submission of Contributions. Unless You
+    explicitly state otherwise,\n          any Contribution intentionally submitted
+    for inclusion in the Work\n          by You to the Licensor shall be under the
+    terms and conditions of\n          this License, without any additional terms
+    or conditions.\n          Notwithstanding the above, nothing herein shall supersede
+    or modify\n          the terms of any separate license agreement you may have
+    executed\n          with Licensor regarding such Contributions.\n    \n       6.
+    Trademarks. This License does not grant permission to use the trade\n          names,
+    trademarks, service marks, or product names of the Licensor,\n          except
+    as required for reasonable and customary use in describing the\n          origin
+    of the Work and reproducing the content of the NOTICE file.\n    \n       7. Disclaimer
+    of Warranty. Unless required by applicable law or\n          agreed to in writing,
+    Licensor provides the Work (and each\n          Contributor provides its Contributions)
+    on an \"AS IS\" BASIS,\n          WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+    either express or\n          implied, including, without limitation, any warranties
+    or conditions\n          of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS
+    FOR A\n          PARTICULAR PURPOSE. You are solely responsible for determining
+    the\n          appropriateness of using or redistributing the Work and assume
+    any\n          risks associated with Your exercise of permissions under this License.\n
+    \   \n       8. Limitation of Liability. In no event and under no legal theory,\n
+    \         whether in tort (including negligence), contract, or otherwise,\n          unless
+    required by applicable law (such as deliberate and grossly\n          negligent
+    acts) or agreed to in writing, shall any Contributor be\n          liable to You
+    for damages, including any direct, indirect, special,\n          incidental, or
+    consequential damages of any character arising as a\n          result of this
+    License or out of the use or inability to use the\n          Work (including but
+    not limited to damages for loss of goodwill,\n          work stoppage, computer
+    failure or malfunction, or any and all\n          other commercial damages or
+    losses), even if such Contributor\n          has been advised of the possibility
+    of such damages.\n    \n       9. Accepting Warranty or Additional Liability.
+    While redistributing\n          the Work or Derivative Works thereof, You may
+    choose to offer,\n          and charge a fee for, acceptance of support, warranty,
+    indemnity,\n          or other liability obligations and/or rights consistent
+    with this\n          License. However, in accepting such obligations, You may
+    act only\n          on Your own behalf and on Your sole responsibility, not on
+    behalf\n          of any other Contributor, and only if You agree to indemnify,\n
+    \         defend, and hold each Contributor harmless for any liability\n          incurred
+    by, or claims asserted against, such Contributor by reason\n          of your
+    accepting any such warranty or additional liability.\n    \n       END OF TERMS
+    AND CONDITIONS\n    \n       APPENDIX: How to apply the Apache License to your
+    work.\n    \n          To apply the Apache License to your work, attach the following\n
+    \         boilerplate notice, with the fields enclosed by brackets \"[]\"\n          replaced
+    with your own identifying information. (Don't include\n          the brackets!)
+    \ The text should be enclosed in the appropriate\n          comment syntax for
+    the file format. We also recommend that a\n          file or class name and description
+    of purpose be included on the\n          same \"printed page\" as the copyright
+    notice for easier\n          identification within third-party archives.\n    \n
+    \      Copyright [yyyy] [name of copyright owner]\n    \n       Licensed under
+    the Apache License, Version 2.0 (the \"License\");\n       you may not use this
+    file except in compliance with the License.\n       You may obtain a copy of the
+    License at\n    \n           http://www.apache.org/licenses/LICENSE-2.0\n    \n
+    \      Unless required by applicable law or agreed to in writing, software\n       distributed
+    under the License is distributed on an \"AS IS\" BASIS,\n       WITHOUT WARRANTIES
+    OR CONDITIONS OF ANY KIND, either express or implied.\n       See the License
+    for the specific language governing permissions and\n       limitations under
+    the License.\n    \n\n### libxml2\n\nMIT\n\nhttp://xmlsoft.org/\n\n    Except
+    where otherwise noted in the source code (e.g. the files hash.c,\n    list.c and
+    the trio files, which are covered by a similar licence but\n    with different
+    Copyright notices) all the files are:\n    \n     Copyright (C) 1998-2012 Daniel
+    Veillard.  All Rights Reserved.\n    \n    Permission is hereby granted, free
+    of charge, to any person obtaining a copy\n    of this software and associated
+    documentation files (the \"Software\"), to deal\n    in the Software without restriction,
+    including without limitation the rights\n    to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell\n    copies of the Software, and to permit
+    persons to whom the Software is fur-\n    nished to do so, subject to the following
+    conditions:\n    \n    The above copyright notice and this permission notice shall
+    be included in\n    all copies or substantial portions of the Software.\n    \n
+    \   THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+    OR\n    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FIT-\n    NESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE\n    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\n
+    \   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\n
+    \   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN\n
+    \   THE SOFTWARE.\n    \n\n### libxslt\n\nMIT\n\nhttp://xmlsoft.org/libxslt/\n\n
+    \   Licence for libxslt except libexslt\n    ----------------------------------------------------------------------\n
+    \    Copyright (C) 2001-2002 Daniel Veillard.  All Rights Reserved.\n    \n    Permission
+    is hereby granted, free of charge, to any person obtaining a copy\n    of this
+    software and associated documentation files (the \"Software\"), to deal\n    in
+    the Software without restriction, including without limitation the rights\n    to
+    use, copy, modify, merge, publish, distribute, sublicense, and/or sell\n    copies
+    of the Software, and to permit persons to whom the Software is fur-\n    nished
+    to do so, subject to the following conditions:\n    \n    The above copyright
+    notice and this permission notice shall be included in\n    all copies or substantial
+    portions of the Software.\n    \n    THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT
+    WARRANTY OF ANY KIND, EXPRESS OR\n    IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+    WARRANTIES OF MERCHANTABILITY, FIT-\n    NESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+    \ IN NO EVENT SHALL THE\n    DANIEL VEILLARD BE LIABLE FOR ANY CLAIM, DAMAGES
+    OR OTHER LIABILITY, WHETHER\n    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+    ARISING FROM, OUT OF OR IN CON-\n    NECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.\n    \n    Except as contained in this notice, the name
+    of Daniel Veillard shall not\n    be used in advertising or otherwise to promote
+    the sale, use or other deal-\n    ings in this Software without prior written
+    authorization from him.\n    \n    ----------------------------------------------------------------------\n
+    \   \n    Licence for libexslt\n    ----------------------------------------------------------------------\n
+    \    Copyright (C) 2001-2002 Thomas Broyer, Charlie Bozeman and Daniel Veillard.\n
+    \    All Rights Reserved.\n    \n    Permission is hereby granted, free of charge,
+    to any person obtaining a copy\n    of this software and associated documentation
+    files (the \"Software\"), to deal\n    in the Software without restriction, including
+    without limitation the rights\n    to use, copy, modify, merge, publish, distribute,
+    sublicense, and/or sell\n    copies of the Software, and to permit persons to
+    whom the Software is fur-\n    nished to do so, subject to the following conditions:\n
+    \   \n    The above copyright notice and this permission notice shall be included
+    in\n    all copies or substantial portions of the Software.\n    \n    THE SOFTWARE
+    IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n    IMPLIED,
+    INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FIT-\n    NESS
+    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE\n    AUTHORS
+    BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER\n    IN AN ACTION
+    OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CON-\n    NECTION WITH
+    THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\n    \n    Except as
+    contained in this notice, the name of the authors shall not\n    be used in advertising
+    or otherwise to promote the sale, use or other deal-\n    ings in this Software
+    without prior written authorization from him.\n    ----------------------------------------------------------------------\n
+    \   \n\n### zlib\n\nzlib license\n\nhttp://www.zlib.net/zlib_license.html\n\n
+    \     Copyright (C) 1995-2017 Jean-loup Gailly and Mark Adler\n    \n      This
+    software is provided 'as-is', without any express or implied\n      warranty.
+    \ In no event will the authors be held liable for any damages\n      arising from
+    the use of this software.\n    \n      Permission is granted to anyone to use
+    this software for any purpose,\n      including commercial applications, and to
+    alter it and redistribute it\n      freely, subject to the following restrictions:\n
+    \   \n      1. The origin of this software must not be misrepresented; you must
+    not\n         claim that you wrote the original software. If you use this software\n
+    \        in a product, an acknowledgment in the product documentation would be\n
+    \        appreciated but is not required.\n      2. Altered source versions must
+    be plainly marked as such, and must not be\n         misrepresented as being the
+    original software.\n      3. This notice may not be removed or altered from any
+    source distribution.\n    \n      Jean-loup Gailly        Mark Adler\n      jloup@gzip.org
+    \         madler@alumni.caltech.edu\n    \n\n### libiconv\n\nLGPL\n\nhttps://www.gnu.org/software/libiconv/\n\n
+    \   \t\t  GNU LIBRARY GENERAL PUBLIC LICENSE\n    \t\t       Version 2, June 1991\n
+    \   \n     Copyright (C) 1991 Free Software Foundation, Inc.\n     51 Franklin
+    Street, Fifth Floor, Boston, MA 02110-1301, USA\n     Everyone is permitted to
+    copy and distribute verbatim copies\n     of this license document, but changing
+    it is not allowed.\n    \n    [This is the first released version of the library
+    GPL.  It is\n     numbered 2 because it goes with version 2 of the ordinary GPL.]\n
+    \   \n    \t\t\t    Preamble\n    \n      The licenses for most software are designed
+    to take away your\n    freedom to share and change it.  By contrast, the GNU General
+    Public\n    Licenses are intended to guarantee your freedom to share and change\n
+    \   free software--to make sure the software is free for all its users.\n    \n
+    \     This license, the Library General Public License, applies to some\n    specially
+    designated Free Software Foundation software, and to any\n    other libraries
+    whose authors decide to use it.  You can use it for\n    your libraries, too.\n
+    \   \n      When we speak of free software, we are referring to freedom, not\n
+    \   price.  Our General Public Licenses are designed to make sure that you\n    have
+    the freedom to distribute copies of free software (and charge for\n    this service
+    if you wish), that you receive source code or can get it\n    if you want it,
+    that you can change the software or use pieces of it\n    in new free programs;
+    and that you know you can do these things.\n    \n      To protect your rights,
+    we need to make restrictions that forbid\n    anyone to deny you these rights
+    or to ask you to surrender the rights.\n    These restrictions translate to certain
+    responsibilities for you if\n    you distribute copies of the library, or if you
+    modify it.\n    \n      For example, if you distribute copies of the library,
+    whether gratis\n    or for a fee, you must give the recipients all the rights
+    that we gave\n    you.  You must make sure that they, too, receive or can get
+    the source\n    code.  If you link a program with the library, you must provide\n
+    \   complete object files to the recipients so that they can relink them\n    with
+    the library, after making changes to the library and recompiling\n    it.  And
+    you must show them these terms so they know their rights.\n    \n      Our method
+    of protecting your rights has two steps: (1) copyright\n    the library, and (2)
+    offer you this license which gives you legal\n    permission to copy, distribute
+    and/or modify the library.\n    \n      Also, for each distributor's protection,
+    we want to make certain\n    that everyone understands that there is no warranty
+    for this free\n    library.  If the library is modified by someone else and passed
+    on, we\n    want its recipients to know that what they have is not the original\n
+    \   version, so that any problems introduced by others will not reflect on\n    the
+    original authors' reputations.\n    \f\n      Finally, any free program is threatened
+    constantly by software\n    patents.  We wish to avoid the danger that companies
+    distributing free\n    software will individually obtain patent licenses, thus
+    in effect\n    transforming the program into proprietary software.  To prevent
+    this,\n    we have made it clear that any patent must be licensed for everyone's\n
+    \   free use or not licensed at all.\n    \n      Most GNU software, including
+    some libraries, is covered by the ordinary\n    GNU General Public License, which
+    was designed for utility programs.  This\n    license, the GNU Library General
+    Public License, applies to certain\n    designated libraries.  This license is
+    quite different from the ordinary\n    one; be sure to read it in full, and don't
+    assume that anything in it is\n    the same as in the ordinary license.\n    \n
+    \     The reason we have a separate public license for some libraries is that\n
+    \   they blur the distinction we usually make between modifying or adding to a\n
+    \   program and simply using it.  Linking a program with a library, without\n
+    \   changing the library, is in some sense simply using the library, and is\n
+    \   analogous to running a utility program or application program.  However, in\n
+    \   a textual and legal sense, the linked executable is a combined work, a\n    derivative
+    of the original library, and the ordinary General Public License\n    treats it
+    as such.\n    \n      Because of this blurred distinction, using the ordinary
+    General\n    Public License for libraries did not effectively promote software\n
+    \   sharing, because most developers did not use the libraries.  We\n    concluded
+    that weaker conditions might promote sharing better.\n    \n      However, unrestricted
+    linking of non-free programs would deprive the\n    users of those programs of
+    all benefit from the free status of the\n    libraries themselves.  This Library
+    General Public License is intended to\n    permit developers of non-free programs
+    to use free libraries, while\n    preserving your freedom as a user of such programs
+    to change the free\n    libraries that are incorporated in them.  (We have not
+    seen how to achieve\n    this as regards changes in header files, but we have
+    achieved it as regards\n    changes in the actual functions of the Library.)  The
+    hope is that this\n    will lead to faster development of free libraries.\n    \n
+    \     The precise terms and conditions for copying, distribution and\n    modification
+    follow.  Pay close attention to the difference between a\n    \"work based on
+    the library\" and a \"work that uses the library\".  The\n    former contains
+    code derived from the library, while the latter only\n    works together with
+    the library.\n    \n      Note that it is possible for a library to be covered
+    by the ordinary\n    General Public License rather than by this special one.\n
+    \   \f\n    \t\t  GNU LIBRARY GENERAL PUBLIC LICENSE\n       TERMS AND CONDITIONS
+    FOR COPYING, DISTRIBUTION AND MODIFICATION\n    \n      0. This License Agreement
+    applies to any software library which\n    contains a notice placed by the copyright
+    holder or other authorized\n    party saying it may be distributed under the terms
+    of this Library\n    General Public License (also called \"this License\").  Each
+    licensee is\n    addressed as \"you\".\n    \n      A \"library\" means a collection
+    of software functions and/or data\n    prepared so as to be conveniently linked
+    with application programs\n    (which use some of those functions and data) to
+    form executables.\n    \n      The \"Library\", below, refers to any such software
+    library or work\n    which has been distributed under these terms.  A \"work based
+    on the\n    Library\" means either the Library or any derivative work under\n
+    \   copyright law: that is to say, a work containing the Library or a\n    portion
+    of it, either verbatim or with modifications and/or translated\n    straightforwardly
+    into another language.  (Hereinafter, translation is\n    included without limitation
+    in the term \"modification\".)\n    \n      \"Source code\" for a work means the
+    preferred form of the work for\n    making modifications to it.  For a library,
+    complete source code means\n    all the source code for all modules it contains,
+    plus any associated\n    interface definition files, plus the scripts used to
+    control compilation\n    and installation of the library.\n    \n      Activities
+    other than copying, distribution and modification are not\n    covered by this
+    License; they are outside its scope.  The act of\n    running a program using
+    the Library is not restricted, and output from\n    such a program is covered
+    only if its contents constitute a work based\n    on the Library (independent
+    of the use of the Library in a tool for\n    writing it).  Whether that is true
+    depends on what the Library does\n    and what the program that uses the Library
+    does.\n      \n      1. You may copy and distribute verbatim copies of the Library's\n
+    \   complete source code as you receive it, in any medium, provided that\n    you
+    conspicuously and appropriately publish on each copy an\n    appropriate copyright
+    notice and disclaimer of warranty; keep intact\n    all the notices that refer
+    to this License and to the absence of any\n    warranty; and distribute a copy
+    of this License along with the\n    Library.\n    \n      You may charge a fee
+    for the physical act of transferring a copy,\n    and you may at your option offer
+    warranty protection in exchange for a\n    fee.\n    \f\n      2. You may modify
+    your copy or copies of the Library or any portion\n    of it, thus forming a work
+    based on the Library, and copy and\n    distribute such modifications or work
+    under the terms of Section 1\n    above, provided that you also meet all of these
+    conditions:\n    \n        a) The modified work must itself be a software library.\n
+    \   \n        b) You must cause the files modified to carry prominent notices\n
+    \       stating that you changed the files and the date of any change.\n    \n
+    \       c) You must cause the whole of the work to be licensed at no\n        charge
+    to all third parties under the terms of this License.\n    \n        d) If a facility
+    in the modified Library refers to a function or a\n        table of data to be
+    supplied by an application program that uses\n        the facility, other than
+    as an argument passed when the facility\n        is invoked, then you must make
+    a good faith effort to ensure that,\n        in the event an application does
+    not supply such function or\n        table, the facility still operates, and performs
+    whatever part of\n        its purpose remains meaningful.\n    \n        (For
+    example, a function in a library to compute square roots has\n        a purpose
+    that is entirely well-defined independent of the\n        application.  Therefore,
+    Subsection 2d requires that any\n        application-supplied function or table
+    used by this function must\n        be optional: if the application does not supply
+    it, the square\n        root function must still compute square roots.)\n    \n
+    \   These requirements apply to the modified work as a whole.  If\n    identifiable
+    sections of that work are not derived from the Library,\n    and can be reasonably
+    considered independent and separate works in\n    themselves, then this License,
+    and its terms, do not apply to those\n    sections when you distribute them as
+    separate works.  But when you\n    distribute the same sections as part of a whole
+    which is a work based\n    on the Library, the distribution of the whole must
+    be on the terms of\n    this License, whose permissions for other licensees extend
+    to the\n    entire whole, and thus to each and every part regardless of who wrote\n
+    \   it.\n    \n    Thus, it is not the intent of this section to claim rights
+    or contest\n    your rights to work written entirely by you; rather, the intent
+    is to\n    exercise the right to control the distribution of derivative or\n    collective
+    works based on the Library.\n    \n    In addition, mere aggregation of another
+    work not based on the Library\n    with the Library (or with a work based on the
+    Library) on a volume of\n    a storage or distribution medium does not bring the
+    other work under\n    the scope of this License.\n    \n      3. You may opt to
+    apply the terms of the ordinary GNU General Public\n    License instead of this
+    License to a given copy of the Library.  To do\n    this, you must alter all the
+    notices that refer to this License, so\n    that they refer to the ordinary GNU
+    General Public License, version 2,\n    instead of to this License.  (If a newer
+    version than version 2 of the\n    ordinary GNU General Public License has appeared,
+    then you can specify\n    that version instead if you wish.)  Do not make any
+    other change in\n    these notices.\n    \f\n      Once this change is made in
+    a given copy, it is irreversible for\n    that copy, so the ordinary GNU General
+    Public License applies to all\n    subsequent copies and derivative works made
+    from that copy.\n    \n      This option is useful when you wish to copy part
+    of the code of\n    the Library into a program that is not a library.\n    \n
+    \     4. You may copy and distribute the Library (or a portion or\n    derivative
+    of it, under Section 2) in object code or executable form\n    under the terms
+    of Sections 1 and 2 above provided that you accompany\n    it with the complete
+    corresponding machine-readable source code, which\n    must be distributed under
+    the terms of Sections 1 and 2 above on a\n    medium customarily used for software
+    interchange.\n    \n      If distribution of object code is made by offering access
+    to copy\n    from a designated place, then offering equivalent access to copy
+    the\n    source code from the same place satisfies the requirement to\n    distribute
+    the source code, even though third parties are not\n    compelled to copy the
+    source along with the object code.\n    \n      5. A program that contains no
+    derivative of any portion of the\n    Library, but is designed to work with the
+    Library by being compiled or\n    linked with it, is called a \"work that uses
+    the Library\".  Such a\n    work, in isolation, is not a derivative work of the
+    Library, and\n    therefore falls outside the scope of this License.\n    \n      However,
+    linking a \"work that uses the Library\" with the Library\n    creates an executable
+    that is a derivative of the Library (because it\n    contains portions of the
+    Library), rather than a \"work that uses the\n    library\".  The executable is
+    therefore covered by this License.\n    Section 6 states terms for distribution
+    of such executables.\n    \n      When a \"work that uses the Library\" uses material
+    from a header file\n    that is part of the Library, the object code for the work
+    may be a\n    derivative work of the Library even though the source code is not.\n
+    \   Whether this is true is especially significant if the work can be\n    linked
+    without the Library, or if the work is itself a library.  The\n    threshold for
+    this to be true is not precisely defined by law.\n    \n      If such an object
+    file uses only numerical parameters, data\n    structure layouts and accessors,
+    and small macros and small inline\n    functions (ten lines or less in length),
+    then the use of the object\n    file is unrestricted, regardless of whether it
+    is legally a derivative\n    work.  (Executables containing this object code plus
+    portions of the\n    Library will still fall under Section 6.)\n    \n      Otherwise,
+    if the work is a derivative of the Library, you may\n    distribute the object
+    code for the work under the terms of Section 6.\n    Any executables containing
+    that work also fall under Section 6,\n    whether or not they are linked directly
+    with the Library itself.\n    \f\n      6. As an exception to the Sections above,
+    you may also compile or\n    link a \"work that uses the Library\" with the Library
+    to produce a\n    work containing portions of the Library, and distribute that
+    work\n    under terms of your choice, provided that the terms permit\n    modification
+    of the work for the customer's own use and reverse\n    engineering for debugging
+    such modifications.\n    \n      You must give prominent notice with each copy
+    of the work that the\n    Library is used in it and that the Library and its use
+    are covered by\n    this License.  You must supply a copy of this License.  If
+    the work\n    during execution displays copyright notices, you must include the\n
+    \   copyright notice for the Library among them, as well as a reference\n    directing
+    the user to the copy of this License.  Also, you must do one\n    of these things:\n
+    \   \n        a) Accompany the work with the complete corresponding\n        machine-readable
+    source code for the Library including whatever\n        changes were used in the
+    work (which must be distributed under\n        Sections 1 and 2 above); and, if
+    the work is an executable linked\n        with the Library, with the complete
+    machine-readable \"work that\n        uses the Library\", as object code and/or
+    source code, so that the\n        user can modify the Library and then relink
+    to produce a modified\n        executable containing the modified Library.  (It
+    is understood\n        that the user who changes the contents of definitions files
+    in the\n        Library will not necessarily be able to recompile the application\n
+    \       to use the modified definitions.)\n    \n        b) Accompany the work
+    with a written offer, valid for at\n        least three years, to give the same
+    user the materials\n        specified in Subsection 6a, above, for a charge no
+    more\n        than the cost of performing this distribution.\n    \n        c)
+    If distribution of the work is made by offering access to copy\n        from a
+    designated place, offer equivalent access to copy the above\n        specified
+    materials from the same place.\n    \n        d) Verify that the user has already
+    received a copy of these\n        materials or that you have already sent this
+    user a copy.\n    \n      For an executable, the required form of the \"work that
+    uses the\n    Library\" must include any data and utility programs needed for\n
+    \   reproducing the executable from it.  However, as a special exception,\n    the
+    source code distributed need not include anything that is normally\n    distributed
+    (in either source or binary form) with the major\n    components (compiler, kernel,
+    and so on) of the operating system on\n    which the executable runs, unless that
+    component itself accompanies\n    the executable.\n    \n      It may happen that
+    this requirement contradicts the license\n    restrictions of other proprietary
+    libraries that do not normally\n    accompany the operating system.  Such a contradiction
+    means you cannot\n    use both them and the Library together in an executable
+    that you\n    distribute.\n    \f\n      7. You may place library facilities that
+    are a work based on the\n    Library side-by-side in a single library together
+    with other library\n    facilities not covered by this License, and distribute
+    such a combined\n    library, provided that the separate distribution of the work
+    based on\n    the Library and of the other library facilities is otherwise\n    permitted,
+    and provided that you do these two things:\n    \n        a) Accompany the combined
+    library with a copy of the same work\n        based on the Library, uncombined
+    with any other library\n        facilities.  This must be distributed under the
+    terms of the\n        Sections above.\n    \n        b) Give prominent notice
+    with the combined library of the fact\n        that part of it is a work based
+    on the Library, and explaining\n        where to find the accompanying uncombined
+    form of the same work.\n    \n      8. You may not copy, modify, sublicense, link
+    with, or distribute\n    the Library except as expressly provided under this License.
+    \ Any\n    attempt otherwise to copy, modify, sublicense, link with, or\n    distribute
+    the Library is void, and will automatically terminate your\n    rights under this
+    License.  However, parties who have received copies,\n    or rights, from you
+    under this License will not have their licenses\n    terminated so long as such
+    parties remain in full compliance.\n    \n      9. You are not required to accept
+    this License, since you have not\n    signed it.  However, nothing else grants
+    you permission to modify or\n    distribute the Library or its derivative works.
+    \ These actions are\n    prohibited by law if you do not accept this License.
+    \ Therefore, by\n    modifying or distributing the Library (or any work based
+    on the\n    Library), you indicate your acceptance of this License to do so, and\n
+    \   all its terms and conditions for copying, distributing or modifying\n    the
+    Library or works based on it.\n    \n      10. Each time you redistribute the
+    Library (or any work based on the\n    Library), the recipient automatically receives
+    a license from the\n    original licensor to copy, distribute, link with or modify
+    the Library\n    subject to these terms and conditions.  You may not impose any
+    further\n    restrictions on the recipients' exercise of the rights granted herein.\n
+    \   You are not responsible for enforcing compliance by third parties to\n    this
+    License.\n    \f\n      11. If, as a consequence of a court judgment or allegation
+    of patent\n    infringement or for any other reason (not limited to patent issues),\n
+    \   conditions are imposed on you (whether by court order, agreement or\n    otherwise)
+    that contradict the conditions of this License, they do not\n    excuse you from
+    the conditions of this License.  If you cannot\n    distribute so as to satisfy
+    simultaneously your obligations under this\n    License and any other pertinent
+    obligations, then as a consequence you\n    may not distribute the Library at
+    all.  For example, if a patent\n    license would not permit royalty-free redistribution
+    of the Library by\n    all those who receive copies directly or indirectly through
+    you, then\n    the only way you could satisfy both it and this License would be
+    to\n    refrain entirely from distribution of the Library.\n    \n    If any portion
+    of this section is held invalid or unenforceable under any\n    particular circumstance,
+    the balance of the section is intended to apply,\n    and the section as a whole
+    is intended to apply in other circumstances.\n    \n    It is not the purpose
+    of this section to induce you to infringe any\n    patents or other property right
+    claims or to contest validity of any\n    such claims; this section has the sole
+    purpose of protecting the\n    integrity of the free software distribution system
+    which is\n    implemented by public license practices.  Many people have made\n
+    \   generous contributions to the wide range of software distributed\n    through
+    that system in reliance on consistent application of that\n    system; it is up
+    to the author/donor to decide if he or she is willing\n    to distribute software
+    through any other system and a licensee cannot\n    impose that choice.\n    \n
+    \   This section is intended to make thoroughly clear what is believed to\n    be
+    a consequence of the rest of this License.\n    \n      12. If the distribution
+    and/or use of the Library is restricted in\n    certain countries either by patents
+    or by copyrighted interfaces, the\n    original copyright holder who places the
+    Library under this License may add\n    an explicit geographical distribution
+    limitation excluding those countries,\n    so that distribution is permitted only
+    in or among countries not thus\n    excluded.  In such case, this License incorporates
+    the limitation as if\n    written in the body of this License.\n    \n      13.
+    The Free Software Foundation may publish revised and/or new\n    versions of the
+    Library General Public License from time to time.\n    Such new versions will
+    be similar in spirit to the present version,\n    but may differ in detail to
+    address new problems or concerns.\n    \n    Each version is given a distinguishing
+    version number.  If the Library\n    specifies a version number of this License
+    which applies to it and\n    \"any later version\", you have the option of following
+    the terms and\n    conditions either of that version or of any later version published
+    by\n    the Free Software Foundation.  If the Library does not specify a\n    license
+    version number, you may choose any version ever published by\n    the Free Software
+    Foundation.\n    \f\n      14. If you wish to incorporate parts of the Library
+    into other free\n    programs whose distribution conditions are incompatible with
+    these,\n    write to the author to ask for permission.  For software which is\n
+    \   copyrighted by the Free Software Foundation, write to the Free\n    Software
+    Foundation; we sometimes make exceptions for this.  Our\n    decision will be
+    guided by the two goals of preserving the free status\n    of all derivatives
+    of our free software and of promoting the sharing\n    and reuse of software generally.\n
+    \   \n    \t\t\t    NO WARRANTY\n    \n      15. BECAUSE THE LIBRARY IS LICENSED
+    FREE OF CHARGE, THERE IS NO\n    WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED
+    BY APPLICABLE LAW.\n    EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+    HOLDERS AND/OR\n    OTHER PARTIES PROVIDE THE LIBRARY \"AS IS\" WITHOUT WARRANTY
+    OF ANY\n    KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+    THE\n    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR\n
+    \   PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE\n    LIBRARY
+    IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME\n    THE COST OF
+    ALL NECESSARY SERVICING, REPAIR OR CORRECTION.\n    \n      16. IN NO EVENT UNLESS
+    REQUIRED BY APPLICABLE LAW OR AGREED TO IN\n    WRITING WILL ANY COPYRIGHT HOLDER,
+    OR ANY OTHER PARTY WHO MAY MODIFY\n    AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED
+    ABOVE, BE LIABLE TO YOU\n    FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL
+    OR\n    CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE\n
+    \   LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING\n    RENDERED
+    INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A\n    FAILURE OF THE
+    LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF\n    SUCH HOLDER OR OTHER
+    PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH\n    DAMAGES.\n    \n    \t\t
+    \    END OF TERMS AND CONDITIONS\n    \f\n         Appendix: How to Apply These
+    Terms to Your New Libraries\n    \n      If you develop a new library, and you
+    want it to be of the greatest\n    possible use to the public, we recommend making
+    it free software that\n    everyone can redistribute and change.  You can do so
+    by permitting\n    redistribution under these terms (or, alternatively, under
+    the terms of the\n    ordinary General Public License).\n    \n      To apply
+    these terms, attach the following notices to the library.  It is\n    safest to
+    attach them to the start of each source file to most effectively\n    convey the
+    exclusion of warranty; and each file should have at least the\n    \"copyright\"
+    line and a pointer to where the full notice is found.\n    \n        <one line
+    to give the library's name and a brief idea of what it does.>\n        Copyright
+    (C) <year>  <name of author>\n    \n        This library is free software; you
+    can redistribute it and/or\n        modify it under the terms of the GNU Library
+    General Public\n        License as published by the Free Software Foundation;
+    either\n        version 2 of the License, or (at your option) any later version.\n
+    \   \n        This library is distributed in the hope that it will be useful,\n
+    \       but WITHOUT ANY WARRANTY; without even the implied warranty of\n        MERCHANTABILITY
+    or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU\n        Library General Public
+    License for more details.\n    \n        You should have received a copy of the
+    GNU Library General Public\n        License along with this library; if not, write
+    to the Free\n        Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+    Boston,\n        MA 02110-1301, USA\n    \n    Also add information on how to
+    contact you by electronic and paper mail.\n    \n    You should also get your
+    employer (if you work as a programmer) or your\n    school, if any, to sign a
+    \"copyright disclaimer\" for the library, if\n    necessary.  Here is a sample;
+    alter the names:\n    \n      Yoyodyne, Inc., hereby disclaims all copyright interest
+    in the\n      library `Frob' (a library for tweaking knobs) written by James Random
+    Hacker.\n    \n      <signature of Ty Coon>, 1 April 1990\n      Ty Coon, President
+    of Vice\n    \n    That's all there is to it!\n\n\n### isorelax\n\nMIT\n\nhttp://iso-relax.sourceforge.net/\n\n
+    \   Copyright (c) 2001-2002, SourceForge ISO-RELAX Project (ASAMI\n    Tomoharu,
+    Daisuke Okajima, Kohsuke Kawaguchi, and MURATA Makoto)\n    \n    Permission is
+    hereby granted, free of charge, to any person obtaining\n    a copy of this software
+    and associated documentation files (the\n    \"Software\"), to deal in the Software
+    without restriction, including\n    without limitation the rights to use, copy,
+    modify, merge, publish,\n    distribute, sublicense, and/or sell copies of the
+    Software, and to\n    permit persons to whom the Software is furnished to do so,
+    subject to\n    the following conditions:\n    \n    The above copyright notice
+    and this permission notice shall be\n    included in all copies or substantial
+    portions of the Software.\n    \n    THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT
+    WARRANTY OF ANY KIND,\n    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+    WARRANTIES OF\n    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND\n    NONINFRINGEMENT.
+    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE\n    LIABLE FOR ANY CLAIM,
+    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION\n    OF CONTRACT, TORT OR OTHERWISE,
+    ARISING FROM, OUT OF OR IN CONNECTION\n    WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.\n\n\n### jing\n\nBSD-3-Clause\n\nhttp://www.thaiopensource.com/relaxng/jing.html\n\n
+    \   Copyright (c) 2001-2003 Thai Open Source Software Center Ltd\n    All rights
+    reserved.\n    \n    Redistribution and use in source and binary forms, with or
+    without\n    modification, are permitted provided that the following conditions\n
+    \   are met:\n    \n    * Redistributions of source code must retain the above
+    copyright\n      notice, this list of conditions and the following disclaimer.\n
+    \   \n    * Redistributions in binary form must reproduce the above\n      copyright
+    notice, this list of conditions and the following\n      disclaimer in the documentation
+    and/or other materials provided\n      with the distribution.\n    \n    * Neither
+    the name of the Thai Open Source Software Center Ltd nor\n      the names of its
+    contributors may be used to endorse or promote\n      products derived from this
+    software without specific prior\n      written permission.\n    \n    THIS SOFTWARE
+    IS PROVIDED BY THE COPYRIGHT HOLDERS AND\n    CONTRIBUTORS \"AS IS\" AND ANY EXPRESS
+    OR IMPLIED WARRANTIES,\n    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+    OF\n    MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE\n    DISCLAIMED.
+    IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE\n    LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY,\n    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+    NOT LIMITED TO,\n    PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR\n    PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n    THEORY
+    OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR\n    TORT (INCLUDING NEGLIGENCE
+    OR OTHERWISE) ARISING IN ANY WAY OUT OF\n    THE USE OF THIS SOFTWARE, EVEN IF
+    ADVISED OF THE POSSIBILITY OF\n    SUCH DAMAGE.\n\n    \n### nekodtd\n\nApache
+    1.0-derived\n\nhttps://people.apache.org/~andyc/neko/doc/dtd/\n\n    The CyberNeko
+    Software License, Version 1.0\n     \n    (C) Copyright 2002-2005, Andy Clark.
+    \ All rights reserved.\n     \n    Redistribution and use in source and binary
+    forms, with or without\n    modification, are permitted provided that the following
+    conditions\n    are met:\n    \n    1. Redistributions of source code must retain
+    the above copyright\n       notice, this list of conditions and the following
+    disclaimer. \n    \n    2. Redistributions in binary form must reproduce the above
+    copyright\n       notice, this list of conditions and the following disclaimer
+    in\n       the documentation and/or other materials provided with the\n       distribution.\n
+    \   \n    3. The end-user documentation included with the redistribution,\n       if
+    any, must include the following acknowledgment:  \n         \"This product includes
+    software developed by Andy Clark.\"\n       Alternately, this acknowledgment may
+    appear in the software itself,\n       if and wherever such third-party acknowledgments
+    normally appear.\n    \n    4. The names \"CyberNeko\" and \"NekoHTML\" must not
+    be used to endorse\n       or promote products derived from this software without
+    prior \n       written permission. For written permission, please contact \n       andyc@cyberneko.net.\n
+    \   \n    5. Products derived from this software may not be called \"CyberNeko\",\n
+    \      nor may \"CyberNeko\" appear in their name, without prior written\n       permission
+    of the author.\n    \n    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED
+    OR IMPLIED\n    WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n
+    \   OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE\n    DISCLAIMED.
+    \ IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS\n    BE LIABLE FOR ANY DIRECT,
+    INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, \n    OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT \n    OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+    USE, DATA, OR PROFITS; OR \n    BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, \n    WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+    NEGLIGENCE \n    OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+    \n    EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n    \n    ====================================================================\n
+    \   \n    This license is based on the Apache Software License, version 1.1.\n\n###
+    nekohtml\n\nApache 2.0\n\nhttp://nekohtml.sourceforge.net/\n\n    \n                                     Apache
+    License\n                               Version 2.0, January 2004\n                            http://www.apache.org/licenses/\n
+    \   \n       TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n    \n
+    \      1. Definitions.\n    \n          \"License\" shall mean the terms and conditions
+    for use, reproduction,\n          and distribution as defined by Sections 1 through
+    9 of this document.\n    \n          \"Licensor\" shall mean the copyright owner
+    or entity authorized by\n          the copyright owner that is granting the License.\n
+    \   \n          \"Legal Entity\" shall mean the union of the acting entity and
+    all\n          other entities that control, are controlled by, or are under common\n
+    \         control with that entity. For the purposes of this definition,\n          \"control\"
+    means (i) the power, direct or indirect, to cause the\n          direction or
+    management of such entity, whether by contract or\n          otherwise, or (ii)
+    ownership of fifty percent (50%) or more of the\n          outstanding shares,
+    or (iii) beneficial ownership of such entity.\n    \n          \"You\" (or \"Your\")
+    shall mean an individual or Legal Entity\n          exercising permissions granted
+    by this License.\n    \n          \"Source\" form shall mean the preferred form
+    for making modifications,\n          including but not limited to software source
+    code, documentation\n          source, and configuration files.\n    \n          \"Object\"
+    form shall mean any form resulting from mechanical\n          transformation or
+    translation of a Source form, including but\n          not limited to compiled
+    object code, generated documentation,\n          and conversions to other media
+    types.\n    \n          \"Work\" shall mean the work of authorship, whether in
+    Source or\n          Object form, made available under the License, as indicated
+    by a\n          copyright notice that is included in or attached to the work\n
+    \         (an example is provided in the Appendix below).\n    \n          \"Derivative
+    Works\" shall mean any work, whether in Source or Object\n          form, that
+    is based on (or derived from) the Work and for which the\n          editorial
+    revisions, annotations, elaborations, or other modifications\n          represent,
+    as a whole, an original work of authorship. For the purposes\n          of this
+    License, Derivative Works shall not include works that remain\n          separable
+    from, or merely link (or bind by name) to the interfaces of,\n          the Work
+    and Derivative Works thereof.\n    \n          \"Contribution\" shall mean any
+    work of authorship, including\n          the original version of the Work and
+    any modifications or additions\n          to that Work or Derivative Works thereof,
+    that is intentionally\n          submitted to Licensor for inclusion in the Work
+    by the copyright owner\n          or by an individual or Legal Entity authorized
+    to submit on behalf of\n          the copyright owner. For the purposes of this
+    definition, \"submitted\"\n          means any form of electronic, verbal, or
+    written communication sent\n          to the Licensor or its representatives,
+    including but not limited to\n          communication on electronic mailing lists,
+    source code control systems,\n          and issue tracking systems that are managed
+    by, or on behalf of, the\n          Licensor for the purpose of discussing and
+    improving the Work, but\n          excluding communication that is conspicuously
+    marked or otherwise\n          designated in writing by the copyright owner as
+    \"Not a Contribution.\"\n    \n          \"Contributor\" shall mean Licensor and
+    any individual or Legal Entity\n          on behalf of whom a Contribution has
+    been received by Licensor and\n          subsequently incorporated within the
+    Work.\n    \n       2. Grant of Copyright License. Subject to the terms and conditions
+    of\n          this License, each Contributor hereby grants to You a perpetual,\n
+    \         worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n          copyright
+    license to reproduce, prepare Derivative Works of,\n          publicly display,
+    publicly perform, sublicense, and distribute the\n          Work and such Derivative
+    Works in Source or Object form.\n    \n       3. Grant of Patent License. Subject
+    to the terms and conditions of\n          this License, each Contributor hereby
+    grants to You a perpetual,\n          worldwide, non-exclusive, no-charge, royalty-free,
+    irrevocable\n          (except as stated in this section) patent license to make,
+    have made,\n          use, offer to sell, sell, import, and otherwise transfer
+    the Work,\n          where such license applies only to those patent claims licensable\n
+    \         by such Contributor that are necessarily infringed by their\n          Contribution(s)
+    alone or by combination of their Contribution(s)\n          with the Work to which
+    such Contribution(s) was submitted. If You\n          institute patent litigation
+    against any entity (including a\n          cross-claim or counterclaim in a lawsuit)
+    alleging that the Work\n          or a Contribution incorporated within the Work
+    constitutes direct\n          or contributory patent infringement, then any patent
+    licenses\n          granted to You under this License for that Work shall terminate\n
+    \         as of the date such litigation is filed.\n    \n       4. Redistribution.
+    You may reproduce and distribute copies of the\n          Work or Derivative Works
+    thereof in any medium, with or without\n          modifications, and in Source
+    or Object form, provided that You\n          meet the following conditions:\n
+    \   \n          (a) You must give any other recipients of the Work or\n              Derivative
+    Works a copy of this License; and\n    \n          (b) You must cause any modified
+    files to carry prominent notices\n              stating that You changed the files;
+    and\n    \n          (c) You must retain, in the Source form of any Derivative
+    Works\n              that You distribute, all copyright, patent, trademark, and\n
+    \             attribution notices from the Source form of the Work,\n              excluding
+    those notices that do not pertain to any part of\n              the Derivative
+    Works; and\n    \n          (d) If the Work includes a \"NOTICE\" text file as
+    part of its\n              distribution, then any Derivative Works that You distribute
+    must\n              include a readable copy of the attribution notices contained\n
+    \             within such NOTICE file, excluding those notices that do not\n              pertain
+    to any part of the Derivative Works, in at least one\n              of the following
+    places: within a NOTICE text file distributed\n              as part of the Derivative
+    Works; within the Source form or\n              documentation, if provided along
+    with the Derivative Works; or,\n              within a display generated by the
+    Derivative Works, if and\n              wherever such third-party notices normally
+    appear. The contents\n              of the NOTICE file are for informational purposes
+    only and\n              do not modify the License. You may add Your own attribution\n
+    \             notices within Derivative Works that You distribute, alongside\n
+    \             or as an addendum to the NOTICE text from the Work, provided\n              that
+    such additional attribution notices cannot be construed\n              as modifying
+    the License.\n    \n          You may add Your own copyright statement to Your
+    modifications and\n          may provide additional or different license terms
+    and conditions\n          for use, reproduction, or distribution of Your modifications,
+    or\n          for any such Derivative Works as a whole, provided Your use,\n          reproduction,
+    and distribution of the Work otherwise complies with\n          the conditions
+    stated in this License.\n    \n       5. Submission of Contributions. Unless You
+    explicitly state otherwise,\n          any Contribution intentionally submitted
+    for inclusion in the Work\n          by You to the Licensor shall be under the
+    terms and conditions of\n          this License, without any additional terms
+    or conditions.\n          Notwithstanding the above, nothing herein shall supersede
+    or modify\n          the terms of any separate license agreement you may have
+    executed\n          with Licensor regarding such Contributions.\n    \n       6.
+    Trademarks. This License does not grant permission to use the trade\n          names,
+    trademarks, service marks, or product names of the Licensor,\n          except
+    as required for reasonable and customary use in describing the\n          origin
+    of the Work and reproducing the content of the NOTICE file.\n    \n       7. Disclaimer
+    of Warranty. Unless required by applicable law or\n          agreed to in writing,
+    Licensor provides the Work (and each\n          Contributor provides its Contributions)
+    on an \"AS IS\" BASIS,\n          WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+    either express or\n          implied, including, without limitation, any warranties
+    or conditions\n          of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS
+    FOR A\n          PARTICULAR PURPOSE. You are solely responsible for determining
+    the\n          appropriateness of using or redistributing the Work and assume
+    any\n          risks associated with Your exercise of permissions under this License.\n
+    \   \n       8. Limitation of Liability. In no event and under no legal theory,\n
+    \         whether in tort (including negligence), contract, or otherwise,\n          unless
+    required by applicable law (such as deliberate and grossly\n          negligent
+    acts) or agreed to in writing, shall any Contributor be\n          liable to You
+    for damages, including any direct, indirect, special,\n          incidental, or
+    consequential damages of any character arising as a\n          result of this
+    License or out of the use or inability to use the\n          Work (including but
+    not limited to damages for loss of goodwill,\n          work stoppage, computer
+    failure or malfunction, or any and all\n          other commercial damages or
+    losses), even if such Contributor\n          has been advised of the possibility
+    of such damages.\n    \n       9. Accepting Warranty or Additional Liability.
+    While redistributing\n          the Work or Derivative Works thereof, You may
+    choose to offer,\n          and charge a fee for, acceptance of support, warranty,
+    indemnity,\n          or other liability obligations and/or rights consistent
+    with this\n          License. However, in accepting such obligations, You may
+    act only\n          on Your own behalf and on Your sole responsibility, not on
+    behalf\n          of any other Contributor, and only if You agree to indemnify,\n
+    \         defend, and hold each Contributor harmless for any liability\n          incurred
+    by, or claims asserted against, such Contributor by reason\n          of your
+    accepting any such warranty or additional liability.\n    \n       END OF TERMS
+    AND CONDITIONS\n    \n       APPENDIX: How to apply the Apache License to your
+    work.\n    \n          To apply the Apache License to your work, attach the following\n
+    \         boilerplate notice, with the fields enclosed by brackets \"[]\"\n          replaced
+    with your own identifying information. (Don't include\n          the brackets!)
+    \ The text should be enclosed in the appropriate\n          comment syntax for
+    the file format. We also recommend that a\n          file or class name and description
+    of purpose be included on the\n          same \"printed page\" as the copyright
+    notice for easier\n          identification within third-party archives.\n    \n
+    \      Copyright [yyyy] [name of copyright owner]\n    \n       Licensed under
+    the Apache License, Version 2.0 (the \"License\");\n       you may not use this
+    file except in compliance with the License.\n       You may obtain a copy of the
+    License at\n    \n           http://www.apache.org/licenses/LICENSE-2.0\n    \n
+    \      Unless required by applicable law or agreed to in writing, software\n       distributed
+    under the License is distributed on an \"AS IS\" BASIS,\n       WITHOUT WARRANTIES
+    OR CONDITIONS OF ANY KIND, either express or implied.\n       See the License
+    for the specific language governing permissions and\n       limitations under
+    the License.\n\n### xalan\n\nApache 2.0\n\nhttps://xml.apache.org/xalan-j/\n\ncovers
+    xalan.jar and serializer.jar\n\n                                    Apache License\n
+    \                              Version 2.0, January 2004\n                            http://www.apache.org/licenses/\n
+    \   \n       TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n    \n
+    \      1. Definitions.\n    \n          \"License\" shall mean the terms and conditions
+    for use, reproduction,\n          and distribution as defined by Sections 1 through
+    9 of this document.\n    \n          \"Licensor\" shall mean the copyright owner
+    or entity authorized by\n          the copyright owner that is granting the License.\n
+    \   \n          \"Legal Entity\" shall mean the union of the acting entity and
+    all\n          other entities that control, are controlled by, or are under common\n
+    \         control with that entity. For the purposes of this definition,\n          \"control\"
+    means (i) the power, direct or indirect, to cause the\n          direction or
+    management of such entity, whether by contract or\n          otherwise, or (ii)
+    ownership of fifty percent (50%) or more of the\n          outstanding shares,
+    or (iii) beneficial ownership of such entity.\n    \n          \"You\" (or \"Your\")
+    shall mean an individual or Legal Entity\n          exercising permissions granted
+    by this License.\n    \n          \"Source\" form shall mean the preferred form
+    for making modifications,\n          including but not limited to software source
+    code, documentation\n          source, and configuration files.\n    \n          \"Object\"
+    form shall mean any form resulting from mechanical\n          transformation or
+    translation of a Source form, including but\n          not limited to compiled
+    object code, generated documentation,\n          and conversions to other media
+    types.\n    \n          \"Work\" shall mean the work of authorship, whether in
+    Source or\n          Object form, made available under the License, as indicated
+    by a\n          copyright notice that is included in or attached to the work\n
+    \         (an example is provided in the Appendix below).\n    \n          \"Derivative
+    Works\" shall mean any work, whether in Source or Object\n          form, that
+    is based on (or derived from) the Work and for which the\n          editorial
+    revisions, annotations, elaborations, or other modifications\n          represent,
+    as a whole, an original work of authorship. For the purposes\n          of this
+    License, Derivative Works shall not include works that remain\n          separable
+    from, or merely link (or bind by name) to the interfaces of,\n          the Work
+    and Derivative Works thereof.\n    \n          \"Contribution\" shall mean any
+    work of authorship, including\n          the original version of the Work and
+    any modifications or additions\n          to that Work or Derivative Works thereof,
+    that is intentionally\n          submitted to Licensor for inclusion in the Work
+    by the copyright owner\n          or by an individual or Legal Entity authorized
+    to submit on behalf of\n          the copyright owner. For the purposes of this
+    definition, \"submitted\"\n          means any form of electronic, verbal, or
+    written communication sent\n          to the Licensor or its representatives,
+    including but not limited to\n          communication on electronic mailing lists,
+    source code control systems,\n          and issue tracking systems that are managed
+    by, or on behalf of, the\n          Licensor for the purpose of discussing and
+    improving the Work, but\n          excluding communication that is conspicuously
+    marked or otherwise\n          designated in writing by the copyright owner as
+    \"Not a Contribution.\"\n    \n          \"Contributor\" shall mean Licensor and
+    any individual or Legal Entity\n          on behalf of whom a Contribution has
+    been received by Licensor and\n          subsequently incorporated within the
+    Work.\n    \n       2. Grant of Copyright License. Subject to the terms and conditions
+    of\n          this License, each Contributor hereby grants to You a perpetual,\n
+    \         worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n          copyright
+    license to reproduce, prepare Derivative Works of,\n          publicly display,
+    publicly perform, sublicense, and distribute the\n          Work and such Derivative
+    Works in Source or Object form.\n    \n       3. Grant of Patent License. Subject
+    to the terms and conditions of\n          this License, each Contributor hereby
+    grants to You a perpetual,\n          worldwide, non-exclusive, no-charge, royalty-free,
+    irrevocable\n          (except as stated in this section) patent license to make,
+    have made,\n          use, offer to sell, sell, import, and otherwise transfer
+    the Work,\n          where such license applies only to those patent claims licensable\n
+    \         by such Contributor that are necessarily infringed by their\n          Contribution(s)
+    alone or by combination of their Contribution(s)\n          with the Work to which
+    such Contribution(s) was submitted. If You\n          institute patent litigation
+    against any entity (including a\n          cross-claim or counterclaim in a lawsuit)
+    alleging that the Work\n          or a Contribution incorporated within the Work
+    constitutes direct\n          or contributory patent infringement, then any patent
+    licenses\n          granted to You under this License for that Work shall terminate\n
+    \         as of the date such litigation is filed.\n    \n       4. Redistribution.
+    You may reproduce and distribute copies of the\n          Work or Derivative Works
+    thereof in any medium, with or without\n          modifications, and in Source
+    or Object form, provided that You\n          meet the following conditions:\n
+    \   \n          (a) You must give any other recipients of the Work or\n              Derivative
+    Works a copy of this License; and\n    \n          (b) You must cause any modified
+    files to carry prominent notices\n              stating that You changed the files;
+    and\n    \n          (c) You must retain, in the Source form of any Derivative
+    Works\n              that You distribute, all copyright, patent, trademark, and\n
+    \             attribution notices from the Source form of the Work,\n              excluding
+    those notices that do not pertain to any part of\n              the Derivative
+    Works; and\n    \n          (d) If the Work includes a \"NOTICE\" text file as
+    part of its\n              distribution, then any Derivative Works that You distribute
+    must\n              include a readable copy of the attribution notices contained\n
+    \             within such NOTICE file, excluding those notices that do not\n              pertain
+    to any part of the Derivative Works, in at least one\n              of the following
+    places: within a NOTICE text file distributed\n              as part of the Derivative
+    Works; within the Source form or\n              documentation, if provided along
+    with the Derivative Works; or,\n              within a display generated by the
+    Derivative Works, if and\n              wherever such third-party notices normally
+    appear. The contents\n              of the NOTICE file are for informational purposes
+    only and\n              do not modify the License. You may add Your own attribution\n
+    \             notices within Derivative Works that You distribute, alongside\n
+    \             or as an addendum to the NOTICE text from the Work, provided\n              that
+    such additional attribution notices cannot be construed\n              as modifying
+    the License.\n    \n          You may add Your own copyright statement to Your
+    modifications and\n          may provide additional or different license terms
+    and conditions\n          for use, reproduction, or distribution of Your modifications,
+    or\n          for any such Derivative Works as a whole, provided Your use,\n          reproduction,
+    and distribution of the Work otherwise complies with\n          the conditions
+    stated in this License.\n    \n       5. Submission of Contributions. Unless You
+    explicitly state otherwise,\n          any Contribution intentionally submitted
+    for inclusion in the Work\n          by You to the Licensor shall be under the
+    terms and conditions of\n          this License, without any additional terms
+    or conditions.\n          Notwithstanding the above, nothing herein shall supersede
+    or modify\n          the terms of any separate license agreement you may have
+    executed\n          with Licensor regarding such Contributions.\n    \n       6.
+    Trademarks. This License does not grant permission to use the trade\n          names,
+    trademarks, service marks, or product names of the Licensor,\n          except
+    as required for reasonable and customary use in describing the\n          origin
+    of the Work and reproducing the content of the NOTICE file.\n    \n       7. Disclaimer
+    of Warranty. Unless required by applicable law or\n          agreed to in writing,
+    Licensor provides the Work (and each\n          Contributor provides its Contributions)
+    on an \"AS IS\" BASIS,\n          WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+    either express or\n          implied, including, without limitation, any warranties
+    or conditions\n          of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS
+    FOR A\n          PARTICULAR PURPOSE. You are solely responsible for determining
+    the\n          appropriateness of using or redistributing the Work and assume
+    any\n          risks associated with Your exercise of permissions under this License.\n
+    \   \n       8. Limitation of Liability. In no event and under no legal theory,\n
+    \         whether in tort (including negligence), contract, or otherwise,\n          unless
+    required by applicable law (such as deliberate and grossly\n          negligent
+    acts) or agreed to in writing, shall any Contributor be\n          liable to You
+    for damages, including any direct, indirect, special,\n          incidental, or
+    consequential damages of any character arising as a\n          result of this
+    License or out of the use or inability to use the\n          Work (including but
+    not limited to damages for loss of goodwill,\n          work stoppage, computer
+    failure or malfunction, or any and all\n          other commercial damages or
+    losses), even if such Contributor\n          has been advised of the possibility
+    of such damages.\n    \n       9. Accepting Warranty or Additional Liability.
+    While redistributing\n          the Work or Derivative Works thereof, You may
+    choose to offer,\n          and charge a fee for, acceptance of support, warranty,
+    indemnity,\n          or other liability obligations and/or rights consistent
+    with this\n          License. However, in accepting such obligations, You may
+    act only\n          on Your own behalf and on Your sole responsibility, not on
+    behalf\n          of any other Contributor, and only if You agree to indemnify,\n
+    \         defend, and hold each Contributor harmless for any liability\n          incurred
+    by, or claims asserted against, such Contributor by reason\n          of your
+    accepting any such warranty or additional liability.\n    \n       END OF TERMS
+    AND CONDITIONS\n    \n       APPENDIX: How to apply the Apache License to your
+    work.\n    \n          To apply the Apache License to your work, attach the following\n
+    \         boilerplate notice, with the fields enclosed by brackets \"[]\"\n          replaced
+    with your own identifying information. (Don't include\n          the brackets!)
+    \ The text should be enclosed in the appropriate\n          comment syntax for
+    the file format. We also recommend that a\n          file or class name and description
+    of purpose be included on the\n          same \"printed page\" as the copyright
+    notice for easier\n          identification within third-party archives.\n    \n
+    \      Copyright [yyyy] [name of copyright owner]\n    \n       Licensed under
+    the Apache License, Version 2.0 (the \"License\");\n       you may not use this
+    file except in compliance with the License.\n       You may obtain a copy of the
+    License at\n    \n           http://www.apache.org/licenses/LICENSE-2.0\n    \n
+    \      Unless required by applicable law or agreed to in writing, software\n       distributed
+    under the License is distributed on an \"AS IS\" BASIS,\n       WITHOUT WARRANTIES
+    OR CONDITIONS OF ANY KIND, either express or implied.\n       See the License
+    for the specific language governing permissions and\n       limitations under
+    the License.\n    \n\n### xerces\n\nApache 2.0\n\nhttps://xerces.apache.org/xerces2-j/\n\n
+    \   \n                                     Apache License\n                               Version
+    2.0, January 2004\n                            http://www.apache.org/licenses/\n
+    \   \n       TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n    \n
+    \      1. Definitions.\n    \n          \"License\" shall mean the terms and conditions
+    for use, reproduction,\n          and distribution as defined by Sections 1 through
+    9 of this document.\n    \n          \"Licensor\" shall mean the copyright owner
+    or entity authorized by\n          the copyright owner that is granting the License.\n
+    \   \n          \"Legal Entity\" shall mean the union of the acting entity and
+    all\n          other entities that control, are controlled by, or are under common\n
+    \         control with that entity. For the purposes of this definition,\n          \"control\"
+    means (i) the power, direct or indirect, to cause the\n          direction or
+    management of such entity, whether by contract or\n          otherwise, or (ii)
+    ownership of fifty percent (50%) or more of the\n          outstanding shares,
+    or (iii) beneficial ownership of such entity.\n    \n          \"You\" (or \"Your\")
+    shall mean an individual or Legal Entity\n          exercising permissions granted
+    by this License.\n    \n          \"Source\" form shall mean the preferred form
+    for making modifications,\n          including but not limited to software source
+    code, documentation\n          source, and configuration files.\n    \n          \"Object\"
+    form shall mean any form resulting from mechanical\n          transformation or
+    translation of a Source form, including but\n          not limited to compiled
+    object code, generated documentation,\n          and conversions to other media
+    types.\n    \n          \"Work\" shall mean the work of authorship, whether in
+    Source or\n          Object form, made available under the License, as indicated
+    by a\n          copyright notice that is included in or attached to the work\n
+    \         (an example is provided in the Appendix below).\n    \n          \"Derivative
+    Works\" shall mean any work, whether in Source or Object\n          form, that
+    is based on (or derived from) the Work and for which the\n          editorial
+    revisions, annotations, elaborations, or other modifications\n          represent,
+    as a whole, an original work of authorship. For the purposes\n          of this
+    License, Derivative Works shall not include works that remain\n          separable
+    from, or merely link (or bind by name) to the interfaces of,\n          the Work
+    and Derivative Works thereof.\n    \n          \"Contribution\" shall mean any
+    work of authorship, including\n          the original version of the Work and
+    any modifications or additions\n          to that Work or Derivative Works thereof,
+    that is intentionally\n          submitted to Licensor for inclusion in the Work
+    by the copyright owner\n          or by an individual or Legal Entity authorized
+    to submit on behalf of\n          the copyright owner. For the purposes of this
+    definition, \"submitted\"\n          means any form of electronic, verbal, or
+    written communication sent\n          to the Licensor or its representatives,
+    including but not limited to\n          communication on electronic mailing lists,
+    source code control systems,\n          and issue tracking systems that are managed
+    by, or on behalf of, the\n          Licensor for the purpose of discussing and
+    improving the Work, but\n          excluding communication that is conspicuously
+    marked or otherwise\n          designated in writing by the copyright owner as
+    \"Not a Contribution.\"\n    \n          \"Contributor\" shall mean Licensor and
+    any individual or Legal Entity\n          on behalf of whom a Contribution has
+    been received by Licensor and\n          subsequently incorporated within the
+    Work.\n    \n       2. Grant of Copyright License. Subject to the terms and conditions
+    of\n          this License, each Contributor hereby grants to You a perpetual,\n
+    \         worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n          copyright
+    license to reproduce, prepare Derivative Works of,\n          publicly display,
+    publicly perform, sublicense, and distribute the\n          Work and such Derivative
+    Works in Source or Object form.\n    \n       3. Grant of Patent License. Subject
+    to the terms and conditions of\n          this License, each Contributor hereby
+    grants to You a perpetual,\n          worldwide, non-exclusive, no-charge, royalty-free,
+    irrevocable\n          (except as stated in this section) patent license to make,
+    have made,\n          use, offer to sell, sell, import, and otherwise transfer
+    the Work,\n          where such license applies only to those patent claims licensable\n
+    \         by such Contributor that are necessarily infringed by their\n          Contribution(s)
+    alone or by combination of their Contribution(s)\n          with the Work to which
+    such Contribution(s) was submitted. If You\n          institute patent litigation
+    against any entity (including a\n          cross-claim or counterclaim in a lawsuit)
+    alleging that the Work\n          or a Contribution incorporated within the Work
+    constitutes direct\n          or contributory patent infringement, then any patent
+    licenses\n          granted to You under this License for that Work shall terminate\n
+    \         as of the date such litigation is filed.\n    \n       4. Redistribution.
+    You may reproduce and distribute copies of the\n          Work or Derivative Works
+    thereof in any medium, with or without\n          modifications, and in Source
+    or Object form, provided that You\n          meet the following conditions:\n
+    \   \n          (a) You must give any other recipients of the Work or\n              Derivative
+    Works a copy of this License; and\n    \n          (b) You must cause any modified
+    files to carry prominent notices\n              stating that You changed the files;
+    and\n    \n          (c) You must retain, in the Source form of any Derivative
+    Works\n              that You distribute, all copyright, patent, trademark, and\n
+    \             attribution notices from the Source form of the Work,\n              excluding
+    those notices that do not pertain to any part of\n              the Derivative
+    Works; and\n    \n          (d) If the Work includes a \"NOTICE\" text file as
+    part of its\n              distribution, then any Derivative Works that You distribute
+    must\n              include a readable copy of the attribution notices contained\n
+    \             within such NOTICE file, excluding those notices that do not\n              pertain
+    to any part of the Derivative Works, in at least one\n              of the following
+    places: within a NOTICE text file distributed\n              as part of the Derivative
+    Works; within the Source form or\n              documentation, if provided along
+    with the Derivative Works; or,\n              within a display generated by the
+    Derivative Works, if and\n              wherever such third-party notices normally
+    appear. The contents\n              of the NOTICE file are for informational purposes
+    only and\n              do not modify the License. You may add Your own attribution\n
+    \             notices within Derivative Works that You distribute, alongside\n
+    \             or as an addendum to the NOTICE text from the Work, provided\n              that
+    such additional attribution notices cannot be construed\n              as modifying
+    the License.\n    \n          You may add Your own copyright statement to Your
+    modifications and\n          may provide additional or different license terms
+    and conditions\n          for use, reproduction, or distribution of Your modifications,
+    or\n          for any such Derivative Works as a whole, provided Your use,\n          reproduction,
+    and distribution of the Work otherwise complies with\n          the conditions
+    stated in this License.\n    \n       5. Submission of Contributions. Unless You
+    explicitly state otherwise,\n          any Contribution intentionally submitted
+    for inclusion in the Work\n          by You to the Licensor shall be under the
+    terms and conditions of\n          this License, without any additional terms
+    or conditions.\n          Notwithstanding the above, nothing herein shall supersede
+    or modify\n          the terms of any separate license agreement you may have
+    executed\n          with Licensor regarding such Contributions.\n    \n       6.
+    Trademarks. This License does not grant permission to use the trade\n          names,
+    trademarks, service marks, or product names of the Licensor,\n          except
+    as required for reasonable and customary use in describing the\n          origin
+    of the Work and reproducing the content of the NOTICE file.\n    \n       7. Disclaimer
+    of Warranty. Unless required by applicable law or\n          agreed to in writing,
+    Licensor provides the Work (and each\n          Contributor provides its Contributions)
+    on an \"AS IS\" BASIS,\n          WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+    either express or\n          implied, including, without limitation, any warranties
+    or conditions\n          of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS
+    FOR A\n          PARTICULAR PURPOSE. You are solely responsible for determining
+    the\n          appropriateness of using or redistributing the Work and assume
+    any\n          risks associated with Your exercise of permissions under this License.\n
+    \   \n       8. Limitation of Liability. In no event and under no legal theory,\n
+    \         whether in tort (including negligence), contract, or otherwise,\n          unless
+    required by applicable law (such as deliberate and grossly\n          negligent
+    acts) or agreed to in writing, shall any Contributor be\n          liable to You
+    for damages, including any direct, indirect, special,\n          incidental, or
+    consequential damages of any character arising as a\n          result of this
+    License or out of the use or inability to use the\n          Work (including but
+    not limited to damages for loss of goodwill,\n          work stoppage, computer
+    failure or malfunction, or any and all\n          other commercial damages or
+    losses), even if such Contributor\n          has been advised of the possibility
+    of such damages.\n    \n       9. Accepting Warranty or Additional Liability.
+    While redistributing\n          the Work or Derivative Works thereof, You may
+    choose to offer,\n          and charge a fee for, acceptance of support, warranty,
+    indemnity,\n          or other liability obligations and/or rights consistent
+    with this\n          License. However, in accepting such obligations, You may
+    act only\n          on Your own behalf and on Your sole responsibility, not on
+    behalf\n          of any other Contributor, and only if You agree to indemnify,\n
+    \         defend, and hold each Contributor harmless for any liability\n          incurred
+    by, or claims asserted against, such Contributor by reason\n          of your
+    accepting any such warranty or additional liability.\n    \n       END OF TERMS
+    AND CONDITIONS\n    \n       APPENDIX: How to apply the Apache License to your
+    work.\n    \n          To apply the Apache License to your work, attach the following\n
+    \         boilerplate notice, with the fields enclosed by brackets \"[]\"\n          replaced
+    with your own identifying information. (Don't include\n          the brackets!)
+    \ The text should be enclosed in the appropriate\n          comment syntax for
+    the file format. We also recommend that a\n          file or class name and description
+    of purpose be included on the\n          same \"printed page\" as the copyright
+    notice for easier\n          identification within third-party archives.\n    \n
+    \      Copyright [yyyy] [name of copyright owner]\n    \n       Licensed under
+    the Apache License, Version 2.0 (the \"License\");\n       you may not use this
+    file except in compliance with the License.\n       You may obtain a copy of the
+    License at\n    \n           http://www.apache.org/licenses/LICENSE-2.0\n    \n
+    \      Unless required by applicable law or agreed to in writing, software\n       distributed
+    under the License is distributed on an \"AS IS\" BASIS,\n       WITHOUT WARRANTIES
+    OR CONDITIONS OF ANY KIND, either express or implied.\n       See the License
+    for the specific language governing permissions and\n       limitations under
+    the License.\n    \n\n### xml-apis\n\nApache 2.0\n\nhttps://xerces.apache.org/xml-commons/\n\n
+    \   Unless otherwise noted all files in XML Commons are covered under the\n    Apache
+    License Version 2.0. Please read the LICENSE and NOTICE files.\n    \n    XML
+    Commons contains some software and documentation that is covered\n    under a
+    number of different licenses. This applies particularly to the\n    xml-commons/java/external/
+    directory. Most files under\n    xml-commons/java/external/ are covered under
+    their respective\n    LICENSE.*.txt files; see the matching README.*.txt files
+    for\n    descriptions.\n\n    \n                                     Apache License\n
+    \                              Version 2.0, January 2004\n                            http://www.apache.org/licenses/\n
+    \   \n       TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n    \n
+    \      1. Definitions.\n    \n          \"License\" shall mean the terms and conditions
+    for use, reproduction,\n          and distribution as defined by Sections 1 through
+    9 of this document.\n    \n          \"Licensor\" shall mean the copyright owner
+    or entity authorized by\n          the copyright owner that is granting the License.\n
+    \   \n          \"Legal Entity\" shall mean the union of the acting entity and
+    all\n          other entities that control, are controlled by, or are under common\n
+    \         control with that entity. For the purposes of this definition,\n          \"control\"
+    means (i) the power, direct or indirect, to cause the\n          direction or
+    management of such entity, whether by contract or\n          otherwise, or (ii)
+    ownership of fifty percent (50%) or more of the\n          outstanding shares,
+    or (iii) beneficial ownership of such entity.\n    \n          \"You\" (or \"Your\")
+    shall mean an individual or Legal Entity\n          exercising permissions granted
+    by this License.\n    \n          \"Source\" form shall mean the preferred form
+    for making modifications,\n          including but not limited to software source
+    code, documentation\n          source, and configuration files.\n    \n          \"Object\"
+    form shall mean any form resulting from mechanical\n          transformation or
+    translation of a Source form, including but\n          not limited to compiled
+    object code, generated documentation,\n          and conversions to other media
+    types.\n    \n          \"Work\" shall mean the work of authorship, whether in
+    Source or\n          Object form, made available under the License, as indicated
+    by a\n          copyright notice that is included in or attached to the work\n
+    \         (an example is provided in the Appendix below).\n    \n          \"Derivative
+    Works\" shall mean any work, whether in Source or Object\n          form, that
+    is based on (or derived from) the Work and for which the\n          editorial
+    revisions, annotations, elaborations, or other modifications\n          represent,
+    as a whole, an original work of authorship. For the purposes\n          of this
+    License, Derivative Works shall not include works that remain\n          separable
+    from, or merely link (or bind by name) to the interfaces of,\n          the Work
+    and Derivative Works thereof.\n    \n          \"Contribution\" shall mean any
+    work of authorship, including\n          the original version of the Work and
+    any modifications or additions\n          to that Work or Derivative Works thereof,
+    that is intentionally\n          submitted to Licensor for inclusion in the Work
+    by the copyright owner\n          or by an individual or Legal Entity authorized
+    to submit on behalf of\n          the copyright owner. For the purposes of this
+    definition, \"submitted\"\n          means any form of electronic, verbal, or
+    written communication sent\n          to the Licensor or its representatives,
+    including but not limited to\n          communication on electronic mailing lists,
+    source code control systems,\n          and issue tracking systems that are managed
+    by, or on behalf of, the\n          Licensor for the purpose of discussing and
+    improving the Work, but\n          excluding communication that is conspicuously
+    marked or otherwise\n          designated in writing by the copyright owner as
+    \"Not a Contribution.\"\n    \n          \"Contributor\" shall mean Licensor and
+    any individual or Legal Entity\n          on behalf of whom a Contribution has
+    been received by Licensor and\n          subsequently incorporated within the
+    Work.\n    \n       2. Grant of Copyright License. Subject to the terms and conditions
+    of\n          this License, each Contributor hereby grants to You a perpetual,\n
+    \         worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n          copyright
+    license to reproduce, prepare Derivative Works of,\n          publicly display,
+    publicly perform, sublicense, and distribute the\n          Work and such Derivative
+    Works in Source or Object form.\n    \n       3. Grant of Patent License. Subject
+    to the terms and conditions of\n          this License, each Contributor hereby
+    grants to You a perpetual,\n          worldwide, non-exclusive, no-charge, royalty-free,
+    irrevocable\n          (except as stated in this section) patent license to make,
+    have made,\n          use, offer to sell, sell, import, and otherwise transfer
+    the Work,\n          where such license applies only to those patent claims licensable\n
+    \         by such Contributor that are necessarily infringed by their\n          Contribution(s)
+    alone or by combination of their Contribution(s)\n          with the Work to which
+    such Contribution(s) was submitted. If You\n          institute patent litigation
+    against any entity (including a\n          cross-claim or counterclaim in a lawsuit)
+    alleging that the Work\n          or a Contribution incorporated within the Work
+    constitutes direct\n          or contributory patent infringement, then any patent
+    licenses\n          granted to You under this License for that Work shall terminate\n
+    \         as of the date such litigation is filed.\n    \n       4. Redistribution.
+    You may reproduce and distribute copies of the\n          Work or Derivative Works
+    thereof in any medium, with or without\n          modifications, and in Source
+    or Object form, provided that You\n          meet the following conditions:\n
+    \   \n          (a) You must give any other recipients of the Work or\n              Derivative
+    Works a copy of this License; and\n    \n          (b) You must cause any modified
+    files to carry prominent notices\n              stating that You changed the files;
+    and\n    \n          (c) You must retain, in the Source form of any Derivative
+    Works\n              that You distribute, all copyright, patent, trademark, and\n
+    \             attribution notices from the Source form of the Work,\n              excluding
+    those notices that do not pertain to any part of\n              the Derivative
+    Works; and\n    \n          (d) If the Work includes a \"NOTICE\" text file as
+    part of its\n              distribution, then any Derivative Works that You distribute
+    must\n              include a readable copy of the attribution notices contained\n
+    \             within such NOTICE file, excluding those notices that do not\n              pertain
+    to any part of the Derivative Works, in at least one\n              of the following
+    places: within a NOTICE text file distributed\n              as part of the Derivative
+    Works; within the Source form or\n              documentation, if provided along
+    with the Derivative Works; or,\n              within a display generated by the
+    Derivative Works, if and\n              wherever such third-party notices normally
+    appear. The contents\n              of the NOTICE file are for informational purposes
+    only and\n              do not modify the License. You may add Your own attribution\n
+    \             notices within Derivative Works that You distribute, alongside\n
+    \             or as an addendum to the NOTICE text from the Work, provided\n              that
+    such additional attribution notices cannot be construed\n              as modifying
+    the License.\n    \n          You may add Your own copyright statement to Your
+    modifications and\n          may provide additional or different license terms
+    and conditions\n          for use, reproduction, or distribution of Your modifications,
+    or\n          for any such Derivative Works as a whole, provided Your use,\n          reproduction,
+    and distribution of the Work otherwise complies with\n          the conditions
+    stated in this License.\n    \n       5. Submission of Contributions. Unless You
+    explicitly state otherwise,\n          any Contribution intentionally submitted
+    for inclusion in the Work\n          by You to the Licensor shall be under the
+    terms and conditions of\n          this License, without any additional terms
+    or conditions.\n          Notwithstanding the above, nothing herein shall supersede
+    or modify\n          the terms of any separate license agreement you may have
+    executed\n          with Licensor regarding such Contributions.\n    \n       6.
+    Trademarks. This License does not grant permission to use the trade\n          names,
+    trademarks, service marks, or product names of the Licensor,\n          except
+    as required for reasonable and customary use in describing the\n          origin
+    of the Work and reproducing the content of the NOTICE file.\n    \n       7. Disclaimer
+    of Warranty. Unless required by applicable law or\n          agreed to in writing,
+    Licensor provides the Work (and each\n          Contributor provides its Contributions)
+    on an \"AS IS\" BASIS,\n          WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+    either express or\n          implied, including, without limitation, any warranties
+    or conditions\n          of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS
+    FOR A\n          PARTICULAR PURPOSE. You are solely responsible for determining
+    the\n          appropriateness of using or redistributing the Work and assume
+    any\n          risks associated with Your exercise of permissions under this License.\n
+    \   \n       8. Limitation of Liability. In no event and under no legal theory,\n
+    \         whether in tort (including negligence), contract, or otherwise,\n          unless
+    required by applicable law (such as deliberate and grossly\n          negligent
+    acts) or agreed to in writing, shall any Contributor be\n          liable to You
+    for damages, including any direct, indirect, special,\n          incidental, or
+    consequential damages of any character arising as a\n          result of this
+    License or out of the use or inability to use the\n          Work (including but
+    not limited to damages for loss of goodwill,\n          work stoppage, computer
+    failure or malfunction, or any and all\n          other commercial damages or
+    losses), even if such Contributor\n          has been advised of the possibility
+    of such damages.\n    \n       9. Accepting Warranty or Additional Liability.
+    While redistributing\n          the Work or Derivative Works thereof, You may
+    choose to offer,\n          and charge a fee for, acceptance of support, warranty,
+    indemnity,\n          or other liability obligations and/or rights consistent
+    with this\n          License. However, in accepting such obligations, You may
+    act only\n          on Your own behalf and on Your sole responsibility, not on
+    behalf\n          of any other Contributor, and only if You agree to indemnify,\n
+    \         defend, and hold each Contributor harmless for any liability\n          incurred
+    by, or claims asserted against, such Contributor by reason\n          of your
+    accepting any such warranty or additional liability.\n    \n       END OF TERMS
+    AND CONDITIONS\n    \n       APPENDIX: How to apply the Apache License to your
+    work.\n    \n          To apply the Apache License to your work, attach the following\n
+    \         boilerplate notice, with the fields enclosed by brackets \"[]\"\n          replaced
+    with your own identifying information. (Don't include\n          the brackets!)
+    \ The text should be enclosed in the appropriate\n          comment syntax for
+    the file format. We also recommend that a\n          file or class name and description
+    of purpose be included on the\n          same \"printed page\" as the copyright
+    notice for easier\n          identification within third-party archives.\n    \n
+    \      Copyright [yyyy] [name of copyright owner]\n    \n       Licensed under
+    the Apache License, Version 2.0 (the \"License\");\n       you may not use this
+    file except in compliance with the License.\n       You may obtain a copy of the
+    License at\n    \n           http://www.apache.org/licenses/LICENSE-2.0\n    \n
+    \      Unless required by applicable law or agreed to in writing, software\n       distributed
+    under the License is distributed on an \"AS IS\" BASIS,\n       WITHOUT WARRANTIES
+    OR CONDITIONS OF ANY KIND, either express or implied.\n       See the License
+    for the specific language governing permissions and\n       limitations under
+    the License.\n"
+- sources: README.md
+  text: |-
+    This project is licensed under the terms of the MIT license.
+
+    See this license at [`LICENSE.md`](LICENSE.md).
+notices: []

--- a/.licenses/bundler/octokit.dep.yml
+++ b/.licenses/bundler/octokit.dep.yml
@@ -1,0 +1,53 @@
+---
+name: octokit
+version: 4.21.0
+type: bundler
+summary: Ruby toolkit for working with the GitHub API
+homepage: https://github.com/octokit/octokit.rb
+license: mit
+licenses:
+- sources: LICENSE.md
+  text: |
+    Copyright (c) 2009-2017 Wynn Netherland, Adam Stacoviak, Erik Michaels-Ober
+
+    Permission is hereby granted, free of charge, to any person obtaining
+    a copy of this software and associated documentation files (the
+    "Software"), to deal in the Software without restriction, including
+    without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to
+    permit persons to whom the Software is furnished to do so, subject to
+    the following conditions:
+
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+    LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+    OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+    WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+- sources: README.md
+  text: |-
+    Copyright (c) 2009-2014 Wynn Netherland, Adam Stacoviak, Erik Michaels-Ober
+
+    Permission is hereby granted, free of charge, to any person obtaining
+    a copy of this software and associated documentation files (the
+    "Software"), to deal in the Software without restriction, including
+    without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to
+    permit persons to whom the Software is furnished to do so, subject to
+    the following conditions:
+
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+    LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+    OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+    WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+notices: []

--- a/.licenses/bundler/parallel.dep.yml
+++ b/.licenses/bundler/parallel.dep.yml
@@ -1,0 +1,31 @@
+---
+name: parallel
+version: 1.21.0
+type: bundler
+summary: Run any kind of code in parallel processes
+homepage: https://github.com/grosser/parallel
+license: mit
+licenses:
+- sources: MIT-LICENSE.txt
+  text: |
+    Copyright (C) 2013 Michael Grosser <michael@grosser.it>
+
+    Permission is hereby granted, free of charge, to any person obtaining
+    a copy of this software and associated documentation files (the
+    "Software"), to deal in the Software without restriction, including
+    without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to
+    permit persons to whom the Software is furnished to do so, subject to
+    the following conditions:
+
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+    LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+    OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+    WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+notices: []

--- a/.licenses/bundler/pathname-common_prefix.dep.yml
+++ b/.licenses/bundler/pathname-common_prefix.dep.yml
@@ -1,0 +1,13 @@
+---
+name: pathname-common_prefix
+version: 0.0.1
+type: bundler
+summary: Calcurate prefix commont to some pathnames
+homepage: https://github.com/KitaitiMakoto/pathname-common_prefix
+license: other
+licenses:
+- sources: README.markdown
+  text: |-
+    This program is distributed under the Ruby's license.
+    But `setup.rb` is distributed under the GNU LGPS license. See the file for more information.
+notices: []

--- a/.licenses/bundler/public_suffix.dep.yml
+++ b/.licenses/bundler/public_suffix.dep.yml
@@ -1,0 +1,38 @@
+---
+name: public_suffix
+version: 4.0.6
+type: bundler
+summary: Domain name parser based on the Public Suffix List.
+homepage: https://simonecarletti.com/code/publicsuffix-ruby
+license: mit
+licenses:
+- sources: LICENSE.txt
+  text: |
+    Copyright (c) 2009-2020 Simone Carletti <weppos@weppos.net>
+
+    MIT License
+
+    Permission is hereby granted, free of charge, to any person obtaining
+    a copy of this software and associated documentation files (the
+    "Software"), to deal in the Software without restriction, including
+    without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to
+    permit persons to whom the Software is furnished to do so, subject to
+    the following conditions:
+
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+    LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+    OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+    WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+- sources: README.md
+  text: |-
+    Copyright (c) 2009-2020 Simone Carletti. This is Free Software distributed under the MIT license.
+
+    The [Public Suffix List source](https://publicsuffix.org/list/) is subject to the terms of the Mozilla Public License, v. 2.0.
+notices: []

--- a/.licenses/bundler/racc.dep.yml
+++ b/.licenses/bundler/racc.dep.yml
@@ -1,0 +1,39 @@
+---
+name: racc
+version: 1.6.0
+type: bundler
+summary: Racc is a LALR(1) parser generator
+homepage: https://i.loveruby.net/en/projects/racc/
+license: other
+licenses:
+- sources: COPYING
+  text: |
+    Copyright (C) 2019 Yukihiro Matsumoto. All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+    1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+    ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+    ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+    OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+    HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+    OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+    SUCH DAMAGE.
+- sources: README.rdoc
+  text: |-
+    Racc is distributed under the same terms of ruby.
+      (see the file COPYING). Note that you do NOT need to follow
+      ruby license for your own parser (racc outputs).
+      You can distribute those files under any licenses you want.
+notices: []

--- a/.licenses/bundler/reverse_markdown.dep.yml
+++ b/.licenses/bundler/reverse_markdown.dep.yml
@@ -1,0 +1,24 @@
+---
+name: reverse_markdown
+version: 1.4.0
+type: bundler
+summary: Convert html code into markdown.
+homepage: http://github.com/xijo/reverse_markdown
+license: wtfpl
+licenses:
+- sources: LICENSE
+  text: |2
+                DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+                        Version 2, December 2004
+
+     Copyright (C) 2014 Johannes Opper <xijo@gmx.de>
+
+     Everyone is permitted to copy and distribute verbatim or modified
+     copies of this license document, and changing it is allowed as long
+     as the name is changed.
+
+                DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+       TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+      0. You just DO WHAT THE FUCK YOU WANT TO.
+notices: []

--- a/.licenses/bundler/ruby-xxHash.dep.yml
+++ b/.licenses/bundler/ruby-xxHash.dep.yml
@@ -1,0 +1,33 @@
+---
+name: ruby-xxHash
+version: 0.4.0.1
+type: bundler
+summary: A pure Ruby implementation of xxhash.
+homepage: https://github.com/justinwsmith/ruby-xxhash
+license: mit
+licenses:
+- sources: LICENSE.txt
+  text: |
+    Copyright (c) 2014 Justin W Smith
+
+    MIT License
+
+    Permission is hereby granted, free of charge, to any person obtaining
+    a copy of this software and associated documentation files (the
+    "Software"), to deal in the Software without restriction, including
+    without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to
+    permit persons to whom the Software is furnished to do so, subject to
+    the following conditions:
+
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+    LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+    OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+    WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+notices: []

--- a/.licenses/bundler/ruby2_keywords.dep.yml
+++ b/.licenses/bundler/ruby2_keywords.dep.yml
@@ -1,0 +1,42 @@
+---
+name: ruby2_keywords
+version: 0.0.5
+type: bundler
+summary: Shim library for Module#ruby2_keywords
+homepage: https://github.com/ruby/ruby2_keywords
+license: other
+licenses:
+- sources: LICENSE
+  text: |
+    Copyright 2019-2020 Nobuyoshi Nakada, Yusuke Endoh
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+    ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+- sources: README.md
+  text: |-
+    The gem is available as open source under the terms of the
+    [Ruby License] or the [2-Clause BSD License].
+
+    [GitHub]: https://github.com/ruby/ruby2_keywords/
+    [Ruby Issue Tracking System]: https://bugs.ruby-lang.org
+    [Ruby License]: https://www.ruby-lang.org/en/about/license.txt
+    [2-Clause BSD License]: https://opensource.org/licenses/BSD-2-Clause
+notices: []

--- a/.licenses/bundler/rugged.dep.yml
+++ b/.licenses/bundler/rugged.dep.yml
@@ -1,0 +1,35 @@
+---
+name: rugged
+version: 1.2.0
+type: bundler
+summary: Rugged is a Ruby binding to the libgit2 linkable library
+homepage: https://github.com/libgit2/rugged
+license: mit
+licenses:
+- sources: LICENSE
+  text: |
+    The MIT License
+
+    Copyright (c) 2016 GitHub, Inc
+    Copyright (c) Rugged Contributors
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+- sources: README.md
+  text: MIT. See LICENSE file.
+notices: []

--- a/.licenses/bundler/sawyer.dep.yml
+++ b/.licenses/bundler/sawyer.dep.yml
@@ -1,0 +1,33 @@
+---
+name: sawyer
+version: 0.8.2
+type: bundler
+summary: Secret User Agent of HTTP
+homepage: https://github.com/lostisland/sawyer
+license: mit
+licenses:
+- sources: LICENSE.md
+  text: |
+    Copyright (c) 2011 rick olson
+
+    Permission is hereby granted, free of charge, to any person obtaining
+    a copy of this software and associated documentation files (the
+    "Software"), to deal in the Software without restriction, including
+    without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to
+    permit persons to whom the Software is furnished to do so, subject to
+    the following conditions:
+
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+    LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+    OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+    WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+- sources: README.md
+  text: The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
+notices: []

--- a/.licenses/bundler/thor.dep.yml
+++ b/.licenses/bundler/thor.dep.yml
@@ -1,0 +1,36 @@
+---
+name: thor
+version: 1.1.0
+type: bundler
+summary: Thor is a toolkit for building powerful command-line interfaces.
+homepage: http://whatisthor.com/
+license: mit
+licenses:
+- sources: LICENSE.md
+  text: |
+    Copyright (c) 2008 Yehuda Katz, Eric Hodel, et al.
+
+    Permission is hereby granted, free of charge, to any person obtaining
+    a copy of this software and associated documentation files (the
+    "Software"), to deal in the Software without restriction, including
+    without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to
+    permit persons to whom the Software is furnished to do so, subject to
+    the following conditions:
+
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+    LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+    OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+    WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+- sources: README.md
+  text: |-
+    Released under the MIT License.  See the [LICENSE][] file for further details.
+
+    [license]: LICENSE.md
+notices: []

--- a/.licenses/bundler/tomlrb.dep.yml
+++ b/.licenses/bundler/tomlrb.dep.yml
@@ -1,0 +1,32 @@
+---
+name: tomlrb
+version: 2.0.1
+type: bundler
+summary: A racc based toml parser
+homepage: https://github.com/fbernier/tomlrb
+license: mit
+licenses:
+- sources: LICENSE.txt
+  text: |
+    The MIT License (MIT)
+
+    Copyright (c) 2015 Francois Bernier
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+notices: []

--- a/test/fixtures/cli/.licensed.yml
+++ b/test/fixtures/cli/.licensed.yml
@@ -3,3 +3,5 @@ ignored:
   bundler:
     # in CI, bundler is set up pretty wonky and isn't found at the expected location
     - "bundler"
+
+cache_path: .licenses_test


### PR DESCRIPTION
ref https://github.com/github/licensed/issues/418

This adds a workflow to the repo that uses https://github.com/jonabc/licensed-ci to keep cached license files up to date.  I've added comments around most configuration of the workflow because this might be the first place that someone sees the action and it's helpful to understand what it's doing 😄 