### PR TITLE
Update otp and elixir tested versions in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -343,8 +343,8 @@ jobs:
     needs: core
     strategy:
       matrix:
-        otp: [22.x, 23.x, 24.x]
-        elixir: [ 1.11.x, 1.12.x ]
+        otp: [24.x, 25.x]
+        elixir: [ 1.13.x, 1.14.x ]
     steps:
     - uses: actions/checkout@v3
     - uses: erlef/setup-beam@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -505,11 +505,11 @@ jobs:
       run: script/test pipenv
 
   swift:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: core
     strategy:
       matrix:
-        swift: [ "5.4", "5.3" ]
+        swift: [ "5.7", "5.6" ]
     steps:
     - uses: actions/checkout@v3
     - name: Setup Swift


### PR DESCRIPTION
The `ubuntu-latest` os type in actions is updating from `ubuntu-20.04` to `ubuntu-22.04`.  `erlef/setup-beam` only support OTP versions 24 and 25 on 22.04 which led to [errors running tests in CI](https://github.com/github/licensed/actions/runs/3344294382/jobs/5538521886)

I took this as an opportunity to update tested framework versions for mix dependencies.  Both OTP and elixir primarily support only the current release, with critical fixes being made to prior releases as needed.  I couldn't find any further documentation about how long previous releases get security fixes, so I updated CI to work with OTP major versions 24 and 25. From there I updated elixir versions for what looked like compatibility - minor versions 1.13 and 1.14.