### PR TITLE
Consider Composer dev dependencies

### DIFF
--- a/docs/sources/composer.md
+++ b/docs/sources/composer.md
@@ -12,3 +12,12 @@ The default composer application file location is `<repository root>/composer.ph
 composer:
   application_path: "/path/to/composer"
 ```
+
+### Dev dependencies
+
+By default licensed ignores all dev dependencies. To consider dev dependencies as well, use the `composer.include_dev` configuration setting.
+
+```yml
+composer:
+  include_dev: true
+```

--- a/lib/licensed/sources/composer.rb
+++ b/lib/licensed/sources/composer.rb
@@ -28,7 +28,12 @@ module Licensed
       end
 
       def packages
-        JSON.parse(File.read(composer_lock))["packages"]
+        packages = JSON.parse(File.read(composer_lock))
+        if not include_dev?
+            return packages["packages"]
+        end
+
+        packages["packages"] + packages["packages-dev"]
       end
 
       # Returns the output from running `php composer.phar` to get package metadata
@@ -55,6 +60,11 @@ module Licensed
 
       def composer_lock
         config.pwd.join("composer.lock")
+      end
+
+      # Returns whether to include dev packages based on the licensed configuration settings
+      def include_dev?
+        config.dig("composer", "include_dev") == true
       end
     end
   end

--- a/lib/licensed/sources/composer.rb
+++ b/lib/licensed/sources/composer.rb
@@ -29,9 +29,7 @@ module Licensed
 
       def packages
         packages = JSON.parse(File.read(composer_lock))
-        if not include_dev?
-            return packages["packages"]
-        end
+        return packages["packages"] unless include_dev?
 
         packages["packages"] + packages["packages-dev"]
       end

--- a/test/sources/composer_test.rb
+++ b/test/sources/composer_test.rb
@@ -70,6 +70,13 @@ if Licensed::Shell.tool_available?("php")
           refute source.dependencies.detect { |dep| dep.name == "phpunit/php-file-iterator" }
         end
       end
+
+      it "includes dev dependencies if enabled" do
+        config["composer"] = { "include_dev" => true }
+        Dir.chdir fixtures do
+          assert source.dependencies.detect { |dep| dep.name == "phpunit/php-file-iterator" }
+        end
+      end
     end
 
     describe "composer_application_path" do


### PR DESCRIPTION
I noticed that composer dev dependencies haven't been considered by this package, so I wanted to add this.

As I am not sure about the BC policy of this library, I made this a configuration option, so that people do not automatically get all the license updates. In general I would consider this enabled by default though, wdyt?