### PR TITLE
Check status of dependencies using computed metadata and configuration file

### DIFF
--- a/docs/commands/status.md
+++ b/docs/commands/status.md
@@ -26,8 +26,8 @@ When using `licensed status` in this scenario, licensed will compile all depende
 
 A dependency will fail the status checks if:
 
-1. The cached record's `licenses` data is empty
-2. The cached record's `license` metadata doesn't match an `allowed` license from the dependency's application configuration and the dependency has not been marked `reviewed` or `ignored`
+1. The record's `licenses` data is empty
+2. The record's `license` metadata doesn't match an `allowed` license from the dependency's application configuration and the dependency has not been marked `reviewed` or `ignored`
    - If `license: other` is specified and all of the `licenses` entries match an `allowed` license a failure will not be logged
    - A `reviewed` entry must reference a specific version of the depdency, e.g. `<name>@<version>`.  The version identifier must specify a specific dependency version, ranges are not allowed.
 

--- a/docs/commands/status.md
+++ b/docs/commands/status.md
@@ -1,16 +1,35 @@
 # `licensed status`
 
-The status command finds all dependencies and checks whether each dependency has a valid cached record.
+The status command finds all dependencies and checks whether each dependency has a valid record.  There are two methods for checking dependencies' statuses
+
+## Checking status with metadata loaded from cached files
+
+This is the default method for checking the status for dependencies and the recommended method for using licensed.  Checking status from cached metadata files will occur when the `--data-source` CLI flag is either unset, or set to `--data-source=files`.
+
+When using `licensed status` in this scenario, licensed will only compile a minimal amount of dependency metadata like the dependency name and version to match against cached files.  Dependency license and notice texts are loaded from cached files that are created from the [licensed cache](./cache.md) command.
 
 A dependency will fail the status checks if:
 
 1. No cached record is found
 2. The cached record's version is different than the current dependency's version
 3. The cached record's `licenses` data is empty
-4. The cached record's `license` metadata doesn't match an `allowed` license from the dependency's application configuration.
+4. The cached record's `license` metadata doesn't match an `allowed` license from the dependency's application configuration and the dependency has not been marked `reviewed` or `ignored`
    - If `license: other` is specified and all of the `licenses` entries match an `allowed` license a failure will not be logged
 5. The cached record is flagged for re-review.
    - This occurs when the record's license text has changed since the record was reviewed.
+
+## Checking status with computed metadata
+
+Checking status with computed metadata and the licensed configuration will occur when the `--data-source` CLI flag is set to `--data-source=configuration`.
+
+When using `licensed status` in this scenario, licensed will compile all dependency metadata and license text to use in status checks.  There is no need to run `licensed cache` prior to running `licensed status --data-source=configuration`.
+
+A dependency will fail the status checks if:
+
+1. The cached record's `licenses` data is empty
+2. The cached record's `license` metadata doesn't match an `allowed` license from the dependency's application configuration and the dependency has not been marked `reviewed` or `ignored`
+   - If `license: other` is specified and all of the `licenses` entries match an `allowed` license a failure will not be logged
+   - A `reviewed` entry must reference a specific version of the depdency, e.g. `<name>@<version>`.  The version identifier must specify a specific dependency version, ranges are not allowed.
 
 ## Options
 
@@ -20,6 +39,9 @@ A dependency will fail the status checks if:
    - default value: not set, all configured sources
 - `--format`/`-f`: the output format
    - default value: `yaml`
+- `--data-source`/`-d`: where to find the data source of records for status checks
+   - available values: `files`, `configuration`
+   - default value: `files`
 - `--force`: if set, forces all dependency metadata files to be recached
    - default value: not set
 
@@ -63,14 +85,16 @@ If the dependency does not include license text but does specify that it uses a 
 
 *Resolution:* Review the changes to the license text and classification, along with other metadata contained in the cached file for the dependency.  If the dependency is still allowable for use in your project, remove the `review_changed_license` key from the cached record file.
 
-### license needs review
+### license needs review / dependency needs review
 
 *Cause:* A dependency is using a license that is not in the configured [allowed list of licenses][allowed], and the dependency has not been marked [ignored] or [reviewed].
 *Resolution:* Review the dependency's usage and specified license with someone familiar with OSS licensing and compliance rules to determine whether the dependency is allowable.  Some common resolutions:
 
