### PR TITLE
Initial support for npm workspaces

### DIFF
--- a/docs/sources/npm.md
+++ b/docs/sources/npm.md
@@ -2,11 +2,21 @@
 
 The npm source will detect dependencies `package.json` is found at an apps `source_path`.  It uses `npm list` to enumerate dependencies and metadata.
 
-### Including development dependencies
+## Including development dependencies
 
 By default, the npm source will exclude all development dependencies. To include development or test dependencies, set `production_only: false` in the licensed configuration.
 
 ```yml
 npm:
   production_only: false
+```
+
+## Using licensed with npm workspaces
+
+Licensed requires npm version 8.5.0 or later to enumerate dependencies inside of npm workspaces.  For the best results, treat each workspace directory as a separate app `source_path`:
+
+```yml
+apps:
+  - source_path: path/to/workspace/a
+  - source_path: path/to/workspace/b
 ```

--- a/test/fixtures/npm/package.json
+++ b/test/fixtures/npm/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "fixtures",
+  "name": "licensed-fixtures",
   "version": "1.0.0",
   "dependencies": {
     "@github/query-selector": "1.0.3",
@@ -11,6 +11,9 @@
   "devDependencies": {
     "string.prototype.startswith": "0.2.0"
   },
+  "workspaces": [
+    "packages/a"
+  ],
   "description": "npm test fixture",
   "repository": "https://github.com/github/licensed",
   "license": "MIT"

--- a/test/fixtures/npm/packages/a/package.json
+++ b/test/fixtures/npm/packages/a/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "licensed-fixtures-a",
+  "version": "1.0.0",
+  "description": "",
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "callbackify": "1.1.0"
+  }
+}

--- a/test/sources/npm_test.rb
+++ b/test/sources/npm_test.rb
@@ -135,6 +135,31 @@ if Licensed::Shell.tool_available?("npm")
           end
         end
       end
+
+      describe "from a workspace" do
+        let(:fixtures) { File.expand_path("../../fixtures/npm/packages/a", __FILE__) }
+
+        it "finds dependencies" do
+          # workspaces will only work as expected with npm > 8.5.0
+          skip if source.npm_version < Gem::Version.new("8.5.0")
+
+          Dir.chdir fixtures do
+            dep = source.dependencies.detect { |d| d.name == "callbackify" }
+            assert dep
+            assert_equal "npm", dep.record["type"]
+            assert_equal "1.1.0", dep.version
+          end
+        end
+
+        it "does not include the current workspace project" do
+          # workspaces will only work as expected with npm > 8.5.0
+          skip if source.npm_version < Gem::Version.new("8.5.0")
+
+          Dir.chdir fixtures do
+            refute source.dependencies.detect { |d| d.name == "licensed-fixtures-a" }
+          end
+        end
+      end
     end
 
     describe "missing dependencies (glob is missing package)" do


### PR DESCRIPTION
ref https://github.com/github/licensed/issues/349#issuecomment-1065612748

This adds in some initial support for using licensed with npm workspaces.  In total the small amount of changes here are:
- remove the workspace package from the returned results
- add notes in docs for npm source about npm version requirements

In order for licensed to work as expected when detecting dependencies used by an npm workspace project, npm 8.5.0 or greater is needed.  Additionally, the expected workflow is that licensed is run from each workspace directory rather than from a workspace root.  Running from the workspace root will technically work but it will require more manual configuration to ignore the workspace projects via the licensed configuration file.