### PR TITLE
Protect from crashes when using Hash#dig

### DIFF
--- a/docs/sources/pip.md
+++ b/docs/sources/pip.md
@@ -20,5 +20,5 @@ You have to add this setting to your licensed configuration file.
 An example usage of this might look like:
 ```yaml
 python:
-    virtual_env_dir:"/path/to/your/venv_dir"
+    virtual_env_dir: "/path/to/your/venv_dir"
 ```

--- a/lib/licensed/sources/npm.rb
+++ b/lib/licensed/sources/npm.rb
@@ -153,7 +153,7 @@ module Licensed
         # "peerDependencies" could be set to the string "[Circular]"
         return unless peerDependencies.is_a?(Hash)
 
-        peerDependencies["name"]
+        peerDependencies[name]
       end
 
       def extract_version(parent, name)

--- a/lib/licensed/sources/npm.rb
+++ b/lib/licensed/sources/npm.rb
@@ -147,7 +147,13 @@ module Licensed
       end
 
       def peer_dependency(parent, name)
-        parent&.dig("peerDependencies", name)
+        return unless parent.is_a?(Hash)
+
+        peerDependencies = parent["peerDependencies"]
+        # "peerDependencies" could be set to the string "[Circular]"
+        return unless peerDependencies.is_a?(Hash)
+
+        peerDependencies["name"]
       end
 
       def extract_version(parent, name)

--- a/lib/licensed/sources/pip.rb
+++ b/lib/licensed/sources/pip.rb
@@ -63,7 +63,10 @@ module Licensed
       def virtual_env_dir
         return @virtual_env_dir if defined?(@virtual_env_dir)
         @virtual_env_dir = begin
-          venv_dir = config.dig("python", "virtual_env_dir")
+          python_config = config["python"]
+          return unless python_config.is_a?(Hash)
+
+          venv_dir = python_config["virtual_env_dir"]
           File.expand_path(venv_dir, config.root) if venv_dir
         end
       end

--- a/test/fixtures/npm/package.json
+++ b/test/fixtures/npm/package.json
@@ -5,7 +5,8 @@
     "@github/query-selector": "1.0.3",
     "@optimizely/optimizely-sdk": "4.0.0",
     "autoprefixer": "5.2.0",
-    "node-fetch": "2.6.7"
+    "node-fetch": "2.6.7",
+    "@nestjs/core": "8.2.6"
   },
   "devDependencies": {
     "string.prototype.startswith": "0.2.0"


### PR DESCRIPTION
resolves https://github.com/github/licensed/issues/448 https://github.com/github/licensed/issues/449

This PR makes two changes to protect against failures reported `String does not have #dig method (TypeError)`

1. In the npm source, it's possible for a `peerDependencies` value to be set as `"[Circular]"`.  I've only been able to reproduce this on npm 6.x.  This was tricky to track down as the error is being thrown internally from Hash#dig.  From the line of code in licensed `parent&.dig("peerDependencies", name)`, parent here is a hash but `parent["peerDependencies"]` is a string.  If I had to guess, I'd bet that the dig method is implemented using recursion like:
```ruby
def dig(*parts)
  key = parts[0]
  value = self[key]
  # no more key path parts to evaluate or value is nil, complete recursion
  return value if parts.length == 1 || value == nil

  # call dig on remaining key path parts
  # this is not resilient to the value not being a hash
  # and most likely value is not previously tested with respond_to?(:dig)
  value.dig(parts[1..])
end
```

2. A safety check in the pip source when using dig to evaluate the python config.  There is an expectation that a user has set the `python` key in the configuration file to a YAML hash, but in this case it looks like it was set to a string