-1. The dependency's specified license text differed enough from the standard license text that it was not recognized and classified as `other`.  If, with human review, the license text is recognizable then update the `license: other` value in the cached metadata file to the correct license.
-   - An updated classification will persist through version upgrades until the detected license contents have changed.  The determination is made by [licensee/licensee](https://github.com/licensee/licensee), the library which this tool uses to detect and classify license contents.
+1. The dependency's specified license text differed enough from the standard license text that it was not recognized and classified as `other`.  
+   - This resolution only applies when checking dependency status [with cached metadata files](./#checking-status-with-metadata-loaded-from-cached-files).
+   - If the cached license text is recognizable with human review then update the `license: other` value in the cached metadata file to the correct license. An updated classification will persist through version upgrades until the detected license contents have changed.  The determination is made by [licensee/licensee](https://github.com/licensee/licensee), the library which this tool uses to detect and classify license contents.
 1. The dependency might need to be marked as [ignored] or [reviewed] if either of those scenarios are applicable.
+   - When checking status [with computed metadata](./#checking-status-with-computed-metadata), a reviewed entry must include both the dependency's name and the version that it was reviewed at e.g. `licensed@3.8.0`
 1. If the used license should be allowable without review (if your entity has a legal team, they may want to review this assessment), ensure the license SPDX is set as [allowed] in the licensed configuration file.
 
 [allowed]: ../configuration/allowed_licenses.md

--- a/lib/licensed/cli.rb
+++ b/lib/licensed/cli.rb
@@ -26,8 +26,11 @@ module Licensed
       desc: "Individual source(s) to evaluate.  Must also be enabled via configuration."
     method_option :format, aliases: "-f", enum: ["yaml", "json"],
       desc: "Output format"
+    method_option :data_source, aliases: "-d",
+      enum: ["files", "configuration"], default: "files",
+      desc: "Whether to check compliance status from cached records or the configuration file"
     def status
-      run Licensed::Commands::Status.new(config: config), sources: options[:sources], reporter: options[:format]
+      run Licensed::Commands::Status.new(config: config), sources: options[:sources], reporter: options[:format], data_source: options[:data_source]
     end
 
     desc "list", "List dependencies"

--- a/lib/licensed/configuration.rb
+++ b/lib/licensed/configuration.rb
@@ -98,9 +98,9 @@ module Licensed
     end
 
     # Set a dependency as reviewed
-    def review(dependency)
+    def review(dependency, at_version: false)
       id = dependency["name"]
-      id += "@#{dependency["version"]}" if dependency["version"]
+      id += "@#{dependency["version"]}" if at_version && dependency["version"]
       (self["reviewed"][dependency["type"]] ||= []) << id
     end
 

--- a/lib/licensed/configuration.rb
+++ b/lib/licensed/configuration.rb
@@ -73,17 +73,18 @@ module Licensed
     end
 
     # Is the given dependency reviewed?
-    def reviewed?(dependency)
-      Array(self["reviewed"][dependency["type"]]).any? do |pattern|
-        File.fnmatch?(pattern, dependency["name"], File::FNM_PATHNAME | File::FNM_CASEFOLD)
-      end
+    def reviewed?(dependency, match_version: false)
+      any_list_pattern_matched? self["reviewed"][dependency["type"]], dependency, match_version: match_version
+    end
+
+    # Find all reviewed dependencies that match the provided dependency's name
+    def reviewed_versions(dependency)
+      similar_list_patterns self["reviewed"][dependency["type"]], dependency
     end
 
     # Is the given dependency ignored?
     def ignored?(dependency)
-      Array(self["ignored"][dependency["type"]]).any? do |pattern|
-        File.fnmatch?(pattern, dependency["name"], File::FNM_PATHNAME | File::FNM_CASEFOLD)
-      end
+      any_list_pattern_matched? self["ignored"][dependency["type"]], dependency
     end
 
     # Is the license of the dependency allowed?
@@ -98,7 +99,9 @@ module Licensed
 
     # Set a dependency as reviewed
     def review(dependency)
-      (self["reviewed"][dependency["type"]] ||= []) << dependency["name"]
+      id = dependency["name"]
+      id += "@#{dependency["version"]}" if dependency["version"]
+      (self["reviewed"][dependency["type"]] ||= []) << id
     end
 
     # Set a license as explicitly allowed
@@ -107,6 +110,27 @@ module Licensed
     end
 
     private
+
+    def any_list_pattern_matched?(list, dependency, match_version: false)
+      Array(list).any? do |pattern|
+        if match_version
+          at_version = "@#{dependency["version"]}"
+          pattern, pattern_version = pattern.rpartition(at_version).values_at(0, 1)
+          next false if pattern == "" || pattern_version == ""
+        end
+
+        File.fnmatch?(pattern, dependency["name"], File::FNM_PATHNAME | File::FNM_CASEFOLD)
+      end
+    end
+
+    def similar_list_patterns(list, dependency)
+      Array(list).select do |pattern|
+        pattern, version = pattern.rpartition("@").values_at(0, 2)
+        next if pattern == "" || version == ""
+
+        File.fnmatch?(pattern, dependency["name"], File::FNM_PATHNAME | File::FNM_CASEFOLD)
+      end
+    end
 
     # Returns the cache path for the application based on:
     # 1. An explicitly set cache path for the application, if set

--- a/test/commands/status_test.rb
+++ b/test/commands/status_test.rb
@@ -245,7 +245,7 @@ describe Licensed::Commands::Status do
 
       config.apps.each do |app|
         app.sources.each do |source|
-          app.review "type" => source.class.type, "name" => "dependency"
+          app.review({ "type" => source.class.type, "name" => "dependency" })
         end
       end
 
@@ -443,7 +443,7 @@ describe Licensed::Commands::Status do
           "type" => TestSource.type,
           "name" => TestSource::DEFAULT_DEPENDENCY_NAME,
           "version" => TestSource::DEPENDENCY_VERSION
-        })
+        }, at_version: true)
       end
 
       run_command
@@ -477,7 +477,7 @@ describe Licensed::Commands::Status do
           "type" => TestSource.type,
           "name" => TestSource::DEFAULT_DEPENDENCY_NAME,
           "version" => "0.0.0",
-        })
+        }, at_version: true)
       end
 
       run_command
