### PR TITLE
Replace mini_racer to fix latest macOS/Apple silicon compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
     needs: core
     strategy:
       matrix:
-        bundler: [ '~> 1.17.0', '~> 2.0.0', '~> 2.1.0', '~> 2.2.0', '~>2.3.0' ]
+        bundler: [ '~> 1.17.0', '~> 2.0.0', '~> 2.1.0', '~> 2.2.0', '~> 2.3.0' ]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby

--- a/test/fixtures/bundler/Gemfile
+++ b/test/fixtures/bundler/Gemfile
@@ -26,8 +26,7 @@ end
 gem "pathed-gem-fixture", path: "pathed-gem-fixture"
 
 # verify https://github.com/github/licensed/issues/71
-git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
-gem "mini_racer", "0.3.1"
+gem "loofah", "2.18.0"
 
 # verify https://github.com/github/licensed/issues/153
 gem "aws-sdk-core", "3.39.0"

--- a/test/sources/bundler_test.rb
+++ b/test/sources/bundler_test.rb
@@ -52,7 +52,7 @@ if Licensed::Shell.tool_available?("bundle")
 
       it "finds platform-specific dependencies" do
         Dir.chdir(fixtures) do
-          assert source.dependencies.find { |d| d.name == "libv8" }
+          assert source.dependencies.find { |d| d.name == "nokogiri" }
         end
       end
 


### PR DESCRIPTION
`mini_racer` 0.3.1 isn't compatible with more recent macOS versions (in part due to lack of python 2) which made `script/setup` fail with `Gem::Ext::BuildError: ERROR: Failed to build gem native extension`

Updating `mini_racer` caused a different problem - a bug in bundler caused it to install both `linux` and `linux-musl` variants in the CI environment. (see: https://github.com/rubyjs/libv8-node/issues/5 and https://github.com/rubygems/rubygems/issues/3174)

This instead replaces `mini_racer` example with `loofah`. That gem depends on `nokogiri` which provides different binary variants, like `libv8`/`libv8-node` did.

But this one builds properly on macOS and does not provide `linux-musl` variant so it should not cause any issues on CI.