### PR TITLE
License updates for dependabot/github_actions/actions/github-script-6

### DIFF
--- a/.licenses/bundler/bundler.dep.yml
+++ b/.licenses/bundler/bundler.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: bundler
-version: 2.3.6
+version: 2.3.7
 type: bundler
 summary: The best way to manage your application's dependencies
 homepage: https://bundler.io


### PR DESCRIPTION
This PR was auto generated by the `licensed-ci` GitHub Action.
It contains updates to cached `github/licensed` dependency metadata to be merged into `dependabot/github_actions/actions/github-script-6`: ([branch](https://github.com/github/licensed/tree/dependabot/github_actions/actions/github-script-6), [PR](https://github.com/github/licensed/pull/457)).

The `licensed-ci` action will add comments to this PR with the status of license checks.  Please make any changes needed to fix any status failures on this branch, then merge license updates into your branch.

If updates are unexpected, please check the `github/licensed` [changelog](https://github.com/github/licensed/tree/master/CHANGELOG.md) for recent updates.