### PR TITLE
License updates for yarn-npm-json-glob-fix

### DIFF
--- a/.licenses/bundler/bundler.dep.yml
+++ b/.licenses/bundler/bundler.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: bundler
-version: 2.3.4
+version: 2.3.5
 type: bundler
 summary: The best way to manage your application's dependencies
 homepage: https://bundler.io

--- a/.licenses/bundler/faraday-multipart.dep.yml
+++ b/.licenses/bundler/faraday-multipart.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: faraday-multipart
-version: 1.0.2
+version: 1.0.3
 type: bundler
 summary: Perform multipart-post requests using Faraday.
 homepage: https://github.com/lostisland/faraday-multipart

--- a/.licenses/bundler/nokogiri.dep.yml
+++ b/.licenses/bundler/nokogiri.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: nokogiri
-version: 1.13.0
+version: 1.13.1
 type: bundler
 summary: Nokogiri (鋸) makes it easy and painless to work with XML and HTML from Ruby.
 homepage: https://nokogiri.org

--- a/.licenses/bundler/octokit.dep.yml
+++ b/.licenses/bundler/octokit.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: octokit
-version: 4.21.0
+version: 4.22.0
 type: bundler
 summary: Ruby toolkit for working with the GitHub API
 homepage: https://github.com/octokit/octokit.rb


### PR DESCRIPTION
This PR was auto generated by the `licensed-ci` GitHub Action.
It contains updates to cached `github/licensed` dependency metadata to be merged into `yarn-npm-json-glob-fix`: ([branch](https://github.com/github/licensed/tree/yarn-npm-json-glob-fix), [PR](https://github.com/github/licensed/pull/439)).

The `licensed-ci` action will add comments to this PR with the status of license checks.  Please make any changes needed to fix any status failures on this branch, then merge license updates into your branch.

If updates are unexpected, please check the `github/licensed` [changelog](https://github.com/github/licensed/tree/master/CHANGELOG.md) for recent updates.