### PR TITLE
License updates for dependabot/github_actions/actions/setup-dotnet-2.1.1

### DIFF
--- a/.licenses/bundler/addressable.dep.yml
+++ b/.licenses/bundler/addressable.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: addressable
-version: 2.8.0
+version: 2.8.1
 type: bundler
 summary: URI Implementation
 homepage: https://github.com/sporkmonger/addressable

--- a/.licenses/bundler/bundler.dep.yml
+++ b/.licenses/bundler/bundler.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: bundler
-version: 2.3.20
+version: 2.3.22
 type: bundler
 summary: The best way to manage your application's dependencies
 homepage: https://bundler.io

--- a/.licenses/bundler/public_suffix.dep.yml
+++ b/.licenses/bundler/public_suffix.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: public_suffix
-version: 4.0.7
+version: 5.0.0
 type: bundler
 summary: Domain name parser based on the Public Suffix List.
 homepage: https://simonecarletti.com/code/publicsuffix-ruby


### PR DESCRIPTION
This PR was auto generated by the `licensed-ci` GitHub Action.
It contains updates to cached `github/licensed` dependency metadata to be merged into `dependabot/github_actions/actions/setup-dotnet-2.1.1`: ([branch](https://github.com/github/licensed/tree/dependabot/github_actions/actions/setup-dotnet-2.1.1), [PR](https://github.com/github/licensed/pull/542)).

The `licensed-ci` action will add comments to this PR with the status of license checks.  Please make any changes needed to fix any status failures on this branch, then merge license updates into your branch.

If updates are unexpected, please check the `github/licensed` [changelog](https://github.com/github/licensed/tree/master/CHANGELOG.md) for recent updates.