### PR TITLE
License updates for no_more_ruby_packer

### DIFF
--- a/.licenses/bundler/json.dep.yml
+++ b/.licenses/bundler/json.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: json
-version: 2.6.2
+version: 2.6.3
 type: bundler
 summary: JSON Implementation for Ruby
 homepage: http://flori.github.com/json

--- a/.licenses/bundler/licensee.dep.yml
+++ b/.licenses/bundler/licensee.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: licensee
-version: 9.15.2
+version: 9.15.3
 type: bundler
 summary: A Ruby Gem to detect open source project licenses
 homepage: https://github.com/benbalter/licensee

--- a/.licenses/bundler/nokogiri.dep.yml
+++ b/.licenses/bundler/nokogiri.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: nokogiri
-version: 1.13.9
+version: 1.13.10
 type: bundler
 summary: Nokogiri (鋸) makes it easy and painless to work with XML and HTML from Ruby.
 homepage: https://nokogiri.org

--- a/.licenses/bundler/octokit.dep.yml
+++ b/.licenses/bundler/octokit.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: octokit
-version: 4.25.1
+version: 6.0.1
 type: bundler
 summary: Ruby toolkit for working with the GitHub API
 homepage: https://github.com/octokit/octokit.rb

--- a/.licenses/bundler/public_suffix.dep.yml
+++ b/.licenses/bundler/public_suffix.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: public_suffix
-version: 5.0.0
+version: 5.0.1
 type: bundler
 summary: Domain name parser based on the Public Suffix List.
 homepage: https://simonecarletti.com/code/publicsuffix-ruby

--- a/.licenses/bundler/racc.dep.yml
+++ b/.licenses/bundler/racc.dep.yml
@@ -1,9 +1,9 @@
 ---
 name: racc
-version: 1.6.0
+version: 1.6.1
 type: bundler
 summary: Racc is a LALR(1) parser generator
-homepage: https://i.loveruby.net/en/projects/racc/
+homepage: https://github.com/ruby/racc
 license: other
 licenses:
 - sources: COPYING

--- a/.licenses/bundler/reverse_markdown.dep.yml
+++ b/.licenses/bundler/reverse_markdown.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: reverse_markdown
-version: 1.4.0
+version: 2.1.1
 type: bundler
 summary: Convert html code into markdown.
 homepage: http://github.com/xijo/reverse_markdown


### PR DESCRIPTION
This PR was auto generated by the `licensed-ci` GitHub Action.
It contains updates to cached `github/licensed` dependency metadata to be merged into `no_more_ruby_packer`: ([branch](https://github.com/github/licensed/tree/no_more_ruby_packer), [PR](https://github.com/github/licensed/pull/586)).

The `licensed-ci` action will add comments to this PR with the status of license checks.  Please make any changes needed to fix any status failures on this branch, then merge license updates into your branch.

If updates are unexpected, please check the `github/licensed` [changelog](https://github.com/github/licensed/tree/master/CHANGELOG.md) for recent updates.