### PR TITLE
License updates for dependabot/bundler/byebug-tw-11.1.3

### DIFF
--- a/.licenses/bundler/bundler.dep.yml
+++ b/.licenses/bundler/bundler.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: bundler
-version: 2.3.9
+version: 2.3.10
 type: bundler
 summary: The best way to manage your application's dependencies
 homepage: https://bundler.io

--- a/.licenses/bundler/parallel.dep.yml
+++ b/.licenses/bundler/parallel.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: parallel
-version: 1.22.0
+version: 1.22.1
 type: bundler
 summary: Run any kind of code in parallel processes
 homepage: https://github.com/grosser/parallel


### PR DESCRIPTION
This PR was auto generated by the `licensed-ci` GitHub Action.
It contains updates to cached `github/licensed` dependency metadata to be merged into `dependabot/bundler/byebug-tw-11.1.3`: ([branch](https://github.com/github/licensed/tree/dependabot/bundler/byebug-tw-11.1.3), [PR](https://github.com/github/licensed/pull/491)).

The `licensed-ci` action will add comments to this PR with the status of license checks.  Please make any changes needed to fix any status failures on this branch, then merge license updates into your branch.

If updates are unexpected, please check the `github/licensed` [changelog](https://github.com/github/licensed/tree/master/CHANGELOG.md) for recent updates.