### PR TITLE
Try fixing rubocop CI failures

### DIFF
--- a/.licenses/bundler/faraday-net_http.dep.yml
+++ b/.licenses/bundler/faraday-net_http.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: faraday-net_http
-version: 3.0.0
+version: 3.0.1
 type: bundler
 summary: Faraday adapter for Net::HTTP
 homepage: https://github.com/lostisland/faraday-net_http

--- a/licensed.gemspec
+++ b/licensed.gemspec
@@ -36,7 +36,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "minitest", "~> 5.8"
   spec.add_development_dependency "mocha", "~> 1.0"
-  spec.add_development_dependency "rubocop", "~> 1.26", "< 1.27"
   spec.add_development_dependency "rubocop-github", "~> 0.6"
   spec.add_development_dependency "byebug", "~> 11.1.3"
 end


### PR DESCRIPTION
Looks like maybe the new release from rubocop-github is causing some issues here.  I'm trying to fix it by removing the explicit dependency version range from licensed's gemspec, which should pick up newer versions of rubocop and let licensed be a bit more flexible in usage.