### PR TITLE
Release 3.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## 3.7.4
+
+### Fixed
+
+- Licenses for Python dependencies built with Hatchling are correctly found (https://github.com/github/licensed/pull/547)
+
 ## 3.7.3
 
 ### Fixed
@@ -631,4 +637,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Initial release :tada:
 
-[Unreleased]: https://github.com/github/licensed/compare/3.7.3...HEAD
+[Unreleased]: https://github.com/github/licensed/compare/3.7.4...HEAD

--- a/lib/licensed/version.rb
+++ b/lib/licensed/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Licensed
-  VERSION = "3.7.3".freeze
+  VERSION = "3.7.4".freeze
 
   def self.previous_major_versions
     major_version = Gem::Version.new(Licensed::VERSION).segments.first


### PR DESCRIPTION
## 3.7.4

### Fixed

- Licenses for Python dependencies built with Hatchling are correctly found (https://github.com/github/licensed/pull/547)