### PR TITLE
chore: add installation from Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ And then execute:
 $> bundle
 ```
 
+### With a Homebrew (on macOS)
+
+```bash
+brew install licensed
+```
+
 ### As an executable
 
 Download a package from GitHub and extract the executable.  Executable packages are available for each release starting with version 1.2.0.


### PR DESCRIPTION
Hi there, and thanks for your great package.

## Why

In https://github.com/Homebrew/homebrew-core/pull/112414, I added the `licensed` formula to Homebrew.
Now macOS users can install the licensed with the following command.

```bash
brew install licensed
```

## What

- add a description about installation from Homebrew