@@ -537,7 +537,7 @@ describe Licensed::Commands::Status do
           "type" => TestSource.type,
           "name" => TestSource::DEFAULT_DEPENDENCY_NAME,
           "version" => TestSource::DEPENDENCY_VERSION
-        })
+        }, at_version: true)
       end
 
       reporter.report.all_reports.clear

--- a/test/commands/status_test.rb
+++ b/test/commands/status_test.rb
@@ -13,18 +13,6 @@ describe Licensed::Commands::Status do
   let(:fixtures) { File.expand_path("../../fixtures", __FILE__) }
   let(:command) { Licensed::Commands::Status.new(config: config) }
 
-  before do
-    generator_config = Marshal.load(Marshal.dump(config))
-    generator = Licensed::Commands::Cache.new(config: generator_config)
-    generator.run(force: true, reporter: TestReporter.new)
-  end
-
-  after do
-    config.apps.each do |app|
-      FileUtils.rm_rf app.cache_path
-    end
-  end
-
   def dependency_errors(app, source, dependency_name = "dependency")
     app_report = reporter.report.reports.find { |r| r.name == app["name"] }
     assert app_report
@@ -36,264 +24,97 @@ describe Licensed::Commands::Status do
     dependency_report&.errors || []
   end
 
-  it "warns if license is not allowed" do
-    run_command
-    config.apps.each do |app|
-      app.sources.each do |source|
-        assert_includes dependency_errors(app, source), "license needs review: mit"
-      end
-    end
-  end
-
-  it "warns if license text changed and needs re-review" do
-    config.apps.each do |app|
-      path = app.cache_path.join("test/dependency.#{Licensed::DependencyRecord::EXTENSION}")
-      record = Licensed::DependencyRecord.read(path)
-      record["review_changed_license"] = true
-      record.save(path)
+  describe "with cached metadata data source" do
+    before do
+      generator_config = Marshal.load(Marshal.dump(config))
+      generator = Licensed::Commands::Cache.new(config: generator_config)
+      generator.run(force: true, reporter: TestReporter.new)
     end
 
