### PR TITLE
Find license files for hatch-built python dependencies

### DIFF
--- a/lib/licensed/sources/pip.rb
+++ b/lib/licensed/sources/pip.rb
@@ -42,8 +42,12 @@ module Licensed
       # folder per https://peps.python.org/pep-0639/
       def package_license_location(package)
         dist_info = File.join(package["Location"], package["Name"].gsub("-", "_") +  "-" + package["Version"] + ".dist-info")
-        license_files = File.join(dist_info, "license_files")
-        return File.exist?(license_files) ? license_files : dist_info
+
+        license_path = ["license_files", "licenses"]
+          .map { |directory| File.join(dist_info, directory) }
+          .find { |path| File.exist?(path) }
+
+        license_path || dist_info
       end
 
       # Returns parsed information for all packages used by the project,

--- a/test/fixtures/pip/requirements.txt
+++ b/test/fixtures/pip/requirements.txt
@@ -1,7 +1,7 @@
 # This comment should be ignored
 --index-url https://pypi.org/simple
 scapy
-Jinja2==2.9.6
+Jinja2==3.0
 requests>=2.21.0
 tqdm<=4.30.0
 Pillow>5.4.0
@@ -12,3 +12,4 @@ boto3>=1.0,<=2.0
 lazy-object-proxy==1.4.0
 backports.shutil-get-terminal-size==1.0.0
 datadog==0.44.0
+nbconvert==7.1.0

--- a/test/fixtures/pipenv/Pipfile
+++ b/test/fixtures/pipenv/Pipfile
@@ -10,3 +10,4 @@ beautifulsoup4 = "==4.7.1"
 dataclasses = {version = "==0.6",markers = "python_version < '3.7.0'"}
 pylint = "==2.3.1"
 datadog = "==0.44.0"
+nbconvert = "==7.1.0"

--- a/test/sources/pip_test.rb
+++ b/test/sources/pip_test.rb
@@ -29,7 +29,7 @@ if Licensed::Shell.tool_available?("pip")
         Dir.chdir fixtures do
           dep = source.dependencies.detect { |d| d.name == "Jinja2" }
           assert dep
-          assert_equal "2.9.6", dep.version
+          assert_equal "3.0.0", dep.version
           assert_equal "pip", dep.record["type"]
           assert dep.record["homepage"]
           assert dep.record["summary"]
@@ -50,6 +50,14 @@ if Licensed::Shell.tool_available?("pip")
         Dir.chdir fixtures do
           dep = source.dependencies.detect { |d| d.name == "datadog" }
           assert dep.path.end_with?("license_files")
+          refute_empty dep.license_files
+        end
+      end
+
+      it "finds hatch build backend license contents from .dist-info/licenses" do
+        Dir.chdir fixtures do
+          dep = source.dependencies.detect { |d| d.name == "nbconvert" }
+          assert dep.path.end_with?("licenses")
           refute_empty dep.license_files
         end
       end

--- a/test/sources/pipenv_test.rb
+++ b/test/sources/pipenv_test.rb
@@ -66,6 +66,14 @@ if Licensed::Shell.tool_available?("pipenv")
           refute_empty dep.license_files
         end
       end
+
+      it "finds hatch build backend license contents from .dist-info/licenses" do
+        Dir.chdir fixtures do
+          dep = source.dependencies.detect { |d| d.name == "nbconvert" }
+          assert dep.path.end_with?("licenses")
+          refute_empty dep.license_files
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Python wheels built using hatch installs files in [a "licenses" folder](https://github.com/pypa/hatch/blob/b67a49aa6384269a027a91f845fcacbac3f836ee/backend/src/hatchling/builders/wheel.py#L511) under `dist-info`, which was not previously being looked at.  Longer term it might be better to examine all files under `dist-info` for license contents but this is an ok option in the short term to fix the immediate issue where license files aren't found.