### PR TITLE
Allow generating notice file from live computed data

### DIFF
--- a/lib/licensed/cli.rb
+++ b/lib/licensed/cli.rb
@@ -46,13 +46,15 @@ module Licensed
       run Licensed::Commands::List.new(config: config), sources: options[:sources], reporter: options[:format], licenses: options[:licenses]
     end
 
-    desc "notices", "Generate a NOTICE file from cached records"
+    desc "notices", "Generate a NOTICE file with dependency data"
     method_option :config, aliases: "-c", type: :string,
       desc: "Path to licensed configuration file"
     method_option :sources, aliases: "-s", type: :array,
       desc: "Individual source(s) to evaluate.  Must also be enabled via configuration."
+    method_option :computed, aliases: "-l", type: :boolean,
+      desc: "Whether to generate a NOTICE file using computed data or cached records"
     def notices
-      run Licensed::Commands::Notices.new(config: config), sources: options[:sources]
+      run Licensed::Commands::Notices.new(config: config), sources: options[:sources], computed: options[:computed]
     end
 
     map "-v" => :version

--- a/lib/licensed/commands/notices.rb
+++ b/lib/licensed/commands/notices.rb
@@ -13,7 +13,7 @@ module Licensed
 
       protected
 
-      # Load stored dependency record data to add to the notices report.
+      # Load a dependency record data and add it to the notices report.
       #
       # app - The application configuration for the dependency
       # source - The dependency source enumerator for the dependency
@@ -22,13 +22,36 @@ module Licensed
       #
       # Returns true.
       def evaluate_dependency(app, source, dependency, report)
+        report["record"] =
+          if load_dependency_record_from_files
+            load_cached_dependency_record(app, source, dependency, report)
+          else
+            dependency.record
+          end
+
+        true
+      end
+
+      # Loads a dependency record from a cached file.
+      #
+      # app - The application configuration for the dependency
+      # source - The dependency source enumerator for the dependency
+      # dependency - An application dependency
+      # report - A report hash for the command to provide extra data for the report output.
+      #
+      # Returns a dependency record or nil if one doesn't exist
+      def load_cached_dependency_record(app, source, dependency, report)
         filename = app.cache_path.join(source.class.type, "#{dependency.name}.#{DependencyRecord::EXTENSION}")
-        report["cached_record"] = Licensed::DependencyRecord.read(filename)
-        if !report["cached_record"]
+        record = Licensed::DependencyRecord.read(filename)
+        if !record
           report.warnings << "expected cached record not found at #{filename}"
         end
 
-        true
+        record
+      end
+
+      def load_dependency_record_from_files
+        !options.fetch(:computed, false)
       end
     end
   end

--- a/lib/licensed/reporters/notices_reporter.rb
+++ b/lib/licensed/reporters/notices_reporter.rb
@@ -54,11 +54,11 @@ module Licensed
       def notices(report)
         return unless report.target.is_a?(Licensed::Dependency)
 
-        cached_record = report["cached_record"]
-        return unless cached_record
+        record = report["record"]
+        return unless record
 
-        texts = cached_record.licenses.map(&:text)
-        cached_record.notices.each do |notice|
+        texts = record.licenses.map(&:text)
+        record.notices.each do |notice|
           case notice
           when Hash
             texts << notice["text"]
@@ -70,7 +70,7 @@ module Licensed
         end
 
         <<~NOTICE
-          #{cached_record["name"]}@#{cached_record["version"]}
+          #{record["name"]}@#{record["version"]}
 
           #{texts.map(&:strip).reject(&:empty?).compact.join(TEXT_SEPARATOR)}
         NOTICE


### PR DESCRIPTION
addresses https://github.com/github/licensed/pull/560#issuecomment-1312449501

This adds a `--computed` long form, `-l` short form option to `licensed notice`.  When set, the command will generate a NOTICE file from dependency data computed dynamically, rather than loading dependency data from metadata files.