-    run_command
-    config.apps.each do |app|
-      app.sources.each do |source|
-        assert_includes \
-          dependency_errors(app, source),
-          "license text has changed and needs re-review. if the new text is ok, remove the `review_changed_license` flag from the cached record"
-      end
-    end
-  end
-
-  it "does not warn if license is allowed" do
-    config.apps.each do |app|
-      app.allow "mit"
-    end
-
-    run_command
-    config.apps.each do |app|
-      app.sources.each do |source|
-        refute_includes dependency_errors(app, source), "license needs review: mit"
-      end
-    end
-  end
-
-  it "does not warn if dependency is ignored" do
-    run_command
-    config.apps.each do |app|
-      app.sources.each do |source|
-        assert dependency_errors(app, source).any?
-        app.ignore "type" => source.class.type, "name" => "dependency"
-      end
-    end
-
-    run_command
-
-    config.apps.each do |app|
-      app.sources.each do |source|
-        assert dependency_errors(app, source).empty?
-      end
-    end
-  end
-
-  it "does not warn if dependency is reviewed" do
-    run_command
-    config.apps.each do |app|
-      app.sources.each do |source|
-        assert dependency_errors(app, source).any?
-        app.ignore "type" => source.class.type, "name" => "dependency"
-      end
-    end
-
-    run_command
-    config.apps.each do |app|
-      app.sources.each do |source|
-        assert dependency_errors(app, source).empty?
-      end
-    end
-  end
-
-  it "warns if license is empty" do
-    config.apps.each do |app|
-      filename = app.cache_path.join("test/dependency.#{Licensed::DependencyRecord::EXTENSION}")
-      record = Licensed::DependencyRecord.new
-      record.save(filename)
-    end
-
-    run_command
-    config.apps.each do |app|
-      app.sources.each do |source|
-        assert_includes dependency_errors(app, source), "missing license text"
-      end
-    end
-  end
-
-  it "warns if record is empty with notices" do
-    config.apps.each do |app|
-      filename = app.cache_path.join("test/dependency.#{Licensed::DependencyRecord::EXTENSION}")
-      record = Licensed::DependencyRecord.new(notices: ["notice"])
-      record.save(filename)
-    end
-
-    run_command
-    config.apps.each do |app|
-      app.sources.each do |source|
-        assert_includes dependency_errors(app, source), "missing license text"
-      end
-    end
-  end
-
-  it "does not warn if license is not empty" do
-    config.apps.each do |app|
-      filename = app.cache_path.join("test/dependency.#{Licensed::DependencyRecord::EXTENSION}")
-      record = Licensed::DependencyRecord.new(licenses: ["license"])
-      record.save(filename)
-    end
-
-    run_command
-    config.apps.each do |app|
-      app.sources.each do |source|
-        refute_includes dependency_errors(app, source), "missing license text"
-      end
-    end
-  end
-
-  it "warns if versions do not match" do
-    config.apps.each do |app|
-      filename = app.cache_path.join("test/dependency.#{Licensed::DependencyRecord::EXTENSION}")
-      record = Licensed::DependencyRecord.read(filename)
-      record["version"] = "9001"
-      record.save(filename)
-    end
-
-    run_command
-    config.apps.each do |app|
-      app.sources.each do |source|
-        assert_includes dependency_errors(app, source), "cached dependency record out of date"
-      end
-    end
-  end
-
-  it "warns if cached license data missing" do
-    config.apps.each do |app|
-      FileUtils.rm app.cache_path.join("test/dependency.#{Licensed::DependencyRecord::EXTENSION}")
-    end
-
-    run_command
-    config.apps.each do |app|
-      app.sources.each do |source|
-        assert_includes dependency_errors(app, source), "cached dependency record not found"
-      end
-    end
-  end
-
-  it "does not warn if cached license data missing for ignored gem" do
-    config.apps.each do |app|
-      FileUtils.rm app.cache_path.join("test/dependency.#{Licensed::DependencyRecord::EXTENSION}")
-      app.ignore "type" => "test", "name" => "dependency"
-    end
-
-    run_command
-    config.apps.each do |app|
-      app.sources.each do |source|
-        refute_includes dependency_errors(app, source), "cached dependency record not found"
-      end
-    end
-  end
-
-  it "reports a link to the documentation on any failures" do
-    # this is the same error case as "warns if license is not allowed"
-    run_command
-
-    command_errors = reporter.report.errors
-    refute_empty command_errors
-    assert command_errors.any? { |e| e =~ /Licensed found errors during source enumeration.  Please see/ }
-  end
-
-  it "does not include ignored dependencies in dependency counts" do
-    run_command
-    count = reporter.report.all_reports.size
-
-    config.apps.each do |app|
-      app.ignore "type" => "test", "name" => "dependency"
-    end
-
-    run_command
-    ignored_count = reporter.report.all_reports.size
-
-    assert_equal count - config.apps.size, ignored_count
-  end
-
-  it "changes the current directory to app.source_path while running" do
-    config.apps.each do |app|
-      app["source_path"] = fixtures
-    end
-
-    run_command
-
-    reports = reporter.report.all_reports
-    dependency_report = reports.find { |report| report.target.is_a?(Licensed::Dependency) }
-    assert dependency_report
-    assert_equal fixtures, dependency_report.target.path
-  end
-
-  it "reports whether a dependency is allowed" do
-    run_command
-
-    reports = reporter.report.all_reports
-    dependency_report = reports.find { |report| report.target.is_a?(Licensed::Dependency) }
-    refute dependency_report["allowed"]
-
-    config.apps.each do |app|
-      app.sources.each do |source|
-        app.review "type" => source.class.type, "name" => "dependency"
-      end
-    end
-
-    reporter.report.all_reports.clear
-
-    run_command
-
-    reports = reporter.report.all_reports
-    dependency_report = reports.find { |report| report.target.is_a?(Licensed::Dependency) }
-    assert dependency_report["allowed"]
-  end
-
-  it "reports a cached record's recorded license" do
-    run_command
-    reports = reporter.report.all_reports
-    dependency_report = reports.find { |report| report.target.is_a?(Licensed::Dependency) }
-    assert_equal "mit", dependency_report["license"]
-  end
-
-  describe "with multiple apps" do
-    let(:apps) do
-      [
-        {
-          "name" => "app1",
-          "cache_path" => "vendor/licenses/app1",
-          "source_path" => Dir.pwd
-        },
-        {
-          "name" => "app2",
-          "cache_path" => "vendor/licenses/app2",
-          "source_path" => Dir.pwd
-        }
-      ]
-    end
-
-    it "verifies dependencies for all apps" do
-      run_command
-      apps.each do |app|
-        assert reporter.report.reports.find { |report| report.name == app["name"] }
-      end
-    end
-  end
-
-  describe "with explicit dependency file path" do
-    let(:source_config) { { name: "dependency/path" } }
-
-    it "verifies content at explicit path" do
+    after do
       config.apps.each do |app|
-        filename = app.cache_path.join("test/dependency/path.#{Licensed::DependencyRecord::EXTENSION}")
+        FileUtils.rm_rf app.cache_path
+      end
+    end
+
+    it "warns if license is not allowed" do
+      run_command
+      config.apps.each do |app|
+        app.sources.each do |source|
+          assert_includes dependency_errors(app, source), "license needs review: mit"
+        end
+      end
+    end
+
+    it "warns if license text changed and needs re-review" do
+      config.apps.each do |app|
+        path = app.cache_path.join("test/dependency.#{Licensed::DependencyRecord::EXTENSION}")
+        record = Licensed::DependencyRecord.read(path)
+        record["review_changed_license"] = true
+        record.save(path)
+      end
+
+      run_command
+      config.apps.each do |app|
+        app.sources.each do |source|
+          assert_includes \
+            dependency_errors(app, source),
+            "license text has changed and needs re-review. if the new text is ok, remove the `review_changed_license` flag from the cached record"
+        end
+      end
+    end
+
+    it "does not warn if license is allowed" do
+      config.apps.each do |app|
+        app.allow "mit"
+      end
+
+      run_command
+      config.apps.each do |app|
+        app.sources.each do |source|
+          refute_includes dependency_errors(app, source), "license needs review: mit"
+        end
+      end
+    end
+
+    it "does not warn if dependency is ignored" do
+      run_command
+      config.apps.each do |app|
+        app.sources.each do |source|
+          assert dependency_errors(app, source).any?
+          app.ignore "type" => source.class.type, "name" => "dependency"
+        end
+      end
+
+      run_command
+
+      config.apps.each do |app|
+        app.sources.each do |source|
+          assert dependency_errors(app, source).empty?
+        end
+      end
+    end
+
+    it "does not warn if dependency is reviewed" do
+      run_command
+      config.apps.each do |app|
+        app.sources.each do |source|
+          assert dependency_errors(app, source).any?
+          app.ignore "type" => source.class.type, "name" => "dependency"
+        end
+      end
+
+      run_command
+      config.apps.each do |app|
+        app.sources.each do |source|
+          assert dependency_errors(app, source).empty?
+        end
+      end
+    end
+
+    it "warns if license is empty" do
+      config.apps.each do |app|
+        filename = app.cache_path.join("test/dependency.#{Licensed::DependencyRecord::EXTENSION}")
         record = Licensed::DependencyRecord.new
         record.save(filename)
       end
