### PR TITLE
Fix documentation link to point at default licensee branch

### DIFF
--- a/docs/configuration/customizing_licensee.md
+++ b/docs/configuration/customizing_licensee.md
@@ -8,6 +8,6 @@ Licensed uses [Licensee](https://github.com/licensee/licensee) to detect and eva
 licensee:
   # the confidence threshold is an integer between 1 and 100. the value represents
   # the minimum percentage confidence that Licensee must have to report a matched license
-  # https://github.com/licensee/licensee/blob/jonabc-patch-1/docs/customizing.md#adjusting-the-confidence-threshold
+  # https://github.com/licensee/licensee/blob/master/docs/customizing.md#adjusting-the-confidence-threshold
   confidence_threshold: 90 # default value: 98
 ```


### PR DESCRIPTION
ref https://github.com/github/licensed/pull/455#discussion_r815731903

🙇  thanks @villelahdenvuo for catching this.  This PR updates the licensee link in documentation to point at licensee/licensee's default branch.