### PR TITLE
License updates for dependabot/github_actions/nanasess/setup-php-3.2.0

### DIFF
--- a/.licenses/bundler/bundler.dep.yml
+++ b/.licenses/bundler/bundler.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: bundler
-version: 2.3.19
+version: 2.3.20
 type: bundler
 summary: The best way to manage your application's dependencies
 homepage: https://bundler.io

--- a/.licenses/bundler/faraday-net_http.dep.yml
+++ b/.licenses/bundler/faraday-net_http.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: faraday-net_http
-version: 2.1.0
+version: 3.0.0
 type: bundler
 summary: Faraday adapter for Net::HTTP
 homepage: https://github.com/lostisland/faraday-net_http

--- a/.licenses/bundler/faraday.dep.yml
+++ b/.licenses/bundler/faraday.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: faraday
-version: 2.4.0
+version: 2.5.2
 type: bundler
 summary: HTTP/REST API client library.
 homepage: https://lostisland.github.io/faraday


### PR DESCRIPTION
This PR was auto generated by the `licensed-ci` GitHub Action.
It contains updates to cached `github/licensed` dependency metadata to be merged into `dependabot/github_actions/nanasess/setup-php-3.2.0`: ([branch](https://github.com/github/licensed/tree/dependabot/github_actions/nanasess/setup-php-3.2.0), [PR](https://github.com/github/licensed/pull/532)).

The `licensed-ci` action will add comments to this PR with the status of license checks.  Please make any changes needed to fix any status failures on this branch, then merge license updates into your branch.

If updates are unexpected, please check the `github/licensed` [changelog](https://github.com/github/licensed/tree/master/CHANGELOG.md) for recent updates.