@@ -301,40 +122,329 @@ describe Licensed::Commands::Status do
       run_command
       config.apps.each do |app|
         app.sources.each do |source|
-          assert_includes dependency_errors(app, source, "dependency/path"), "missing license text"
+          assert_includes dependency_errors(app, source), "missing license text"
+        end
+      end
+    end
+
+    it "warns if record is empty with notices" do
+      config.apps.each do |app|
+        filename = app.cache_path.join("test/dependency.#{Licensed::DependencyRecord::EXTENSION}")
+        record = Licensed::DependencyRecord.new(notices: ["notice"])
+        record.save(filename)
+      end
+
+      run_command
+      config.apps.each do |app|
+        app.sources.each do |source|
+          assert_includes dependency_errors(app, source), "missing license text"
+        end
+      end
+    end
+
+    it "does not warn if license is not empty" do
+      config.apps.each do |app|
+        filename = app.cache_path.join("test/dependency.#{Licensed::DependencyRecord::EXTENSION}")
+        record = Licensed::DependencyRecord.new(licenses: ["license"])
+        record.save(filename)
+      end
+
+      run_command
+      config.apps.each do |app|
+        app.sources.each do |source|
+          refute_includes dependency_errors(app, source), "missing license text"
+        end
+      end
+    end
+
+    it "warns if versions do not match" do
+      config.apps.each do |app|
+        filename = app.cache_path.join("test/dependency.#{Licensed::DependencyRecord::EXTENSION}")
+        record = Licensed::DependencyRecord.read(filename)
+        record["version"] = "9001"
+        record.save(filename)
+      end
+
+      run_command
+      config.apps.each do |app|
+        app.sources.each do |source|
+          assert_includes dependency_errors(app, source), "dependency record out of date"
+        end
+      end
+    end
+
+    it "warns if cached license data missing" do
+      config.apps.each do |app|
+        FileUtils.rm app.cache_path.join("test/dependency.#{Licensed::DependencyRecord::EXTENSION}")
+      end
+
+      run_command
+      config.apps.each do |app|
+        app.sources.each do |source|
+          assert_includes dependency_errors(app, source), "cached dependency record not found"
+        end
+      end
+    end
+
+    it "does not warn if cached license data missing for ignored gem" do
+      config.apps.each do |app|
+        FileUtils.rm app.cache_path.join("test/dependency.#{Licensed::DependencyRecord::EXTENSION}")
+        app.ignore "type" => "test", "name" => "dependency"
+      end
+
+      run_command
+      config.apps.each do |app|
+        app.sources.each do |source|
+          refute_includes dependency_errors(app, source), "dependency record not found"
+        end
+      end
+    end
+
+    it "reports a link to the documentation on any failures" do
+      # this is the same error case as "warns if license is not allowed"
+      run_command
+
+      command_errors = reporter.report.errors
+      refute_empty command_errors
+      assert command_errors.any? { |e| e =~ /Licensed found errors during source enumeration.  Please see/ }
+    end
+
+    it "does not include ignored dependencies in dependency counts" do
+      run_command
+      count = reporter.report.all_reports.size
+
+      config.apps.each do |app|
+        app.ignore "type" => "test", "name" => "dependency"
+      end
+
+      run_command
+      ignored_count = reporter.report.all_reports.size
+
+      assert_equal count - config.apps.size, ignored_count
+    end
+
+    it "changes the current directory to app.source_path while running" do
+      config.apps.each do |app|
+        app["source_path"] = fixtures
+      end
+
+      run_command
+
+      reports = reporter.report.all_reports
+      dependency_report = reports.find { |report| report.target.is_a?(Licensed::Dependency) }
+      assert dependency_report
+      assert_equal fixtures, dependency_report.target.path
+    end
+
+    it "reports whether a dependency is allowed" do
+      run_command
+
+      reports = reporter.report.all_reports
+      dependency_report = reports.find { |report| report.target.is_a?(Licensed::Dependency) }
+      refute dependency_report["allowed"]
+
+      config.apps.each do |app|
+        app.sources.each do |source|
+          app.review "type" => source.class.type, "name" => "dependency"
+        end
+      end
+
+      reporter.report.all_reports.clear
+
+      run_command
+
+      reports = reporter.report.all_reports
+      dependency_report = reports.find { |report| report.target.is_a?(Licensed::Dependency) }
+      assert dependency_report["allowed"]
+    end
+
+    it "reports a cached record's recorded license" do
+      run_command
+      reports = reporter.report.all_reports
+      dependency_report = reports.find { |report| report.target.is_a?(Licensed::Dependency) }
+      assert_equal "mit", dependency_report["license"]
+    end
+
+    describe "with multiple apps" do
+      let(:apps) do
+        [
+          {
+            "name" => "app1",
+            "cache_path" => "vendor/licenses/app1",
+            "source_path" => Dir.pwd
+          },
+          {
+            "name" => "app2",
+            "cache_path" => "vendor/licenses/app2",
+            "source_path" => Dir.pwd
+          }
+        ]
+      end
+
+      it "verifies dependencies for all apps" do
+        run_command
+        apps.each do |app|
+          assert reporter.report.reports.find { |report| report.name == app["name"] }
+        end
+      end
+    end
+
+    describe "with explicit dependency file path" do
+      let(:source_config) { { name: "dependency/path" } }
+
+      it "verifies content at explicit path" do
+        config.apps.each do |app|
+          filename = app.cache_path.join("test/dependency/path.#{Licensed::DependencyRecord::EXTENSION}")
+          record = Licensed::DependencyRecord.new
+          record.save(filename)
+        end
+
+        run_command
+        config.apps.each do |app|
+          app.sources.each do |source|
+            assert_includes dependency_errors(app, source, "dependency/path"), "missing license text"
+          end
+        end
+      end
+    end
+
+    describe "with multiple cached license notices" do
+      let(:bsd_3) { Licensed::DependencyRecord::License.new(Licensee::License.find("bsd-3-clause").to_s) }
+      let(:mit) { Licensed::DependencyRecord::License.new(Licensee::License.find("mit").to_s) }
+      let(:agpl_3) { Licensed::DependencyRecord::License.new(Licensee::License.find("agpl-3.0").to_s) }
+      let(:readme_mit) { Licensed::DependencyRecord::License.new("## License:\n\nMIT") }
+
+      before do
+        config.apps.each do |app|
+          app.allow("mit")
+          app.allow("bsd-3-clause")
+        end
+      end
+
+      def update_records(classification, *licenses)
+        config.apps.each do |app|
+          path = app.cache_path.join("test/dependency.#{Licensed::DependencyRecord::EXTENSION}")
+          record = Licensed::DependencyRecord.read(path)
+          record.licenses.clear
+          record.licenses.push(*licenses)
+          record["license"] = classification
+          record.save(path)
+        end
+      end
+
+      it "does not warn if the top level license field is allowed" do
+        # licenses contains an unapproved license notice (agpl-3.0), but should not be checked
+        # because the top level license field is allowed
+        update_records("mit", mit, agpl_3)
+
+        run_command
+        config.apps.each do |app|
+          app.sources.each do |source|
+            assert dependency_errors(app, source).empty?
+          end
+        end
+      end
+
+      it "warns if the top level license field is not allowed and not 'other'" do
+        # both record license texts are approved, but licensed should only check
+        # them when the record's top level license field is set to other
+        update_records("agpl-3.0", mit, bsd_3)
+
+        run_command
+        config.apps.each do |app|
+          app.sources.each do |source|
+            assert_includes dependency_errors(app, source), "license needs review: agpl-3.0"
+          end
+        end
+      end
+
+      it "warns if any of the license notices is not allowed" do
+        # licenses contains an unapproved license notice (agpl-3.0),
+        # and will be checked because the top level license field is set to other
+        update_records("other", mit, agpl_3)
+
+        run_command
+        config.apps.each do |app|
+          app.sources.each do |source|
+            assert_includes dependency_errors(app, source), "license needs review: other"
+          end
+        end
+      end
+
+      it "does not warn if all of the license notices are allowed" do
+        # licenses contains only approved values, which pass status checks
+        # when the top level license field is set to other
+        update_records("other", mit, bsd_3)
+
+        run_command
+        config.apps.each do |app|
+          app.sources.each do |source|
+            assert dependency_errors(app, source).empty?
+          end
+        end
+      end
+
+      it "parses readme contents as well as license text" do
+        # licenses includes content that will be matched as part of a README file,
+        # but not as part of a LICENSE file
+        update_records("other", readme_mit, bsd_3)
+
+        run_command
+        config.apps.each do |app|
+          app.sources.each do |source|
+            assert dependency_errors(app, source).empty?
+          end
         end
       end
     end
   end
 
