### PR TITLE
Release 3.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## 3.4.1
+
+2022-01-07
+
+### Fixed
+
+- Malformed package.json files will no longer crash yarn dependency detection (https://github.com/github/licensed/pull/431)
+
 ## 3.4.0
 
 2021-12-14
@@ -539,4 +547,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Initial release :tada:
 
-[Unreleased]: https://github.com/github/licensed/compare/3.4.0...HEAD
+[Unreleased]: https://github.com/github/licensed/compare/3.4.1...HEAD

--- a/lib/licensed/version.rb
+++ b/lib/licensed/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Licensed
-  VERSION = "3.4.0".freeze
+  VERSION = "3.4.1".freeze
 
   def self.previous_major_versions
     major_version = Gem::Version.new(Licensed::VERSION).segments.first


### PR DESCRIPTION
## 3.4.1

2022-01-07

### Fixed

- Malformed package.json files will no longer crash yarn dependency detection (https://github.com/github/licensed/pull/431)