### PR TITLE
License updates for yarn-handle-malformed-json

### DIFF
--- a/.licenses/bundler/faraday-multipart.dep.yml
+++ b/.licenses/bundler/faraday-multipart.dep.yml
@@ -1,17 +1,16 @@
 ---
-name: bundler
-version: 2.3.4
+name: faraday-multipart
+version: 1.0.2
 type: bundler
-summary: The best way to manage your application's dependencies
-homepage: https://bundler.io
+summary: Perform multipart-post requests using Faraday.
+homepage: https://github.com/lostisland/faraday-multipart
 license: mit
 licenses:
 - sources: LICENSE.md
   text: |
-    The MIT License
+    The MIT License (MIT)
 
-    Portions copyright (c) 2010-2019 André Arko
-    Portions copyright (c) 2009 Engine Yard
+    Copyright (c) 2022 The Faraday Team
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal
@@ -31,5 +30,5 @@ licenses:
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
     THE SOFTWARE.
 - sources: README.md
-  text: Bundler is available under an [MIT License](https://github.com/rubygems/rubygems/blob/master/bundler/LICENSE.md).
+  text: The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
 notices: []

--- a/.licenses/bundler/faraday-retry.dep.yml
+++ b/.licenses/bundler/faraday-retry.dep.yml
@@ -1,17 +1,16 @@
 ---
-name: bundler
-version: 2.3.4
+name: faraday-retry
+version: 1.0.3
 type: bundler
-summary: The best way to manage your application's dependencies
-homepage: https://bundler.io
+summary: Catches exceptions and retries each request a limited number of times
+homepage: https://github.com/lostisland/faraday-retry
 license: mit
 licenses:
 - sources: LICENSE.md
   text: |
-    The MIT License
+    The MIT License (MIT)
 
-    Portions copyright (c) 2010-2019 André Arko
-    Portions copyright (c) 2009 Engine Yard
+    Copyright (c) 2021 Mattia Giuffrida
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal
@@ -31,5 +30,8 @@ licenses:
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
     THE SOFTWARE.
 - sources: README.md
-  text: Bundler is available under an [MIT License](https://github.com/rubygems/rubygems/blob/master/bundler/LICENSE.md).
+  text: |-
+    The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
+
+    [raise_error]:  https://lostisland.github.io/faraday/middleware/raise-error
 notices: []

--- a/.licenses/bundler/faraday.dep.yml
+++ b/.licenses/bundler/faraday.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: faraday
-version: 1.8.0
+version: 1.9.3
 type: bundler
 summary: HTTP/REST API client library.
 homepage: https://lostisland.github.io/faraday

--- a/.licenses/bundler/nokogiri.dep.yml
+++ b/.licenses/bundler/nokogiri.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: nokogiri
-version: 1.12.5
+version: 1.13.0
 type: bundler
 summary: Nokogiri (鋸) makes it easy and painless to work with XML and HTML from Ruby.
 homepage: https://nokogiri.org

--- a/.licenses/bundler/rugged.dep.yml
+++ b/.licenses/bundler/rugged.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: rugged
-version: 1.2.0
+version: 1.3.0
 type: bundler
 summary: Rugged is a Ruby binding to the libgit2 linkable library
 homepage: https://github.com/libgit2/rugged

--- a/.licenses/bundler/thor.dep.yml
+++ b/.licenses/bundler/thor.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: thor
-version: 1.1.0
+version: 1.2.1
 type: bundler
 summary: Thor is a toolkit for building powerful command-line interfaces.
 homepage: http://whatisthor.com/

--- a/test/fixtures/bundler/Gemfile
+++ b/test/fixtures/bundler/Gemfile
@@ -32,4 +32,4 @@ gem "mini_racer", "0.3.1"
 # verify https://github.com/github/licensed/issues/153
 gem "aws-sdk-core", "3.39.0"
 
-gem "thor", git: "https://github.com/rails/thor", tag: "1.2.1"
+gem "thor", git: "https://github.com/rails/thor", tag: "v1.2.1"

--- a/test/fixtures/bundler/Gemfile
+++ b/test/fixtures/bundler/Gemfile
@@ -32,4 +32,4 @@ gem "mini_racer", "0.3.1"
 # verify https://github.com/github/licensed/issues/153
 gem "aws-sdk-core", "3.39.0"
 
-gem "thor", git: "https://github.com/erikhuda/thor", tag: "1.2.1"
+gem "thor", git: "https://github.com/rails/thor", tag: "1.2.1"

--- a/test/fixtures/bundler/Gemfile
+++ b/test/fixtures/bundler/Gemfile
@@ -32,4 +32,4 @@ gem "mini_racer", "0.3.1"
 # verify https://github.com/github/licensed/issues/153
 gem "aws-sdk-core", "3.39.0"
 
-gem "thor", git: "https://github.com/erikhuda/thor"
+gem "thor", git: "https://github.com/erikhuda/thor", tag: "1.2.1"


### PR DESCRIPTION
This PR was auto generated by the `licensed-ci` GitHub Action.
It contains updates to cached `github/licensed` dependency metadata to be merged into `yarn-handle-malformed-json`: ([branch](https://github.com/github/licensed/tree/yarn-handle-malformed-json), [PR](https://github.com/github/licensed/pull/431)).

The `licensed-ci` action will add comments to this PR with the status of license checks.  Please make any changes needed to fix any status failures on this branch, then merge license updates into your branch.

If updates are unexpected, please check the `github/licensed` [changelog](https://github.com/github/licensed/tree/master/CHANGELOG.md) for recent updates.