### PR TITLE
License updates for dependabot/github_actions/actions/setup-dotnet-3.0.1

### DIFF
--- a/.licenses/bundler/faraday.dep.yml
+++ b/.licenses/bundler/faraday.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: faraday
-version: 2.5.2
+version: 2.6.0
 type: bundler
 summary: HTTP/REST API client library.
 homepage: https://lostisland.github.io/faraday


### PR DESCRIPTION
This PR was auto generated by the `licensed-ci` GitHub Action.
It contains updates to cached `github/licensed` dependency metadata to be merged into `dependabot/github_actions/actions/setup-dotnet-3.0.1`: ([branch](https://github.com/github/licensed/tree/dependabot/github_actions/actions/setup-dotnet-3.0.1), [PR](https://github.com/github/licensed/pull/545)).

The `licensed-ci` action will add comments to this PR with the status of license checks.  Please make any changes needed to fix any status failures on this branch, then merge license updates into your branch.

If updates are unexpected, please check the `github/licensed` [changelog](https://github.com/github/licensed/tree/master/CHANGELOG.md) for recent updates.