### PR TITLE
License updates for dependabot/bundler/mocha-tw-2.0

### DIFF
--- a/.licenses/bundler/bundler.dep.yml
+++ b/.licenses/bundler/bundler.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: bundler
-version: 2.3.24
+version: 2.3.25
 type: bundler
 summary: The best way to manage your application's dependencies
 homepage: https://bundler.io


### PR DESCRIPTION
This PR was auto generated by the `licensed-ci` GitHub Action.
It contains updates to cached `github/licensed` dependency metadata to be merged into `dependabot/bundler/mocha-tw-2.0`: ([branch](https://github.com/github/licensed/tree/dependabot/bundler/mocha-tw-2.0), [PR](https://github.com/github/licensed/pull/568)).

The `licensed-ci` action will add comments to this PR with the status of license checks.  Please make any changes needed to fix any status failures on this branch, then merge license updates into your branch.

If updates are unexpected, please check the `github/licensed` [changelog](https://github.com/github/licensed/tree/master/CHANGELOG.md) for recent updates.