### PR TITLE
Overwrite a dependency license classification when force option is given

### DIFF
--- a/test/commands/cache_test.rb
+++ b/test/commands/cache_test.rb
@@ -319,4 +319,50 @@ describe Licensed::Commands::Cache do
       end
     end
   end
+
+  describe "with the force option" do
+    it "overwrites an existing cached record" do
+      run_command
+
+      config.apps.each do |app|
+        path = app.cache_path.join("test/dependency.#{Licensed::DependencyRecord::EXTENSION}")
+        record = Licensed::DependencyRecord.read(path)
+        record["license"] = "updated"
+        record["version"] = "updated"
+        record["homepage"] = "updated"
+        record.licenses.clear
+        record.save(path)
+      end
+
+      run_command(force: true)
+
+      config.apps.each do |app|
+        path = app.cache_path.join("test/dependency.#{Licensed::DependencyRecord::EXTENSION}")
+        record = Licensed::DependencyRecord.read(path)
+        refute_equal "updated", record["license"]
+        refute_equal "updated", record["version"]
+        refute_equal "updated", record["homepage"]
+        refute_empty record.licenses
+      end
+    end
+
+    it "overwrites a record when the version and license contents match" do
+      run_command
+
+      config.apps.each do |app|
+        path = app.cache_path.join("test/dependency.#{Licensed::DependencyRecord::EXTENSION}")
+        record = Licensed::DependencyRecord.read(path)
+        record["license"] = "updated"
+        record.save(path)
+      end
+
+      run_command(force: true)
+
+      config.apps.each do |app|
+        path = app.cache_path.join("test/dependency.#{Licensed::DependencyRecord::EXTENSION}")
+        record = Licensed::DependencyRecord.read(path)
+        refute_equal "updated", record["license"]
+      end
+    end
+  end
 end


### PR DESCRIPTION
ref https://github.com/github/licensed/pull/455#issuecomment-1057403620

When looking at a customer issue I found that the `licensed cache --force` option was not overwriting the cached license contents as was expected, because the cached license contents matched the newly detected contents.

This change short circuits any logic to manipulate the newly detected metadata based on existing cached contents when the force option is specified.  The force option now makes the tool act like the cached record did not previously exist.