### PR TITLE
Fix cargo setup

### DIFF
--- a/script/source-setup/cargo
+++ b/script/source-setup/cargo
@@ -13,7 +13,11 @@ BASE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd $BASE_PATH/test/fixtures/cargo
 
 if [ "$1" == "-f" ]; then
-  find . -not -regex "\.*" -and -not -path "*app*" -print0 | xargs -0 rm -rf
+  find . -not -regex "\.*" \
+    -and -not -path "*/Cargo.lock" \
+    -and -not -path "*/Cargo.toml" \
+    -and -not -path "*/src*" \
+    -print0 | xargs -0 rm -rf
 fi
 
 cargo build


### PR DESCRIPTION
Previously `script/setup -f` would delete all cargo test files