### PR TITLE
License updates for rubocop-fixes

### DIFF
--- a/.licenses/bundler/bundler.dep.yml
+++ b/.licenses/bundler/bundler.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: bundler
-version: 2.3.15
+version: 2.3.19
 type: bundler
 summary: The best way to manage your application's dependencies
 homepage: https://bundler.io

--- a/.licenses/bundler/dotenv.dep.yml
+++ b/.licenses/bundler/dotenv.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: dotenv
-version: 2.7.6
+version: 2.8.1
 type: bundler
 summary: Loads environment variables from `.env`.
 homepage: https://github.com/bkeepers/dotenv

--- a/.licenses/bundler/faraday-net_http.dep.yml
+++ b/.licenses/bundler/faraday-net_http.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: faraday-net_http
-version: 2.0.3
+version: 2.1.0
 type: bundler
 summary: Faraday adapter for Net::HTTP
 homepage: https://github.com/lostisland/faraday-net_http

--- a/.licenses/bundler/faraday.dep.yml
+++ b/.licenses/bundler/faraday.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: faraday
-version: 2.3.0
+version: 2.4.0
 type: bundler
 summary: HTTP/REST API client library.
 homepage: https://lostisland.github.io/faraday
@@ -8,7 +8,7 @@ license: mit
 licenses:
 - sources: LICENSE.md
   text: |
-    Copyright (c) 2009-2020 Rick Olson, Zack Hobson
+    Copyright (c) 2009-2022 Rick Olson, Zack Hobson
 
     Permission is hereby granted, free of charge, to any person obtaining
     a copy of this software and associated documentation files (the

--- a/.licenses/bundler/nokogiri.dep.yml
+++ b/.licenses/bundler/nokogiri.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: nokogiri
-version: 1.13.6
+version: 1.13.8
 type: bundler
 summary: Nokogiri (鋸) makes it easy and painless to work with XML and HTML from Ruby.
 homepage: https://nokogiri.org

--- a/.licenses/bundler/octokit.dep.yml
+++ b/.licenses/bundler/octokit.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: octokit
-version: 4.24.0
+version: 4.25.1
 type: bundler
 summary: Ruby toolkit for working with the GitHub API
 homepage: https://github.com/octokit/octokit.rb

--- a/.licenses/bundler/rugged.dep.yml
+++ b/.licenses/bundler/rugged.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: rugged
-version: 1.4.3
+version: 1.5.0.1
 type: bundler
 summary: Rugged is a Ruby binding to the libgit2 linkable library
 homepage: https://github.com/libgit2/rugged


### PR DESCRIPTION
This PR was auto generated by the `licensed-ci` GitHub Action.
It contains updates to cached `github/licensed` dependency metadata to be merged into `rubocop-fixes`: ([branch](https://github.com/github/licensed/tree/rubocop-fixes), [PR](https://github.com/github/licensed/pull/526)).

The `licensed-ci` action will add comments to this PR with the status of license checks.  Please make any changes needed to fix any status failures on this branch, then merge license updates into your branch.

If updates are unexpected, please check the `github/licensed` [changelog](https://github.com/github/licensed/tree/master/CHANGELOG.md) for recent updates.