### PR TITLE
Release 3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## 3.7.0
+
+### Changed
+
+- Pip and pipenv sources will find dependency licenses under `dist-info/license_files` when available (https://github.com/github/licensed/pull/504)
+
 ## 3.6.0
 
 2022-03-17
@@ -597,4 +603,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Initial release :tada:
 
-[Unreleased]: https://github.com/github/licensed/compare/3.6.0...HEAD
+[Unreleased]: https://github.com/github/licensed/compare/3.7.0...HEAD

--- a/lib/licensed/version.rb
+++ b/lib/licensed/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Licensed
-  VERSION = "3.6.0".freeze
+  VERSION = "3.7.0".freeze
 
   def self.previous_major_versions
     major_version = Gem::Version.new(Licensed::VERSION).segments.first


### PR DESCRIPTION
## 3.7.0

### Changed

- Pip and pipenv sources will find dependency licenses under `dist-info/license_files` when available (https://github.com/github/licensed/pull/504)