### PR TITLE
License updates for dependabot/github_actions/haskell/actions-2

### DIFF
--- a/.licenses/bundler/nokogiri.dep.yml
+++ b/.licenses/bundler/nokogiri.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: nokogiri
-version: 1.13.3
+version: 1.13.4
 type: bundler
 summary: Nokogiri (鋸) makes it easy and painless to work with XML and HTML from Ruby.
 homepage: https://nokogiri.org

--- a/.licenses/bundler/public_suffix.dep.yml
+++ b/.licenses/bundler/public_suffix.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: public_suffix
-version: 4.0.6
+version: 4.0.7
 type: bundler
 summary: Domain name parser based on the Public Suffix List.
 homepage: https://simonecarletti.com/code/publicsuffix-ruby
@@ -8,7 +8,7 @@ license: mit
 licenses:
 - sources: LICENSE.txt
   text: |
-    Copyright (c) 2009-2020 Simone Carletti <weppos@weppos.net>
+    Copyright (c) 2009-2022 Simone Carletti <weppos@weppos.net>
 
     MIT License
 
@@ -32,7 +32,7 @@ licenses:
     WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 - sources: README.md
   text: |-
-    Copyright (c) 2009-2020 Simone Carletti. This is Free Software distributed under the MIT license.
+    Copyright (c) 2009-2022 Simone Carletti. This is Free Software distributed under the MIT license.
 
     The [Public Suffix List source](https://publicsuffix.org/list/) is subject to the terms of the Mozilla Public License, v. 2.0.
 notices: []

--- a/.licenses/bundler/rugged.dep.yml
+++ b/.licenses/bundler/rugged.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: rugged
-version: 1.4.2
+version: 1.4.3
 type: bundler
 summary: Rugged is a Ruby binding to the libgit2 linkable library
 homepage: https://github.com/libgit2/rugged


### PR DESCRIPTION
This PR was auto generated by the `licensed-ci` GitHub Action.
It contains updates to cached `github/licensed` dependency metadata to be merged into `dependabot/github_actions/haskell/actions-2`: ([branch](https://github.com/github/licensed/tree/dependabot/github_actions/haskell/actions-2), [PR](https://github.com/github/licensed/pull/502)).

The `licensed-ci` action will add comments to this PR with the status of license checks.  Please make any changes needed to fix any status failures on this branch, then merge license updates into your branch.

If updates are unexpected, please check the `github/licensed` [changelog](https://github.com/github/licensed/tree/master/CHANGELOG.md) for recent updates.