### PR TITLE
Ignore nested "metadata" from pip sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@
 /tmp/
 
 # test fixtures
+test/fixtures/**/.licenses
+
 test/fixtures/bundler/.bundle/
 test/fixtures/bundler/vendor/
 test/fixtures/bundler/Gemfile.lock

--- a/lib/licensed/sources/pip.rb
+++ b/lib/licensed/sources/pip.rb
@@ -74,11 +74,13 @@ module Licensed
       # Returns a hash filled with package info parsed from the email-header formatted output
       # returned by `pip show`
       def parse_package_info(package_info)
-        package_info.lines.each_with_object(Hash.new(0)) { |pkg, a|
+        package_info.lines.each_with_object(Hash.new(0)) do |pkg, a|
+          next if pkg.start_with?(/^\s/)
+
           k, v = pkg.split(":", 2)
           next if k.nil? || k.empty?
           a[k.strip] = v&.strip
-        }
+        end
       end
 
       # Returns the output from `pip list --format=json`

--- a/test/fixtures/pip/requirements.txt
+++ b/test/fixtures/pip/requirements.txt
@@ -13,3 +13,4 @@ lazy-object-proxy==1.4.0
 backports.shutil-get-terminal-size==1.0.0
 datadog==0.44.0
 nbconvert==7.1.0
+scipy==1.9.2

--- a/test/sources/pip_test.rb
+++ b/test/sources/pip_test.rb
@@ -61,6 +61,13 @@ if Licensed::Shell.tool_available?("pip")
           refute_empty dep.license_files
         end
       end
+
+      it "does not parse metadata from content" do
+        Dir.chdir fixtures do
+          dep = source.dependencies.detect { |d| d.name == "scipy" }
+          assert dep.record.licenses.any? { |l| l.text.include?("Name: GCC runtime library") }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
closes https://github.com/github/licensed/issues/550

The pip source (and pipenv source by extension) were incorrectly parsing a `Name: GCC runtime library` string from the license field in the `pip show scipy` output as the name of the dependency, overwriting the `Name: scipy` output that was previously detected.

The error came from a combination of two factors:
1. The output parsing is pretty naive and looks only for a `key: value` pair
1. The output from `pip show` is specifically formatted as `RFC-compliant mail header format` with no CLI option to use a different formatting like JSON.

The change here is minimal - since we expect that any multi-line field values will have lines 2+ indented I'm ignoring any line that starts with a whitespace character.