### PR TITLE
License updates for computed-notices

### DIFF
--- a/.licenses/bundler/bundler.dep.yml
+++ b/.licenses/bundler/bundler.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: bundler
-version: 2.3.24
+version: 2.3.25
 type: bundler
 summary: The best way to manage your application's dependencies
 homepage: https://bundler.io

--- a/.licenses/bundler/faraday-net_http.dep.yml
+++ b/.licenses/bundler/faraday-net_http.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: faraday-net_http
-version: 3.0.1
+version: 3.0.2
 type: bundler
 summary: Faraday adapter for Net::HTTP
 homepage: https://github.com/lostisland/faraday-net_http


### PR DESCRIPTION
This PR was auto generated by the `licensed-ci` GitHub Action.
It contains updates to cached `github/licensed` dependency metadata to be merged into `computed-notices`: ([branch](https://github.com/github/licensed/tree/computed-notices), [PR](https://github.com/github/licensed/pull/572)).

The `licensed-ci` action will add comments to this PR with the status of license checks.  Please make any changes needed to fix any status failures on this branch, then merge license updates into your branch.

If updates are unexpected, please check the `github/licensed` [changelog](https://github.com/github/licensed/tree/master/CHANGELOG.md) for recent updates.