### PR TITLE
Update mini_racer to fix latest macOS/Apple silicon compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,11 +34,11 @@ jobs:
       run: script/test bower
 
   bundler:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     needs: core
     strategy:
       matrix:
-        bundler: [ '~> 1.17.0', '~> 2.0.0', '~> 2.1.0', '~> 2.2.0', '~>2.3.0' ]
+        bundler: [ '~> 1.17.0', '~> 2.0.0', '~> 2.1.0', '~> 2.2.0', '~> 2.3.0' ]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby

--- a/test/fixtures/bundler/Gemfile
+++ b/test/fixtures/bundler/Gemfile
@@ -26,8 +26,7 @@ end
 gem "pathed-gem-fixture", path: "pathed-gem-fixture"
 
 # verify https://github.com/github/licensed/issues/71
-git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
-gem "mini_racer", "0.3.1"
+gem "mini_racer", "0.6.2"
 
 # verify https://github.com/github/licensed/issues/153
 gem "aws-sdk-core", "3.39.0"

--- a/test/sources/bundler_test.rb
+++ b/test/sources/bundler_test.rb
@@ -52,7 +52,7 @@ if Licensed::Shell.tool_available?("bundle")
 
       it "finds platform-specific dependencies" do
         Dir.chdir(fixtures) do
-          assert source.dependencies.find { |d| d.name == "libv8" }
+          assert source.dependencies.find { |d| d.name == "libv8-node" }
         end
       end
 


### PR DESCRIPTION
mini_racer 0.3.1 isn't compatible with more recent macOS versions (in part due to lack of python 2) which made `script/setup` fail with:

```
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /Users/cvx/dev/licensed/test/fixtures/bundler/vendor/gems/ruby/2.7.0/gems/libv8-8.4.255.0/ext/libv8
/Users/cvx/.rubies/ruby-2.7.6/bin/ruby -I /Users/cvx/.rubies/ruby-2.7.6/lib/ruby/site_ruby/2.7.0 extconf.rb
creating Makefile
/Users/cvx/dev/licensed/test/fixtures/bundler/vendor/gems/ruby/2.7.0/gems/libv8-8.4.255.0/ext/libv8/builder.rb:57:in `setup_python!': libv8 requires python 2 to be installed in order to build, but it is currently
3.9.13 (RuntimeError)
	from /Users/cvx/dev/licensed/test/fixtures/bundler/vendor/gems/ruby/2.7.0/gems/libv8-8.4.255.0/ext/libv8/builder.rb:39:in `build_libv8!'
	from /Users/cvx/dev/licensed/test/fixtures/bundler/vendor/gems/ruby/2.7.0/gems/libv8-8.4.255.0/ext/libv8/location.rb:24:in `install!'
	from extconf.rb:7:in `<main>'

extconf failed, exit code 1

Gem files will remain installed in /Users/cvx/dev/licensed/test/fixtures/bundler/vendor/gems/ruby/2.7.0/gems/libv8-8.4.255.0 for inspection.
Results logged to /Users/cvx/dev/licensed/test/fixtures/bundler/vendor/gems/ruby/2.7.0/extensions/arm64-darwin-21/2.7.0-static/libv8-8.4.255.0/gem_make.out

  /Users/cvx/.rubies/ruby-2.7.6/lib/ruby/site_ruby/2.7.0/rubygems/ext/builder.rb:102:in `run'
  /Users/cvx/.rubies/ruby-2.7.6/lib/ruby/site_ruby/2.7.0/rubygems/ext/ext_conf_builder.rb:28:in `build'
  /Users/cvx/.rubies/ruby-2.7.6/lib/ruby/site_ruby/2.7.0/rubygems/ext/builder.rb:171:in `build_extension'
  /Users/cvx/.rubies/ruby-2.7.6/lib/ruby/site_ruby/2.7.0/rubygems/ext/builder.rb:205:in `block in build_extensions'
  /Users/cvx/.rubies/ruby-2.7.6/lib/ruby/site_ruby/2.7.0/rubygems/ext/builder.rb:202:in `each'
  /Users/cvx/.rubies/ruby-2.7.6/lib/ruby/site_ruby/2.7.0/rubygems/ext/builder.rb:202:in `build_extensions'
  /Users/cvx/.rubies/ruby-2.7.6/lib/ruby/site_ruby/2.7.0/rubygems/installer.rb:851:in `build_extensions'
  /Users/cvx/.rubies/ruby-2.7.6/lib/ruby/site_ruby/2.7.0/bundler/rubygems_gem_installer.rb:72:in `build_extensions'
  /Users/cvx/.rubies/ruby-2.7.6/lib/ruby/site_ruby/2.7.0/bundler/rubygems_gem_installer.rb:28:in `install'
  /Users/cvx/.rubies/ruby-2.7.6/lib/ruby/site_ruby/2.7.0/bundler/source/rubygems.rb:207:in `install'
  /Users/cvx/.rubies/ruby-2.7.6/lib/ruby/site_ruby/2.7.0/bundler/installer/gem_installer.rb:54:in `install'
  /Users/cvx/.rubies/ruby-2.7.6/lib/ruby/site_ruby/2.7.0/bundler/installer/gem_installer.rb:16:in `install_from_spec'
  /Users/cvx/.rubies/ruby-2.7.6/lib/ruby/site_ruby/2.7.0/bundler/installer/parallel_installer.rb:186:in `do_install'
  /Users/cvx/.rubies/ruby-2.7.6/lib/ruby/site_ruby/2.7.0/bundler/installer/parallel_installer.rb:177:in `block in worker_pool'
  /Users/cvx/.rubies/ruby-2.7.6/lib/ruby/site_ruby/2.7.0/bundler/worker.rb:62:in `apply_func'
  /Users/cvx/.rubies/ruby-2.7.6/lib/ruby/site_ruby/2.7.0/bundler/worker.rb:57:in `block in process_queue'
  /Users/cvx/.rubies/ruby-2.7.6/lib/ruby/site_ruby/2.7.0/bundler/worker.rb:54:in `loop'
  /Users/cvx/.rubies/ruby-2.7.6/lib/ruby/site_ruby/2.7.0/bundler/worker.rb:54:in `process_queue'
  /Users/cvx/.rubies/ruby-2.7.6/lib/ruby/site_ruby/2.7.0/bundler/worker.rb:91:in `block (2 levels) in create_threads'

An error occurred while installing libv8 (8.4.255.0), and Bundler cannot continue.

In Gemfile:
  mini_racer was resolved to 0.3.1, which depends on
    libv8
Encountered an error running script/source-setup/bundler.
```