-  describe "with multiple cached license notices" do
-    let(:bsd_3) { Licensed::DependencyRecord::License.new(Licensee::License.find("bsd-3-clause").to_s) }
-    let(:mit) { Licensed::DependencyRecord::License.new(Licensee::License.find("mit").to_s) }
-    let(:agpl_3) { Licensed::DependencyRecord::License.new(Licensee::License.find("agpl-3.0").to_s) }
-    let(:readme_mit) { Licensed::DependencyRecord::License.new("## License:\n\nMIT") }
+  describe "with configuration data source" do
+    def run_command(**opts)
+      opts = { data_source: "configuration" }.merge(opts)
+      super(**opts)
+    end
 
-    before do
+    it "does not warn if license is allowed" do
       config.apps.each do |app|
-        app.allow("mit")
-        app.allow("bsd-3-clause")
+        app.allow "mit"
+      end
+
+      run_command
+      config.apps.each do |app|
+        app.sources.each do |source|
+          refute_includes dependency_errors(app, source), "dependency needs review"
+        end
       end
     end
 
-    def update_records(classification, *licenses)
+    it "does not warn if dependency is ignored" do
+      run_command
       config.apps.each do |app|
-        path = app.cache_path.join("test/dependency.#{Licensed::DependencyRecord::EXTENSION}")
-        record = Licensed::DependencyRecord.read(path)
-        record.licenses.clear
-        record.licenses.push(*licenses)
-        record["license"] = classification
-        record.save(path)
+        app.sources.each do |source|
+          assert dependency_errors(app, source).any?
+          app.ignore "type" => source.class.type, "name" => "dependency"
+        end
+      end
+
+      run_command
+
+      config.apps.each do |app|
+        app.sources.each do |source|
+          assert dependency_errors(app, source).empty?
+        end
       end
     end
 
