### PR TITLE
Fix bundler 2.3.19 compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
     needs: core
     strategy:
       matrix:
-        bundler: [ '~> 1.17.0', '~> 2.0.0', '~> 2.1.0', '~> 2.2.0' ]
+        bundler: [ '~> 1.17.0', '~> 2.0.0', '~> 2.1.0', '~> 2.2.0', '~> 2.3.0' ]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby

--- a/lib/licensed/sources/bundler/missing_specification.rb
+++ b/lib/licensed/sources/bundler/missing_specification.rb
@@ -40,8 +40,8 @@ module Licensed
     end
 
     module LazySpecification
-      def __materialize__
-        spec = super
+      def __materialize__(*args)
+        spec = super(*args)
         return spec if spec
 
         Licensed::Bundler::MissingSpecification.new(name: name, version: version, platform: platform, source: source)


### PR DESCRIPTION
https://github.com/rubygems/rubygems/pull/5070 changed the arity of `__materialize__` method which broke `licensed`

Fixes #521 