### PR TITLE
Small cleanup in the licensed checks github action workflow

### DIFF
--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -60,6 +60,3 @@ jobs:
 
           # see https://github.com/jonabc/licensed-ci for more details
           workflow: branch
-        env:
-          GOPRIVATE: "*github.com/github/*"
-          GOPROXY: "direct"


### PR DESCRIPTION
There is no go code in this repo, those env vars came from a template workflow that included references to some private repos.