-    it "does not warn if the top level license field is allowed" do
-      # licenses contains an unapproved license notice (agpl-3.0), but should not be checked
-      # because the top level license field is allowed
-      update_records("mit", mit, agpl_3)
+    it "does not warn if dependency is reviewed at a specific version" do
+      run_command
+      config.apps.each do |app|
+        app.review({
+          "type" => TestSource.type,
+          "name" => TestSource::DEFAULT_DEPENDENCY_NAME,
+          "version" => TestSource::DEPENDENCY_VERSION
+        })
+      end
 
       run_command
       config.apps.each do |app|
@@ -344,54 +454,128 @@ describe Licensed::Commands::Status do
       end
     end
 
-    it "warns if the top level license field is not allowed and not 'other'" do
-      # both record license texts are approved, but licensed should only check
-      # them when the record's top level license field is set to other
-      update_records("agpl-3.0", mit, bsd_3)
+    it "warns if dependency is marked reviewed without version" do
+      config.apps.each do |app|
+        app.review({
+          "type" => TestSource.type,
+          "name" => TestSource::DEFAULT_DEPENDENCY_NAME
+        })
+      end
 
       run_command
-      config.apps.each do |app|
-        app.sources.each do |source|
-          assert_includes dependency_errors(app, source), "license needs review: agpl-3.0"
-        end
+
+      dependency_report = reporter.report.all_reports.find { |report| report.target.is_a?(Licensed::Dependency) }
+      assert dependency_report.errors.any? do |e|
+        e.match?("dependency needs review") &&
+          e.match?("unversioned 'reviewed' match found: #{TestSource::DEFAULT_DEPENDENCY_NAME}")
       end
     end
 
-    it "warns if any of the license notices is not allowed" do
-      # licenses contains an unapproved license notice (agpl-3.0),
-      # and will be checked because the top level license field is set to other
-      update_records("other", mit, agpl_3)
+    it "warns if dependency is reviewed at different version" do
+      config.apps.each do |app|
+        app.review({
+          "type" => TestSource.type,
+          "name" => TestSource::DEFAULT_DEPENDENCY_NAME,
+          "version" => "0.0.0",
+        })
+      end
 
       run_command
-      config.apps.each do |app|
-        app.sources.each do |source|
-          assert_includes dependency_errors(app, source), "license needs review: other"
-        end
+
+      dependency_report = reporter.report.all_reports.find { |report| report.target.is_a?(Licensed::Dependency) }
+      assert dependency_report.errors.any? do |e|
+        e.match?("dependency needs review") &&
+          e.match?("possible 'reviewed' matches found at other versions: #{TestSource::DEFAULT_DEPENDENCY_NAME}@0.0.0")
       end
     end
 
-    it "does not warn if all of the license notices are allowed" do
-      # licenses contains only approved values, which pass status checks
-      # when the top level license field is set to other
-      update_records("other", mit, bsd_3)
-
+    it "reports a link to the documentation on any failures" do
+      # this is the same error case as "warns if license is not allowed"
       run_command
-      config.apps.each do |app|
-        app.sources.each do |source|
-          assert dependency_errors(app, source).empty?
-        end
-      end
+
+      command_errors = reporter.report.errors
+      refute_empty command_errors
+      assert command_errors.any? { |e| e =~ /Licensed found errors during source enumeration.  Please see/ }
     end
 
-    it "parses readme contents as well as license text" do
-      # licenses includes content that will be matched as part of a README file,
-      # but not as part of a LICENSE file
-      update_records("other", readme_mit, bsd_3)
+    it "does not include ignored dependencies in dependency counts" do
+      run_command
+      count = reporter.report.all_reports.size
+
+      config.apps.each do |app|
+        app.ignore "type" => "test", "name" => "dependency"
+      end
 
       run_command
+      ignored_count = reporter.report.all_reports.size
+
+      assert_equal count - config.apps.size, ignored_count
+    end
+
+    it "changes the current directory to app.source_path while running" do
       config.apps.each do |app|
