### PR TITLE
Use pip list to get packages for pip source

### DIFF
--- a/.licenses/bundler/bundler.dep.yml
+++ b/.licenses/bundler/bundler.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: bundler
-version: 2.3.8
+version: 2.3.9
 type: bundler
 summary: The best way to manage your application's dependencies
 homepage: https://bundler.io

--- a/docs/sources/pip.md
+++ b/docs/sources/pip.md
@@ -2,11 +2,6 @@
 
 The pip source uses `pip` CLI commands to enumerate dependencies and properties. It is expected that `pip` is available in the `virtual_env_dir` specific directory before running `licensed`.
 
-Your repository root should also contain a `requirements.txt` file which contains all the packages and dependences that are needed. You can generate one with `pip` using the command:
-```
-pip freeze > requirements.txt
-```
-
 A `virtualenv` directory is required before running `licensed`. You can setup a `virtualenv` by running the command:
 ```
 virtualenv <your_venv_dir>

--- a/test/sources/pip_test.rb
+++ b/test/sources/pip_test.rb
@@ -25,109 +25,20 @@ if Licensed::Shell.tool_available?("pip")
     end
 
     describe "dependencies" do
-      it "detects dependencies without a version constraint" do
-        Dir.chdir fixtures do
-          dep = source.dependencies.detect { |d| d.name == "scapy" }
-          assert dep
-          assert_equal "pip", dep.record["type"]
-          assert dep.record["homepage"]
-          assert dep.record["summary"]
-        end
-      end
-
-      it "detects dependencies with == version constraint" do
+      it "detects explicit dependencies" do
         Dir.chdir fixtures do
           dep = source.dependencies.detect { |d| d.name == "Jinja2" }
           assert dep
+          assert_equal "2.9.6", dep.version
           assert_equal "pip", dep.record["type"]
           assert dep.record["homepage"]
           assert dep.record["summary"]
         end
       end
 
-      it "detects dependencies with >= version constraint" do
+      it "detects transitive dependencies" do
         Dir.chdir fixtures do
-          dep = source.dependencies.detect { |d| d.name == "requests" }
-          assert dep
-          assert_equal "pip", dep.record["type"]
-          assert dep.record["homepage"]
-          assert dep.record["summary"]
-        end
-      end
-
-      it "detects dependencies with <= version constraint" do
-        Dir.chdir fixtures do
-          dep = source.dependencies.detect { |d| d.name == "tqdm" }
-          assert dep
-          assert_equal "pip", dep.record["type"]
-          assert dep.record["homepage"]
-          assert dep.record["summary"]
-        end
-      end
-
-      it "detects dependencies with < version constraint" do
-        Dir.chdir fixtures do
-          dep = source.dependencies.detect { |d| d.name == "Pillow" }
-          assert dep
-          assert_equal "pip", dep.record["type"]
-          assert dep.record["homepage"]
-          assert dep.record["summary"]
-        end
-      end
-
-      it "detects dependencies with > version constraint" do
-        Dir.chdir fixtures do
-          dep = source.dependencies.detect { |d| d.name == "Scrapy" }
-          assert dep
-          assert_equal "pip", dep.record["type"]
-          assert dep.record["homepage"]
-          assert dep.record["summary"]
-        end
-      end
-
-      it "detects dependencies with != version constraint" do
-        Dir.chdir fixtures do
-          dep = source.dependencies.detect { |d| d.name == "numpy" }
-          assert dep
-          assert_equal "pip", dep.record["type"]
-          assert dep.record["homepage"]
-          assert dep.record["summary"]
-        end
-      end
-
-      it "detects dependencies with whitespace between the package name and version operator" do
-        Dir.chdir fixtures do
-          dep = source.dependencies.detect { |d| d.name == "botocore" }
-          assert dep
-          assert_equal "pip", dep.record["type"]
-          assert dep.record["homepage"]
-          assert dep.record["summary"]
-        end
-      end
-
-      it "detects dependencies with multiple version constraints" do
-        Dir.chdir fixtures do
-          dep = source.dependencies.detect { |d| d.name == "boto3" }
-          assert dep
-          assert_equal "pip", dep.record["type"]
-          assert dep.record["homepage"]
-          assert dep.record["summary"]
-        end
-      end
-
-      it "detects dependencies with hyphens in package name" do
-        Dir.chdir fixtures do
-          dep = source.dependencies.detect { |d| d.name == "lazy-object-proxy" }
-          assert dep
-          assert_equal "pip", dep.record["type"]
-          assert dep.record["homepage"]
-          assert dep.record["summary"]
-        end
-      end
-
-      it "detects dependencies with dots in package name" do
-        Dir.chdir fixtures do
-          dep = source.dependencies.detect { |d| d.name == "backports.shutil-get-terminal-size" }
+          dep = source.dependencies.detect { |d| d.name == "google-auth-oauthlib" }
           assert dep
           assert_equal "pip", dep.record["type"]
           assert dep.record["homepage"]

--- a/test/sources/pip_test.rb
+++ b/test/sources/pip_test.rb
@@ -38,7 +38,7 @@ if Licensed::Shell.tool_available?("pip")
 
       it "detects transitive dependencies" do
         Dir.chdir fixtures do
-          dep = source.dependencies.detect { |d| d.name == "google-auth-oauthlib" }
+          dep = source.dependencies.detect { |d| d.name == "MarkupSafe" }
           assert dep
           assert_equal "pip", dep.record["type"]
           assert dep.record["homepage"]


### PR DESCRIPTION
This change updates the pip source to gather dependencies from `pip list` rather than parsing `requirements.txt`.  This is done to accommodate the multitude of [requirement specifies](https://pip.pypa.io/en/stable/cli/pip_install/#requirement-specifiers) that weren't currently being handled, such as direct file specifiers.  Instead licensed now relies on pip to report what dependencies are being used.  As a side effect, this now causes the pip source to report on transitive/nested dependencies, where previously only explicit dependencies were being reported 🤦 

After all dependencies were being reported, I found that performance was really suffering because many more `pip show` commands were being executed. Thankfully though `pip show` supports entering multiple package names in one command, which overall made the source faster than it was before this PR 🚀 .

Some minor side effects of this change
1. the number of test cases needed drops significantly because licensed no longer needs to validate requirements.txt parsing logic
1. there is no longer a need for a `requirements.txt` file.  we just need to know the virtual env directory to run under and pip gives us all the rest of the information.