### PR TITLE
Fix issues shown with latest rubocop-github

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
     needs: core
     strategy:
       matrix:
-        bundler: [ '~> 1.17.0', '~> 2.0.0', '~> 2.1.0', '~> 2.2.0' ]
+        bundler: [ '~> 1.17.0', '~> 2.0.0', '~> 2.1.0', '~> 2.2.0', '~>2.3.0' ]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby

--- a/.licenses/bundler/bundler.dep.yml
+++ b/.licenses/bundler/bundler.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: bundler
-version: 2.3.15
+version: 2.3.19
 type: bundler
 summary: The best way to manage your application's dependencies
 homepage: https://bundler.io

--- a/.licenses/bundler/dotenv.dep.yml
+++ b/.licenses/bundler/dotenv.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: dotenv
-version: 2.7.6
+version: 2.8.1
 type: bundler
 summary: Loads environment variables from `.env`.
 homepage: https://github.com/bkeepers/dotenv

--- a/.licenses/bundler/faraday-net_http.dep.yml
+++ b/.licenses/bundler/faraday-net_http.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: faraday-net_http
-version: 2.0.3
+version: 2.1.0
 type: bundler
 summary: Faraday adapter for Net::HTTP
 homepage: https://github.com/lostisland/faraday-net_http

--- a/.licenses/bundler/faraday.dep.yml
+++ b/.licenses/bundler/faraday.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: faraday
-version: 2.3.0
+version: 2.4.0
 type: bundler
 summary: HTTP/REST API client library.
 homepage: https://lostisland.github.io/faraday
@@ -8,7 +8,7 @@ license: mit
 licenses:
 - sources: LICENSE.md
   text: |
