### PR TITLE
Handle additional case of missing optional npm peer dependencies

### DIFF
--- a/.licenses/bundler/bundler.dep.yml
+++ b/.licenses/bundler/bundler.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: bundler
-version: 2.3.5
+version: 2.3.6
 type: bundler
 summary: The best way to manage your application's dependencies
 homepage: https://bundler.io

--- a/.licenses/bundler/rugged.dep.yml
+++ b/.licenses/bundler/rugged.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: rugged
-version: 1.3.0
+version: 1.3.1
 type: bundler
 summary: Rugged is a Ruby binding to the libgit2 linkable library
 homepage: https://github.com/libgit2/rugged

--- a/lib/licensed/sources/npm.rb
+++ b/lib/licensed/sources/npm.rb
@@ -135,7 +135,15 @@ module Licensed
       end
 
       def missing_peer?(parent, dependency, name)
-        dependency["peerMissing"] || (dependency["missing"] && peer_dependency(parent, name))
+        # return true if dependency is marked as "peerMissing"
+        return true if dependency["peerMissing"]
+
+        # return false unless the parent has registered the dependency
+        # as a peer
+        return false unless peer_dependency(parent, name)
+        # return true if the dependency itself is marked as missing
+        return true if dependency["missing"]
+        dependency.empty? && parent&.dig("peerDependenciesMeta", name, "optional")
       end
 
       def peer_dependency(parent, name)

--- a/test/fixtures/npm/package.json
+++ b/test/fixtures/npm/package.json
@@ -4,7 +4,8 @@
   "dependencies": {
     "@github/query-selector": "1.0.3",
     "@optimizely/optimizely-sdk": "4.0.0",
-    "autoprefixer": "5.2.0"
+    "autoprefixer": "5.2.0",
+    "node-fetch": "2.6.7"
   },
   "devDependencies": {
     "string.prototype.startswith": "0.2.0"

--- a/test/sources/npm_test.rb
+++ b/test/sources/npm_test.rb
@@ -94,7 +94,13 @@ if Licensed::Shell.tool_available?("npm")
         Dir.chdir fixtures do
           # peer dependency of @optimizely/js-sdk-datafile-manager, which is
           # an indirect dependency through @optimizely/optimizely-sdk
+          # this checks the combination of being set in peerDependencies + `"missing": true`
           refute source.dependencies.detect { |dep| dep.name == "@react-native-community/async-storage" }
+
+          # peer dependency of node-fetch
+          # this checks the combination of being set in peerDependencies,
+          # + peerDependencyMetadata `"optional": true`, + empty dependency data
+          refute source.dependencies.detect { |dep| dep.name == "encoding" }
         end
       end
 


### PR DESCRIPTION
Found this in a [dependabot update to licensed-ci](https://github.com/jonabc/licensed-ci/pull/115), it looks like recent versions of npm use a new method to signal for optional peer dependencies.  The `npm list` output I'm seeing here looks like the following.

```json
"node-fetch": {
      ...
      "peerDependencies": {
        "encoding": "^0.1.0"
      },
      "peerDependenciesMeta": {
        "encoding": {
          "optional": true
        }
      },
      ...
      "dependencies": {
        "encoding": {},
        ...
```

This PR adds a check for the combination of an empty dependency hash, being set in `peerDependencies`, and having optional set in `peerDependenciesMeta`.