### PR TITLE
License updates for explicit-json-dependency

### DIFF
--- a/.licensed.yml
+++ b/.licensed.yml
@@ -7,6 +7,7 @@ allowed:
 
 reviewed:
   bundler:
+    - json
     - pathname-common_prefix
     - racc
     - reverse_markdown

--- a/.licenses/bundler/json.dep.yml
+++ b/.licenses/bundler/json.dep.yml
@@ -1,0 +1,43 @@
+---
+name: json
+version: 2.6.2
+type: bundler
+summary: JSON Implementation for Ruby
+homepage: http://flori.github.com/json
+license: other
+licenses:
+- sources: LICENSE
+  text: "Ruby is copyrighted free software by Yukihiro Matsumoto <matz@netlab.jp>.\nYou
+    can redistribute it and/or modify it under either the terms of the\n2-clause BSDL
+    (see the file BSDL), or the conditions below:\n\n  1. You may make and give away
+    verbatim copies of the source form of the\n     software without restriction,
+    provided that you duplicate all of the\n     original copyright notices and associated
+    disclaimers.\n\n  2. You may modify your copy of the software in any way, provided
+    that\n     you do at least ONE of the following:\n\n       a) place your modifications
+    in the Public Domain or otherwise\n          make them Freely Available, such
+    as by posting said\n\t  modifications to Usenet or an equivalent medium, or by
+    allowing\n\t  the author to include your modifications in the software.\n\n       b)
+    use the modified software only within your corporation or\n          organization.\n\n
+    \      c) give non-standard binaries non-standard names, with\n          instructions
+    on where to get the original software distribution.\n\n       d) make other distribution
+    arrangements with the author.\n\n  3. You may distribute the software in object
+    code or binary form,\n     provided that you do at least ONE of the following:\n\n
+    \      a) distribute the binaries and library files of the software,\n\t  together
+    with instructions (in the manual page or equivalent)\n\t  on where to get the
+    original distribution.\n\n       b) accompany the distribution with the machine-readable
+    source of\n\t  the software.\n\n       c) give non-standard binaries non-standard
+    names, with\n          instructions on where to get the original software distribution.\n\n
+    \      d) make other distribution arrangements with the author.\n\n  4. You may
+    modify and include the part of the software into any other\n     software (possibly
+    commercial).  But some files in the distribution\n     are not written by the
+    author, so that they are not under these terms.\n\n     For the list of those
+    files and their copying conditions, see the\n     file LEGAL.\n\n  5. The scripts
+    and library files supplied as input to or produced as\n     output from the software
+    do not automatically fall under the\n     copyright of the software, but belong
+    to whomever generated them,\n     and may be sold commercially, and may be aggregated
+    with this\n     software.\n\n  6. THIS SOFTWARE IS PROVIDED \"AS IS\" AND WITHOUT
+    ANY EXPRESS OR\n     IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED\n
+    \    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR\n     PURPOSE.\n"
+- sources: README.md
+  text: Ruby License, see https://www.ruby-lang.org/en/about/license.txt.
+notices: []


### PR DESCRIPTION
This PR was auto generated by the `licensed-ci` GitHub Action.
It contains updates to cached `github/licensed` dependency metadata to be merged into `explicit-json-dependency`: ([branch](https://github.com/github/licensed/tree/explicit-json-dependency), [PR](https://github.com/github/licensed/pull/530)).

The `licensed-ci` action will add comments to this PR with the status of license checks.  Please make any changes needed to fix any status failures on this branch, then merge license updates into your branch.

If updates are unexpected, please check the `github/licensed` [changelog](https://github.com/github/licensed/tree/master/CHANGELOG.md) for recent updates.