-        app.sources.each do |source|
-          assert dependency_errors(app, source).empty?
+        app["source_path"] = fixtures
+      end
+
+      run_command
+
+      reports = reporter.report.all_reports
+      dependency_report = reports.find { |report| report.target.is_a?(Licensed::Dependency) }
+      assert dependency_report
+      assert_equal fixtures, dependency_report.target.path
+    end
+
+    it "reports whether a dependency is allowed" do
+      run_command
+
+      reports = reporter.report.all_reports
+      dependency_report = reports.find { |report| report.target.is_a?(Licensed::Dependency) }
+      refute dependency_report["allowed"]
+
+      config.apps.each do |app|
+        app.review({
+          "type" => TestSource.type,
+          "name" => TestSource::DEFAULT_DEPENDENCY_NAME,
+          "version" => TestSource::DEPENDENCY_VERSION
+        })
+      end
+
+      reporter.report.all_reports.clear
+
+      run_command
+
+      reports = reporter.report.all_reports
+      dependency_report = reports.find { |report| report.target.is_a?(Licensed::Dependency) }
+      assert dependency_report["allowed"]
+    end
+
+    it "reports a cached record's recorded license" do
+      run_command
+      reports = reporter.report.all_reports
+      dependency_report = reports.find { |report| report.target.is_a?(Licensed::Dependency) }
+      assert_equal "mit", dependency_report["license"]
+    end
+
+    describe "with multiple apps" do
+      let(:apps) do
+        [
+          {
+            "name" => "app1",
+            "cache_path" => "vendor/licenses/app1",
+            "source_path" => Dir.pwd
+          },
+          {
+            "name" => "app2",
+            "cache_path" => "vendor/licenses/app2",
+            "source_path" => Dir.pwd
+          }
+        ]
+      end
+
+      it "verifies dependencies for all apps" do
+        run_command
+        apps.each do |app|
+          assert reporter.report.reports.find { |report| report.name == app["name"] }
         end
       end
     end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -388,7 +388,7 @@ describe Licensed::AppConfiguration do
         assert config.reviewed?(package)
         refute config.reviewed?(package, match_version: true)
 
-        config.review package
+        config.review package, at_version: true
         refute config.reviewed?(package.merge("version" => "1.0.0"), match_version: true)
         assert config.reviewed?(package, match_version: true)
         assert_equal ["#{package["name"]}@#{package["version"]}"], config.reviewed_versions(package)
@@ -396,12 +396,12 @@ describe Licensed::AppConfiguration do
 
       it "reviewing dependencies at version will not match dependencies without version" do
         package = { "type" => "bundler", "name" => "licensed", "version" => "1.0.0" }
-        config.review(package)
+        config.review(package, at_version: true)
         refute config.reviewed?(package, match_version: false)
       end
 
       it "matches glob patterns for specified versions" do
-        config.review({ "type" => "go", "name" => "github.com/github/**/*", "version" => "1.2.3" })
+        config.review({ "type" => "go", "name" => "github.com/github/**/*", "version" => "1.2.3" }, at_version: true)
         assert_equal ["github.com/github/**/*@1.2.3"], config.reviewed_versions(package)
 
         refute config.reviewed?(package.merge("version" => "1.0.0"), match_version: true)
@@ -413,7 +413,7 @@ describe Licensed::AppConfiguration do
         config.review(package)
         assert_empty config.reviewed_versions(package)
 
-        config.review(package.merge("version" => "1.2.3"))
+        config.review(package.merge("version" => "1.2.3"), at_version: true)
         assert_equal ["@github/package@1.2.3"], config.reviewed_versions(package)
       end
     end

--- a/test/test_helpers/test_source.rb
+++ b/test/test_helpers/test_source.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 class TestSource < Licensed::Sources::Source
-  def initialize(config, name = "dependency", metadata = {})
+  DEPENDENCY_VERSION = "1.0".freeze
+  DEFAULT_DEPENDENCY_NAME = "dependency".freeze
+
+  def initialize(config, name = DEFAULT_DEPENDENCY_NAME, metadata = {})
     super config
     @name = name
     @metadata = metadata
@@ -18,7 +21,7 @@ class TestSource < Licensed::Sources::Source
   def enumerate_dependencies
     dependency_config = {
       name: @name,
-      version: "1.0",
+      version: DEPENDENCY_VERSION,
       path: Dir.pwd,
       metadata: {
         "type" => TestSource.type,


### PR DESCRIPTION
closes https://github.com/github/licensed/issues/541

This PR proposes a new way of running `licensed status` that does not require the prior use of `licensed cache`.

A new `--data-source` CLI option has been added to the `licensed status` CLI command, with available values of `files` and `configuration`.  `files` is the default value and maps to licensed's current behavior that requires `licensed cache` to be run and metadata files to be present in the repository under the configured `cache_path`.

Using the `configuration` option value allows small teams and projects to check their compliance without needing to first cache files.  The license metadata and contents/text are computed when the CLI command is run rather than loading data from a file.

One explicit behavior change in this PR is that dependencies added to the `reviewed` configuration must include a version identifier.  For example if licensed finds a dependency named `my_dependency` at version `v1.2.3`, the reviewed list must contain an entry for `my_dependency@v1.2.3` and not `my_dependency`.

I've tried to make the error output more helpful by including possible near-matches in common scenarios:
- when the reviewed list contains `my_dependency` rather than `my_dependency@v1.2.3`
- when the reviewed list matches a dependency at a different version

cc @ericcornelissen I'd appreciate if you can take a look and let me know if this would solve the underlying need from the linked issue you opened.  also if you wouldn't mind reading [the updated docs page](https://github.com/github/licensed/blob/reviewed-dependency-version/docs/commands/status.md) and letting me know if you think it's clear how to use the new behavior?