### PR TITLE
Support pip packages that install with a license_files folder

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -437,7 +437,7 @@ jobs:
     needs: core
     strategy:
       matrix:
-        python: [ '3.6', '3.7', '3.8', '3.9' ]
+        python: [ '3.7', '3.8', '3.9', '3.10' ]
     steps:
     - uses: actions/checkout@v3
     - name: Setup python

--- a/.licenses/bundler/bundler.dep.yml
+++ b/.licenses/bundler/bundler.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: bundler
-version: 2.3.11
+version: 2.3.12
 type: bundler
 summary: The best way to manage your application's dependencies
 homepage: https://bundler.io

--- a/lib/licensed/sources/pip.rb
+++ b/lib/licensed/sources/pip.rb
@@ -32,7 +32,7 @@ module Licensed
 
       # Returns the command to run pip
       def pip_command
-        return [] unless virtual_env_dir
+        return unless virtual_env_dir
         File.join(virtual_env_dir, "bin", "pip")
       end
 

--- a/lib/licensed/sources/pip.rb
+++ b/lib/licensed/sources/pip.rb
@@ -20,7 +20,7 @@ module Licensed
             version: package["Version"],
             path: package_license_location(package),
             metadata: {
-              "type"        => Pip.type,
+              "type"        => self.class.type,
               "summary"     => package["Summary"],
               "homepage"    => package["Home-page"]
             }

--- a/lib/licensed/sources/pip.rb
+++ b/lib/licensed/sources/pip.rb
@@ -10,7 +10,7 @@ module Licensed
       PACKAGE_INFO_SEPARATOR = "\n---\n"
 
       def enabled?
-        pip_command && Licensed::Shell.tool_available?(pip_command)
+        !pip_command.empty? && Licensed::Shell.tool_available?(pip_command.join(""))
       end
 
       def enumerate_dependencies
@@ -32,8 +32,8 @@ module Licensed
 
       # Returns the command to run pip
       def pip_command
-        return unless virtual_env_dir
-        File.join(virtual_env_dir, "bin", "pip")
+        return [] unless virtual_env_dir
+        Array(File.join(virtual_env_dir, "bin", "pip"))
       end
 
       private
@@ -79,12 +79,12 @@ module Licensed
 
       # Returns the output from `pip list --format=json`
       def pip_list_command
-        Licensed::Shell.execute(pip_command, "--disable-pip-version-check", "list", "--format=json")
+        Licensed::Shell.execute(*pip_command, "--disable-pip-version-check", "list", "--format=json")
       end
 
       # Returns the output from `pip show <package> <package> ...`
       def pip_show_command(packages)
-        Licensed::Shell.execute(pip_command, "--disable-pip-version-check", "show", *packages)
+        Licensed::Shell.execute(*pip_command, "--disable-pip-version-check", "show", *packages)
       end
 
       def virtual_env_dir

--- a/lib/licensed/sources/pip.rb
+++ b/lib/licensed/sources/pip.rb
@@ -10,16 +10,15 @@ module Licensed
       PACKAGE_INFO_SEPARATOR = "\n---\n"
 
       def enabled?
-        virtual_env_pip && Licensed::Shell.tool_available?(virtual_env_pip)
+        pip_command && Licensed::Shell.tool_available?(pip_command)
       end
 
       def enumerate_dependencies
         packages.map do |package|
