### PR TITLE
License updates for sort-by-sources-path-as-strings

### DIFF
--- a/.licenses/bundler/bundler.dep.yml
+++ b/.licenses/bundler/bundler.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: bundler
-version: 2.3.25
+version: 2.3.26
 type: bundler
 summary: The best way to manage your application's dependencies
 homepage: https://bundler.io

--- a/.licenses/bundler/faraday.dep.yml
+++ b/.licenses/bundler/faraday.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: faraday
-version: 2.6.0
+version: 2.7.1
 type: bundler
 summary: HTTP/REST API client library.
 homepage: https://lostisland.github.io/faraday


### PR DESCRIPTION
This PR was auto generated by the `licensed-ci` GitHub Action.
It contains updates to cached `github/licensed` dependency metadata to be merged into `sort-by-sources-path-as-strings`: ([branch](https://github.com/github/licensed/tree/sort-by-sources-path-as-strings), [PR](https://github.com/github/licensed/pull/578)).

The `licensed-ci` action will add comments to this PR with the status of license checks.  Please make any changes needed to fix any status failures on this branch, then merge license updates into your branch.

If updates are unexpected, please check the `github/licensed` [changelog](https://github.com/github/licensed/tree/master/CHANGELOG.md) for recent updates.