-    Copyright (c) 2009-2020 Rick Olson, Zack Hobson
+    Copyright (c) 2009-2022 Rick Olson, Zack Hobson
 
     Permission is hereby granted, free of charge, to any person obtaining
     a copy of this software and associated documentation files (the

--- a/.licenses/bundler/nokogiri.dep.yml
+++ b/.licenses/bundler/nokogiri.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: nokogiri
-version: 1.13.6
+version: 1.13.8
 type: bundler
 summary: Nokogiri (鋸) makes it easy and painless to work with XML and HTML from Ruby.
 homepage: https://nokogiri.org

--- a/.licenses/bundler/octokit.dep.yml
+++ b/.licenses/bundler/octokit.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: octokit
-version: 4.24.0
+version: 4.25.1
 type: bundler
 summary: Ruby toolkit for working with the GitHub API
 homepage: https://github.com/octokit/octokit.rb

--- a/.licenses/bundler/rugged.dep.yml
+++ b/.licenses/bundler/rugged.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: rugged
-version: 1.4.3
+version: 1.5.0.1
 type: bundler
 summary: Rugged is a Ruby binding to the libgit2 linkable library
 homepage: https://github.com/libgit2/rugged

--- a/lib/licensed/configuration.rb
+++ b/lib/licensed/configuration.rb
@@ -243,15 +243,16 @@ module Licensed
 
       # try to expand the source path for glob patterns
       expanded_source_paths = source_path_array.reduce(Set.new) do |matched_paths, pattern|
-        current_matched_paths = if pattern.start_with?("!")
-          # if the pattern is an exclusion, remove all matching files
-          # from the result
-          matched_paths - Dir.glob(pattern[1..-1])
-        else
-          # if the pattern is an inclusion, add all matching files
-          # to the result
-          matched_paths + Dir.glob(pattern)
-        end
+        current_matched_paths =
+          if pattern.start_with?("!")
+            # if the pattern is an exclusion, remove all matching files
+            # from the result
+            matched_paths - Dir.glob(pattern[1..-1])
+          else
+            # if the pattern is an inclusion, add all matching files
+            # to the result
+            matched_paths + Dir.glob(pattern)
+          end
 
         current_matched_paths.select { |p| File.directory?(p) }
       end

--- a/lib/licensed/reporters/status_reporter.rb
+++ b/lib/licensed/reporters/status_reporter.rb
@@ -19,7 +19,7 @@ module Licensed
       # app - An application configuration
       # report - A report containing information about the app evaluation
       def begin_report_app(app, report)
-          shell.info "Checking cached dependency records for #{app["name"]}"
+        shell.info "Checking cached dependency records for #{app["name"]}"
       end
 
       # Reports any errors found when checking status, as well as

--- a/lib/licensed/sources/bundler/missing_specification.rb
+++ b/lib/licensed/sources/bundler/missing_specification.rb
@@ -40,8 +40,8 @@ module Licensed
     end
 
     module LazySpecification
-      def __materialize__
-        spec = super
+      def __materialize__(*args)
+        spec = super(*args)
         return spec if spec
 
         Licensed::Bundler::MissingSpecification.new(name: name, version: version, platform: platform, source: source)

--- a/lib/licensed/sources/git_submodule.rb
+++ b/lib/licensed/sources/git_submodule.rb
@@ -20,12 +20,13 @@ module Licensed
         git_submodules_command.lines.map do |line|
           displaypath, toplevel, version, homepage = line.strip.split
           name = File.basename(displaypath)
-          submodule_path = if toplevel == config.pwd.to_s
-            name
-          else
-            parent = File.basename(toplevel)
-            "#{submodule_paths[parent]}/#{name}"
-          end
+          submodule_path =
+            if toplevel == config.pwd.to_s
+              name
+            else
+              parent = File.basename(toplevel)
+              "#{submodule_paths[parent]}/#{name}"
+            end
           submodule_paths[name] = submodule_path
 
           Licensed::Dependency.new(

--- a/lib/licensed/sources/go.rb
+++ b/lib/licensed/sources/go.rb
@@ -36,11 +36,12 @@ module Licensed
 
       # Returns an array of dependency package import paths
       def packages
-        dependency_packages = if go_version < Gem::Version.new("1.11.0")
-          root_package_deps
-        else
-          go_list_deps
-        end
+        dependency_packages =
+          if go_version < Gem::Version.new("1.11.0")
+            root_package_deps
+          else
+            go_list_deps
+          end
 
         # don't include go std packages
         # don't include packages under the root project that aren't vendored

--- a/lib/licensed/sources/helpers/content_versioning.rb
+++ b/lib/licensed/sources/helpers/content_versioning.rb
@@ -27,14 +27,14 @@ module Licensed
       def version_strategy
         # default to git for backwards compatible behavior
         @version_strategy ||= begin
-           case config.fetch("version_strategy", nil)
-           when CONTENTS
-             CONTENTS
-           when GIT
-             GIT
-           else
-             Licensed::Git.available? ? GIT : CONTENTS
-           end
+          case config.fetch("version_strategy", nil)
+          when CONTENTS
+            CONTENTS
+          when GIT
+            GIT
+          else
+            Licensed::Git.available? ? GIT : CONTENTS
+          end
         end
       end
 

--- a/test/sources/go_test.rb
+++ b/test/sources/go_test.rb
@@ -187,20 +187,20 @@ if Licensed::Shell.tool_available?("go")
       end
 
       describe "package version" do
-          it "is the latest git SHA of the package directory when configured" do
-            Dir.chdir fixtures do
-              dep = source.dependencies.detect { |d| d.name == "github.com/gorilla/context" }
-              assert_equal source.git_version([dep.path]), dep.version
-            end
+        it "is the latest git SHA of the package directory when configured" do
+          Dir.chdir fixtures do
+            dep = source.dependencies.detect { |d| d.name == "github.com/gorilla/context" }
+            assert_equal source.git_version([dep.path]), dep.version
           end
+        end
 
-          it "is the hash of all contents in the package directory when configured" do
-            config["version_strategy"] = Licensed::Sources::ContentVersioning::CONTENTS
-            Dir.chdir fixtures do
-              dep = source.dependencies.detect { |d| d.name == "github.com/gorilla/context" }
-              assert_equal source.contents_hash(Dir["#{dep.path}/*"]), dep.version
-            end
+        it "is the hash of all contents in the package directory when configured" do
+          config["version_strategy"] = Licensed::Sources::ContentVersioning::CONTENTS
+          Dir.chdir fixtures do
+            dep = source.dependencies.detect { |d| d.name == "github.com/gorilla/context" }
+            assert_equal source.contents_hash(Dir["#{dep.path}/*"]), dep.version
           end
+        end
       end
 
       describe "from a subfolder source_path" do


### PR DESCRIPTION
Licensed uses an indeterminate semver string when choosing which version of rubocop-github to install, and a recent update to rubocop-github enabled the `Layout/IndentationWidth` cop by default. There were some violations of that check in this repo which caused CI to fail on a number of open PRs.

This fixes the indentation errors
1. by moving the condition in a conditional assignment onto a new line so that the following lines are seen as properly indented
1. by fixing the indentation in a few places