### PR TITLE
Try building ruby-packer on demand from source

### DIFF
--- a/.github/workflows/build-packer.yml
+++ b/.github/workflows/build-packer.yml
@@ -1,0 +1,72 @@
+name: Build ruby-packer
+on:
+  workflow_dispatch:
+    inputs:
+      source_repository:
+        description: "Source ruby-packer repo to compile binary from"
+        required: true
+        default: "ericbeland/ruby-packer"
+    
+jobs:
+  make-linux:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: "Install dependencies"
+        run: |
+          sudo apt update
+          sudo apt install -y build-essential squashfs-tools
+      - uses: actions/checkout@v3
+        with:
+          repository: ${{ inputs.source_repository }}
+      - name: "Check dependencies"
+        run: |
+          cat /etc/issue
+          uname -a
+          uname -p
+          uname -m
+          lscpu
+          which mksquashfs
+          mksquashfs -version
+      - name: "Set up Ruby"
+        uses: ruby/setup-ruby@v1
+      - name: "Bundle install"
+        run: bundle install
+      - name: "Build"
+        run: bundle exec rake rubyc
+      - name: "Upload"
+        uses: actions/upload-artifact@v2
+        with:
+          name: rubyc-linux
+          path: rubyc
+
+  make-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: ${{ inputs.source_repository }}
+      - name: "Install dependencies"
+        run: |
+          brew upgrade
+          brew install squashfs
+      - name: "Check dependencies"
+        run: |
+          sw_vers
+          uname -a
+          uname -p
+          uname -m
+          sysctl -n machdep.cpu.brand_string
+          which mksquashfs
+          mksquashfs -version
+      - name: "Set up Ruby"
+        uses: ruby/setup-ruby@v1
+      - name: "Bundle install"
+        run: bundle install
+      - name: "Build"
+        run: bundle exec rake rubyc
+      - name: "Upload"
+        uses: actions/upload-artifact@v2
+        with:
+          name: rubyc-macos
+          path: rubyc
+

--- a/.github/workflows/build-packer.yml
+++ b/.github/workflows/build-packer.yml
@@ -6,6 +6,10 @@ on:
         description: "Source ruby-packer repo to compile binary from"
         required: true
         default: "ericbeland/ruby-packer"
+      ref:
+        description: "Git ref to checkout the source repository at"
+        required: true
+        default: "master"
     
 jobs:
   make-linux:
@@ -18,6 +22,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: ${{ inputs.source_repository }}
+          ref: ${{ inputs.ref }}
       - name: "Check dependencies"
         run: |
           cat /etc/issue
@@ -45,6 +50,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: ${{ inputs.source_repository }}
+          ref: ${{ inputs.ref }}
       - name: "Install dependencies"
         run: |
           brew upgrade


### PR DESCRIPTION
Exploring using actions in this repo to build a version of ruby-packer from a source repository.  

The current version of ruby-packer used for distributed binaries is 2.6 which is quite old.  I'd like to be able to use builds that include newer versions of ruby but those are only available from forks of the original repo, which don't always have releases with prebuilt binaries available.

The goal, if this works, is to store compiled rubyc binaries in a release in this repo to remove the external dependency.