### PR TITLE
improve glob when finding dependency package.json files from the yarn sources

### DIFF
--- a/.licenses/bundler/bundler.dep.yml
+++ b/.licenses/bundler/bundler.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: bundler
-version: 2.3.4
+version: 2.3.5
 type: bundler
 summary: The best way to manage your application's dependencies
 homepage: https://bundler.io

--- a/.licenses/bundler/faraday-multipart.dep.yml
+++ b/.licenses/bundler/faraday-multipart.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: faraday-multipart
-version: 1.0.2
+version: 1.0.3
 type: bundler
 summary: Perform multipart-post requests using Faraday.
 homepage: https://github.com/lostisland/faraday-multipart

--- a/.licenses/bundler/nokogiri.dep.yml
+++ b/.licenses/bundler/nokogiri.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: nokogiri
-version: 1.13.0
+version: 1.13.1
 type: bundler
 summary: Nokogiri (鋸) makes it easy and painless to work with XML and HTML from Ruby.
 homepage: https://nokogiri.org

--- a/.licenses/bundler/octokit.dep.yml
+++ b/.licenses/bundler/octokit.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: octokit
-version: 4.21.0
+version: 4.22.0
 type: bundler
 summary: Ruby toolkit for working with the GitHub API
 homepage: https://github.com/octokit/octokit.rb

--- a/Rakefile
+++ b/Rakefile
@@ -62,6 +62,7 @@ namespace :test do
     t.libs << "lib"
     t.test_files = FileList["test/**/*_test.rb"].exclude("test/fixtures/**/*_test.rb")
                                                 .exclude("test/sources/*_test.rb")
+                                                .exclude("test/sources/**/*_test.rb")
   end
 end
 

--- a/lib/licensed/sources/yarn.rb
+++ b/lib/licensed/sources/yarn.rb
@@ -27,7 +27,10 @@ module Licensed
       # Returns a hash that maps all dependency names to their location on disk
       # by parsing every package.json file under node_modules.
       def dependency_paths
-        @dependency_paths ||= Dir.glob(config.pwd.join("**/node_modules/*/package.json")).each_with_object({}) do |file, hsh|
+        @dependency_paths ||= [
+            *Dir.glob(config.pwd.join("**/node_modules/*/package.json")),
+            *Dir.glob(config.pwd.join("**/node_modules/@*/*/package.json"))
+          ].each_with_object({}) do |file, hsh|
           begin
             dirname = File.dirname(file)
             json = JSON.parse(File.read(file))

--- a/lib/licensed/sources/yarn.rb
+++ b/lib/licensed/sources/yarn.rb
@@ -23,6 +23,22 @@ module Licensed
       def yarn_version
         Gem::Version.new(Licensed::Shell.execute("yarn", "-v"))
       end
+
+      # Returns a hash that maps all dependency names to their location on disk
+      # by parsing every package.json file under node_modules.
+      def dependency_paths
+        @dependency_paths ||= Dir.glob(config.pwd.join("**/node_modules/*/package.json")).each_with_object({}) do |file, hsh|
+          begin
+            dirname = File.dirname(file)
+            json = JSON.parse(File.read(file))
+            hsh["#{json["name"]}@#{json["version"]}"] = dirname
+          rescue JSON::ParserError
+            # don't crash execution if there is a problem parsing a package.json file
+            # if the bad package.json file relates to a package that licensed should be reporting on
+            # then this will still result in an error about a missing package
+          end
+        end
+      end
     end
   end
 end

--- a/lib/licensed/sources/yarn/berry.rb
+++ b/lib/licensed/sources/yarn/berry.rb
@@ -32,7 +32,7 @@ module Licensed
         mapped_packages = yarn_info.reduce({}) do |accum, package|
           name, _ = package["value"].rpartition("@")
           version = package.dig("children", "Version")
-          id = "#{name}-#{version}"
+          id = "#{name}@#{version}"
 
           accum[name] ||= []
           accum[name] << {
@@ -55,22 +55,6 @@ module Licensed
             results.each do |package|
               hsh[package["id"]] = package
             end
-          end
-        end
-      end
-
-      # Returns a hash that maps all dependency names to their location on disk
-      # by parsing every package.json file under node_modules.
-      def dependency_paths
-        @dependency_paths ||= Dir.glob(config.pwd.join("node_modules/**/package.json")).each_with_object({}) do |file, hsh|
-          begin
-            dirname = File.dirname(file)
-            json = JSON.parse(File.read(file))
-            hsh["#{json["name"]}-#{json["version"]}"] = dirname
-          rescue JSON::ParserError
-            # don't crash execution if there is a problem parsing a package.json file
-            # if the bad package.json file relates to a package that licensed should be reporting on
-            # then this will still result in an error about a missing package
           end
         end
       end

--- a/lib/licensed/sources/yarn/v1.rb
+++ b/lib/licensed/sources/yarn/v1.rb
@@ -73,22 +73,6 @@ module Licensed
         result
       end
 
-      # Returns a hash that maps all dependency names to their location on disk
-      # by parsing every package.json file under node_modules.
-      def dependency_paths
-        @dependency_paths ||= Dir.glob(config.pwd.join("node_modules/**/package.json")).each_with_object({}) do |file, hsh|
-          begin
-            dirname = File.dirname(file)
-            json = JSON.parse(File.read(file))
-            hsh["#{json["name"]}@#{json["version"]}"] = dirname
-          rescue JSON::ParserError
-            # don't crash execution if there is a problem parsing a package.json file
-            # if the bad package.json file relates to a package that licensed should be reporting on
-            # then this will still result in an error about a missing package
-          end
-        end
-      end
-
       # Finds and returns the yarn package tree listing from `yarn list` output
       def yarn_package_tree
         return @yarn_package_tree if defined?(@yarn_package_tree)

--- a/test/sources/yarn/berry_test.rb
+++ b/test/sources/yarn/berry_test.rb
@@ -59,6 +59,7 @@ if Licensed::Shell.tool_available?("yarn")
           dep = source.dependencies.detect { |d| d.name == "@github/query-selector" }
           assert dep
           assert_equal "1.0.3", dep.version
+          refute_equal "", dep.path
         end
       end
 

--- a/test/sources/yarn/berry_test.rb
+++ b/test/sources/yarn/berry_test.rb
@@ -84,7 +84,7 @@ if Licensed::Shell.tool_available?("yarn")
             graceful_fs_dependencies = source.dependencies.select { |dep| dep.name =~ /graceful-fs/ }
             assert_equal 2, graceful_fs_dependencies.size
             graceful_fs_dependencies.each do |dependency|
-              assert_equal "#{dependency.record["name"]}-#{dependency.version}", dependency.name
+              assert_equal "#{dependency.record["name"]}@#{dependency.version}", dependency.name
               assert dependency.exist?
             end
           end

--- a/test/sources/yarn/v1_test.rb
+++ b/test/sources/yarn/v1_test.rb
@@ -59,6 +59,7 @@ if Licensed::Shell.tool_available?("yarn")
           assert dep
           assert_equal "1.0.3", dep.version
           assert dep.record["homepage"]
+          refute_equal "", dep.path
         end
       end
 


### PR DESCRIPTION
suggested by @ljharb in https://github.com/github/licensed/issues/436#issuecomment-1009038779 as an improvement to the glob for finding dependency paths by ignoring package.json files that don't represent installed packages

this also moves the dependency_paths method to the shared class to consolidate the functionality across both yarn source enumerator versions