### PR TITLE
Restrict leading content in legal notice filename pattern

### DIFF
--- a/lib/licensed/dependency.rb
+++ b/lib/licensed/dependency.rb
@@ -3,7 +3,7 @@ require "licensee"
 
 module Licensed
   class Dependency < Licensee::Projects::FSProject
-    LEGAL_FILES_PATTERN = /\A(AUTHORS|NOTICE|LEGAL)(?:\..*)?\z/i
+    LEGAL_FILES_PATTERN = /#{File::SEPARATOR}(AUTHORS|NOTICE|LEGAL)(?:\..*)?\z/i
 
     attr_reader :name
     attr_reader :version
@@ -83,7 +83,6 @@ module Licensed
     # Returns legal notices found at the dependency path
     def notice_contents
       Dir.glob(dir_path.join("*"))
-         .map(&File.method(:basename))
          .grep(LEGAL_FILES_PATTERN)
          .select { |path| File.file?(path) }
          .sort # sorted by the path

--- a/lib/licensed/dependency.rb
+++ b/lib/licensed/dependency.rb
@@ -3,7 +3,7 @@ require "licensee"
 
 module Licensed
   class Dependency < Licensee::Projects::FSProject
-    LEGAL_FILES_PATTERN = /(AUTHORS|NOTICE|LEGAL)(?:\..*)?\z/i
+    LEGAL_FILES_PATTERN = /\A(AUTHORS|NOTICE|LEGAL)(?:\..*)?\z/i
 
     attr_reader :name
     attr_reader :version
@@ -83,6 +83,7 @@ module Licensed
     # Returns legal notices found at the dependency path
     def notice_contents
       Dir.glob(dir_path.join("*"))
+         .map(&File.method(:basename))
          .grep(LEGAL_FILES_PATTERN)
          .select { |path| File.file?(path) }
          .sort # sorted by the path

--- a/test/dependency_test.rb
+++ b/test/dependency_test.rb
@@ -268,7 +268,7 @@ describe Licensed::Dependency do
       end
     end
 
-    it "handles invlaid encodings in legal notices" do
+    it "handles invalid encodings in legal notices" do
       mkproject do |dependency|
         File.write "AUTHORS", [0x20, 0x42, 0x3f, 0x63, 0x6b].pack("ccccc")
         File.write "NOTICE", "notice"

--- a/test/dependency_test.rb
+++ b/test/dependency_test.rb
@@ -240,6 +240,7 @@ describe Licensed::Dependency do
         File.write "AUTHORS", "authors"
         File.write "NOTICE", "notice"
         File.write "LEGAL", "legal"
+        File.write "otherLEGAL.c", "new legal"
 
         assert_includes dependency.notice_contents,
                         { "sources" => "AUTHORS", "text" => "authors" }
@@ -247,6 +248,8 @@ describe Licensed::Dependency do
                         { "sources" => "NOTICE", "text" => "notice" }
         assert_includes dependency.notice_contents,
                         { "sources" => "LEGAL", "text" => "legal" }
+
+        refute dependency.notice_contents.any? { |c| c["sources"] == "otherLEGAL.c" }
       end
     end
 


### PR DESCRIPTION
closes https://github.com/github/licensed/issues/509

This is a small update to legal notice filename pattern matching to exclude names like `faLegal.js` which contain content ahead of the matching `legal` filename, as mentioned in the linked issue.  This change also puts the legal notice pattern matching inline with the patterns [licensee uses](https://github.com/licensee/licensee/blob/2e912652b5737421c3b1571afbbaa08ba4d71801/lib/licensee/project_files/license_file.rb#L36-L50) to match license file names.