### PR TITLE
License updates for dependabot/github_actions/actions/setup-python-4

### DIFF
--- a/.licenses/bundler/octokit.dep.yml
+++ b/.licenses/bundler/octokit.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: octokit
-version: 4.23.0
+version: 4.24.0
 type: bundler
 summary: Ruby toolkit for working with the GitHub API
 homepage: https://github.com/octokit/octokit.rb

--- a/.licenses/bundler/sawyer.dep.yml
+++ b/.licenses/bundler/sawyer.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: sawyer
-version: 0.9.1
+version: 0.9.2
 type: bundler
 summary: Secret User Agent of HTTP
 homepage: https://github.com/lostisland/sawyer


### PR DESCRIPTION
This PR was auto generated by the `licensed-ci` GitHub Action.
It contains updates to cached `github/licensed` dependency metadata to be merged into `dependabot/github_actions/actions/setup-python-4`: ([branch](https://github.com/github/licensed/tree/dependabot/github_actions/actions/setup-python-4), [PR](https://github.com/github/licensed/pull/519)).

The `licensed-ci` action will add comments to this PR with the status of license checks.  Please make any changes needed to fix any status failures on this branch, then merge license updates into your branch.

If updates are unexpected, please check the `github/licensed` [changelog](https://github.com/github/licensed/tree/master/CHANGELOG.md) for recent updates.