### PR TITLE
License updates for configurable-confidence

### DIFF
--- a/.licenses/bundler/bundler.dep.yml
+++ b/.licenses/bundler/bundler.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: bundler
-version: 2.3.7
+version: 2.3.8
 type: bundler
 summary: The best way to manage your application's dependencies
 homepage: https://bundler.io

--- a/.licenses/bundler/faraday.dep.yml
+++ b/.licenses/bundler/faraday.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: faraday
-version: 1.9.3
+version: 1.10.0
 type: bundler
 summary: HTTP/REST API client library.
 homepage: https://lostisland.github.io/faraday

--- a/.licenses/bundler/licensee.dep.yml
+++ b/.licenses/bundler/licensee.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: licensee
-version: 9.15.1
+version: 9.15.2
 type: bundler
 summary: A Ruby Gem to detect open source project licenses
 homepage: https://github.com/benbalter/licensee

--- a/.licenses/bundler/nokogiri.dep.yml
+++ b/.licenses/bundler/nokogiri.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: nokogiri
-version: 1.13.1
+version: 1.13.3
 type: bundler
 summary: Nokogiri (鋸) makes it easy and painless to work with XML and HTML from Ruby.
 homepage: https://nokogiri.org


### PR DESCRIPTION
This PR was auto generated by the `licensed-ci` GitHub Action.
It contains updates to cached `github/licensed` dependency metadata to be merged into `configurable-confidence`: ([branch](https://github.com/github/licensed/tree/configurable-confidence), [PR](https://github.com/github/licensed/pull/455)).

The `licensed-ci` action will add comments to this PR with the status of license checks.  Please make any changes needed to fix any status failures on this branch, then merge license updates into your branch.

If updates are unexpected, please check the `github/licensed` [changelog](https://github.com/github/licensed/tree/master/CHANGELOG.md) for recent updates.