### PR TITLE
Handle changes in materializing lazy specs in recent versions of bundler

### DIFF
--- a/.licenses/bundler/bundler.dep.yml
+++ b/.licenses/bundler/bundler.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: bundler
-version: 2.3.19
+version: 2.3.20
 type: bundler
 summary: The best way to manage your application's dependencies
 homepage: https://bundler.io

--- a/.licenses/bundler/faraday-net_http.dep.yml
+++ b/.licenses/bundler/faraday-net_http.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: faraday-net_http
-version: 2.1.0
+version: 3.0.0
 type: bundler
 summary: Faraday adapter for Net::HTTP
 homepage: https://github.com/lostisland/faraday-net_http

--- a/.licenses/bundler/faraday.dep.yml
+++ b/.licenses/bundler/faraday.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: faraday
-version: 2.4.0
+version: 2.5.2
 type: bundler
 summary: HTTP/REST API client library.
 homepage: https://lostisland.github.io/faraday

--- a/lib/licensed/sources/bundler/missing_specification.rb
+++ b/lib/licensed/sources/bundler/missing_specification.rb
@@ -40,6 +40,13 @@ module Licensed
     end
 
     module LazySpecification
+      def materialize_for_installation(*args)
+        spec = super(*args)
+        return spec unless spec.is_a?(LazySpecification)
+
+        Licensed::Bundler::MissingSpecification.new(name: name, version: version, platform: platform, source: source)
+      end
+
       def __materialize__(*args)
         spec = super(*args)
         return spec if spec


### PR DESCRIPTION
Seen in [CI logs on a dependency update](https://github.com/github/licensed/runs/7841329149?check_suite_focus=true), licensed isn't working as expected for recent versions of bundler.  As far as I can tell this has to do with small changes in the materialization of lazy specifications, and theres a new method `materialize_for_installation` that I can tie into to check whether materialization failed.  From what I can tell it should play fine with the previous `__materialize__` override and should only affect newer versions of bundler that implement the method on LazySpecifications.