### PR TITLE
Update status.md

### DIFF
--- a/docs/commands/status.md
+++ b/docs/commands/status.md
@@ -37,6 +37,8 @@ The following data is reported for each dependency when the YAML or JSON report 
 
 ## Status errors and resolutions
 
+**Note** The recommended commands are different in github/github. If you need help resolving a licensed error in github/github, see [the dotcom guide on the hub](https://thehub.github.com/epd/engineering/products-and-services/dotcom/licenses/).
+
 ### cached dependency record not found
 
 *Cause:* A dependency was found while running `licensed status` that does not have a corresponding cached metadata file


### PR DESCRIPTION
- I was linked to this doc from a [CI failure](https://github.com/github/github/pull/232896/checks?check_run_id=7922799494) on a github/github PR. 
- The recommended commands, i.e. `licensed cache` don't work for github/github. There is a doc that explains the correct commands for dotcom, so I think we should link to it for folks who find this doc first. 