-          location = File.join(package["Location"], package["Name"].gsub("-", "_") +  "-" + package["Version"] + ".dist-info")
           Dependency.new(
             name: package["Name"],
             version: package["Version"],
-            path: location,
+            path: package_license_location(package),
             metadata: {
               "type"        => Pip.type,
               "summary"     => package["Summary"],
@@ -29,7 +28,23 @@ module Licensed
         end
       end
 
+      protected
+
+      # Returns the command to run pip
+      def pip_command
+        return [] unless virtual_env_dir
+        File.join(virtual_env_dir, "bin", "pip")
+      end
+
       private
+
+      # Returns the location of license files in the package, checking for the inclusion of a new `license_files`
+      # folder per https://peps.python.org/pep-0639/
+      def package_license_location(package)
+        dist_info = File.join(package["Location"], package["Name"].gsub("-", "_") +  "-" + package["Version"] + ".dist-info")
+        license_files = File.join(dist_info, "license_files")
+        return File.exist?(license_files) ? license_files : dist_info
+      end
 
       # Returns parsed information for all packages used by the project,
       # using `pip list` to determine what packages are used and `pip show`
@@ -64,17 +79,12 @@ module Licensed
 
       # Returns the output from `pip list --format=json`
       def pip_list_command
-        Licensed::Shell.execute(virtual_env_pip, "--disable-pip-version-check", "list", "--format=json")
+        Licensed::Shell.execute(pip_command, "--disable-pip-version-check", "list", "--format=json")
       end
 
       # Returns the output from `pip show <package> <package> ...`
       def pip_show_command(packages)
-        Licensed::Shell.execute(virtual_env_pip, "--disable-pip-version-check", "show", *packages)
-      end
-
-      def virtual_env_pip
-        return unless virtual_env_dir
-        File.join(virtual_env_dir, "bin", "pip")
+        Licensed::Shell.execute(pip_command, "--disable-pip-version-check", "show", *packages)
       end
 
       def virtual_env_dir

--- a/lib/licensed/sources/pipenv.rb
+++ b/lib/licensed/sources/pipenv.rb
@@ -4,44 +4,16 @@ require "parallel"
 
 module Licensed
   module Sources
-    class Pipenv < Source
+    class Pipenv < Pip
       def enabled?
         Licensed::Shell.tool_available?("pipenv") && File.exist?(config.pwd.join("Pipfile.lock"))
       end
 
-      def enumerate_dependencies
-        Parallel.map(pakages_from_pipfile_lock, in_threads: Parallel.processor_count) do |package_name|
-          package = package_info(package_name)
-          location = File.join(package["Location"], package["Name"].gsub("-", "_") +  "-" + package["Version"] + ".dist-info")
-          Dependency.new(
-            name: package["Name"],
-            version: package["Version"],
-            path: location,
-            metadata: {
-              "type"        => Pipenv.type,
-              "summary"     => package["Summary"],
-              "homepage"    => package["Home-page"]
-            }
-          )
-        end
-      end
+      protected
 
-      private
-
-      def pakages_from_pipfile_lock
-        Licensed::Shell.execute("pipenv", "run", "pip", "list")
-            .lines
-            .drop(2)  # Header
-            .map { |line| line.strip.split.first.strip }
-      end
-
-      def package_info(package_name)
-        p_info = Licensed::Shell.execute("pipenv", "run", "pip", "--disable-pip-version-check", "show", package_name).lines
-        p_info.each_with_object(Hash.new(0)) { |pkg, a|
-          k, v = pkg.split(":", 2)
-          next if k.nil? || k.empty?
-          a[k.strip] = v&.strip
-        }
+      # Returns the command to run pip
+      def pip_command
+        "pipenv run pip"
       end
     end
   end

--- a/lib/licensed/sources/pipenv.rb
+++ b/lib/licensed/sources/pipenv.rb
@@ -13,7 +13,7 @@ module Licensed
 
       # Returns the command to run pip
       def pip_command
-        "pipenv run pip"
+        %w(pipenv run pip)
       end
     end
   end

--- a/lib/licensed/sources/source.rb
+++ b/lib/licensed/sources/source.rb
@@ -14,8 +14,13 @@ module Licensed
       class << self
         attr_reader :sources
         def inherited(klass)
-          # add child source classes are defined,
-          # add them to the known sources list
+          # register the inherited class as a source on the Licensed::Sources::Source class
+          Licensed::Sources::Source.register_source(klass)
+        end
+
+        def register_source(klass)
+          # add the source class to the known sources list
+          return unless klass < Licensed::Sources::Source
           (@sources ||= []) << klass
         end
 

--- a/test/fixtures/pip/requirements.txt
+++ b/test/fixtures/pip/requirements.txt
@@ -11,3 +11,4 @@ botocore == 1.12.91
 boto3>=1.0,<=2.0
 lazy-object-proxy==1.4.0
 backports.shutil-get-terminal-size==1.0.0
+datadog==0.44.0

--- a/test/fixtures/pipenv/Pipfile
+++ b/test/fixtures/pipenv/Pipfile
@@ -9,4 +9,4 @@ verify_ssl = true
 beautifulsoup4 = "==4.7.1"
 dataclasses = {version = "==0.6",markers = "python_version < '3.7.0'"}
 pylint = "==2.3.1"
-datadog = "==0.44.0
+datadog = "==0.44.0"

--- a/test/fixtures/pipenv/Pipfile
+++ b/test/fixtures/pipenv/Pipfile
@@ -9,3 +9,4 @@ verify_ssl = true
 beautifulsoup4 = "==4.7.1"
 dataclasses = {version = "==0.6",markers = "python_version < '3.7.0'"}
 pylint = "==2.3.1"
+datadog = "==0.44.0

--- a/test/sources/pip_test.rb
+++ b/test/sources/pip_test.rb
@@ -45,6 +45,14 @@ if Licensed::Shell.tool_available?("pip")
           assert dep.record["summary"]
         end
       end
+
+      it "finds license contents from .dist-info/license_files" do
+        Dir.chdir fixtures do
+          dep = source.dependencies.detect { |d| d.name == "datadog" }
+          assert dep.path.end_with?("license_files")
+          refute_empty dep.license_files
+        end
+      end
     end
   end
 end

--- a/test/sources/pipenv_test.rb
+++ b/test/sources/pipenv_test.rb
@@ -58,6 +58,14 @@ if Licensed::Shell.tool_available?("pipenv")
           assert dep.record["summary"]
         end
       end
+
+      it "finds license contents from .dist-info/license_files" do
+        Dir.chdir fixtures do
+          dep = source.dependencies.detect { |d| d.name == "datadog" }
+          assert dep.path.end_with?("license_files")
+          refute_empty dep.license_files
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
From https://peps.python.org/pep-0639/ it looks like pip can start to install dependencies where the dependency license metadata files are installed at `.dist-info/license_files`.  This PR accounts for that change by having the source enumerator check whether the `license_files` folder exists under .dist-info, and using that folder to look for license files if it does exist.

I've also changed the pipenv source to inherit from the pip source.  These two sources started with different implementations but over time they have gotten pretty close to each other, where now they are only slightly different.  This change consolidates the implementation so that both sources benefit from future changes.