### PR TITLE
License updates for cleanup-ruby-usage

### DIFF
--- a/.licensed.yml
+++ b/.licensed.yml
@@ -7,8 +7,17 @@ allowed:
 
 reviewed:
   bundler:
+    # bsd-3 and mit
+    - ffi
+  
+    # ruby license
     - json
+    - httpclient
     - pathname-common_prefix
+
+    # bsd-2 or ruby
     - racc
-    - reverse_markdown
     - ruby2_keywords
+
+    # dwtfyw
+    - reverse_markdown

--- a/.licenses/bundler/activesupport.dep.yml
+++ b/.licenses/bundler/activesupport.dep.yml
@@ -1,16 +1,15 @@
 ---
-name: public_suffix
-version: 4.0.7
+name: activesupport
+version: 6.1.7
 type: bundler
-summary: Domain name parser based on the Public Suffix List.
-homepage: https://simonecarletti.com/code/publicsuffix-ruby
+summary: A toolkit of support libraries and Ruby core extensions extracted from the
+  Rails framework.
+homepage: https://rubyonrails.org
 license: mit
 licenses:
-- sources: LICENSE.txt
+- sources: MIT-LICENSE
   text: |
-    Copyright (c) 2009-2022 Simone Carletti <weppos@weppos.net>
-
-    MIT License
+    Copyright (c) 2005-2022 David Heinemeier Hansson
 
     Permission is hereby granted, free of charge, to any person obtaining
     a copy of this software and associated documentation files (the
@@ -30,9 +29,9 @@ licenses:
     LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
     OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
     WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-- sources: README.md
+- sources: README.rdoc
   text: |-
-    Copyright (c) 2009-2022 Simone Carletti. This is Free Software distributed under the MIT license.
+    Active Support is released under the MIT license:
 
-    The [Public Suffix List source](https://publicsuffix.org/list/) is subject to the terms of the Mozilla Public License, v. 2.0.
+    * https://opensource.org/licenses/MIT
 notices: []

--- a/.licenses/bundler/algoliasearch.dep.yml
+++ b/.licenses/bundler/algoliasearch.dep.yml
@@ -1,17 +1,16 @@
 ---
-name: bundler
-version: 2.3.26
+name: algoliasearch
+version: 1.27.5
 type: bundler
-summary: The best way to manage your application's dependencies
-homepage: https://bundler.io
+summary: A simple Ruby client for the algolia.com REST API
+homepage: https://github.com/algolia/algoliasearch-client-ruby
 license: mit
 licenses:
-- sources: LICENSE.md
+- sources: LICENSE
   text: |
-    The MIT License
+    MIT License
 
-    Portions copyright (c) 2010-2019 André Arko
-    Portions copyright (c) 2009 Engine Yard
+    Copyright (c) 2013-Present Algolia
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal
@@ -20,16 +19,14 @@ licenses:
     copies of the Software, and to permit persons to whom the Software is
     furnished to do so, subject to the following conditions:
 
-    The above copyright notice and this permission notice shall be included in
-    all copies or substantial portions of the Software.
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
 
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-    THE SOFTWARE.
-- sources: README.md
-  text: Bundler is available under an [MIT License](https://github.com/rubygems/rubygems/blob/master/bundler/LICENSE.md).
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
 notices: []

--- a/.licenses/bundler/cocoapods-core.dep.yml
+++ b/.licenses/bundler/cocoapods-core.dep.yml
@@ -1,0 +1,33 @@
+---
+name: cocoapods-core
+version: 1.11.3
+type: bundler
+summary: The models of CocoaPods
+homepage: https://github.com/CocoaPods/CocoaPods
+license: mit
+licenses:
+- sources: LICENSE
+  text: |
+    Copyright (c) 2011 - 2012 Eloy Durán <eloy.de.enige@gmail.com>
+    Copyright (c)        2012 Fabio Pelosin <fabiopelosin@gmail.com>
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+- sources: README.md
+  text: This gem and CocoaPods are available under the MIT license.
+notices: []

--- a/.licenses/bundler/concurrent-ruby.dep.yml
+++ b/.licenses/bundler/concurrent-ruby.dep.yml
@@ -1,0 +1,33 @@
+---
+name: concurrent-ruby
+version: 1.1.10
+type: bundler
+summary: Modern concurrency tools for Ruby. Inspired by Erlang, Clojure, Scala, Haskell,
+  F#, C#, Java, and classic concurrency patterns.
+homepage: http://www.concurrent-ruby.com
+license: other
+licenses:
+- sources: LICENSE.txt
+  text: |
+    Copyright (c) Jerry D'Antonio -- released under the MIT license.
+
+    http://www.opensource.org/licenses/mit-license.php
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+notices: []

--- a/.licenses/bundler/concurrent-ruby.dep.yml
+++ b/.licenses/bundler/concurrent-ruby.dep.yml
@@ -5,7 +5,7 @@ type: bundler
 summary: Modern concurrency tools for Ruby. Inspired by Erlang, Clojure, Scala, Haskell,
   F#, C#, Java, and classic concurrency patterns.
 homepage: http://www.concurrent-ruby.com
-license: other
+license: mit
 licenses:
 - sources: LICENSE.txt
   text: |

--- a/.licenses/bundler/ethon.dep.yml
+++ b/.licenses/bundler/ethon.dep.yml
@@ -1,16 +1,14 @@
 ---
-name: public_suffix
-version: 4.0.7
+name: ethon
+version: 0.16.0
 type: bundler
-summary: Domain name parser based on the Public Suffix List.
-homepage: https://simonecarletti.com/code/publicsuffix-ruby
+summary: Libcurl wrapper.
+homepage: https://github.com/typhoeus/ethon
 license: mit
 licenses:
-- sources: LICENSE.txt
+- sources: LICENSE
   text: |
-    Copyright (c) 2009-2022 Simone Carletti <weppos@weppos.net>
-
-    MIT License
+    Copyright (c) 2012-2016 Hans Hasselberg
 
     Permission is hereby granted, free of charge, to any person obtaining
     a copy of this software and associated documentation files (the
@@ -30,9 +28,4 @@ licenses:
     LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
     OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
     WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-- sources: README.md
-  text: |-
-    Copyright (c) 2009-2022 Simone Carletti. This is Free Software distributed under the MIT license.
-
-    The [Public Suffix List source](https://publicsuffix.org/list/) is subject to the terms of the Mozilla Public License, v. 2.0.
 notices: []

--- a/.licenses/bundler/faraday.dep.yml
+++ b/.licenses/bundler/faraday.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: faraday
-version: 2.7.1
+version: 2.7.2
 type: bundler
 summary: HTTP/REST API client library.
 homepage: https://lostisland.github.io/faraday

--- a/.licenses/bundler/ffi.dep.yml
+++ b/.licenses/bundler/ffi.dep.yml
@@ -1,0 +1,114 @@
+---
+name: ffi
+version: 1.15.5
+type: bundler
+summary: Ruby FFI
+homepage: https://github.com/ffi/ffi/wiki
+license: other
+licenses:
+- sources: LICENSE
+  text: |
+    Copyright (c) 2008-2016, Ruby FFI project contributors
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+        * Redistributions of source code must retain the above copyright
+          notice, this list of conditions and the following disclaimer.
+        * Redistributions in binary form must reproduce the above copyright
+          notice, this list of conditions and the following disclaimer in the
+          documentation and/or other materials provided with the distribution.
+        * Neither the name of the Ruby FFI project nor the
+          names of its contributors may be used to endorse or promote products
+          derived from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+    ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+- sources: COPYING
+  text: |+
+    Copyright (c) 2008-2013, Ruby FFI project contributors
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+        * Redistributions of source code must retain the above copyright
+          notice, this list of conditions and the following disclaimer.
+        * Redistributions in binary form must reproduce the above copyright
+          notice, this list of conditions and the following disclaimer in the
+          documentation and/or other materials provided with the distribution.
+        * Neither the name of the Ruby FFI project nor the
+          names of its contributors may be used to endorse or promote products
+          derived from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+    ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+    libffi, used by this project, is licensed under the MIT license:
+
+    libffi - Copyright (c) 1996-2011  Anthony Green, Red Hat, Inc and others.
+    See source files for details.
+
+    Permission is hereby granted, free of charge, to any person obtaining
+    a copy of this software and associated documentation files (the
+    ``Software''), to deal in the Software without restriction, including
+    without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to
+    permit persons to whom the Software is furnished to do so, subject to
+    the following conditions:
+
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED ``AS IS'', WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+- sources: LICENSE.SPECS
+  text: |
+    Copyright (c) 2008-2012 Ruby-FFI contributors
+
+    Permission is hereby granted, free of charge, to any person
+    obtaining a copy of this software and associated documentation
+    files (the "Software"), to deal in the Software without
+    restriction, including without limitation the rights to use,
+    copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following
+    conditions:
+
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+    OTHER DEALINGS IN THE SOFTWARE.
+- sources: README.md
+  text: |-
+    The ffi library is covered by the BSD license, also see the LICENSE file.
+    The specs are covered by the same license as [ruby/spec](https://github.com/ruby/spec), the MIT license.
+notices: []

--- a/.licenses/bundler/fuzzy_match.dep.yml
+++ b/.licenses/bundler/fuzzy_match.dep.yml
@@ -1,16 +1,15 @@
 ---
-name: public_suffix
-version: 4.0.7
+name: fuzzy_match
+version: 2.0.4
 type: bundler
-summary: Domain name parser based on the Public Suffix List.
-homepage: https://simonecarletti.com/code/publicsuffix-ruby
+summary: Find a needle in a haystack using string similarity and (optionally) regexp
+  rules. Replaces loose_tight_dictionary.
+homepage: https://github.com/seamusabshere/fuzzy_match
 license: mit
 licenses:
-- sources: LICENSE.txt
+- sources: LICENSE
   text: |
-    Copyright (c) 2009-2022 Simone Carletti <weppos@weppos.net>
-
-    MIT License
+    Copyright 2011 Brighter Planet, Inc.
 
     Permission is hereby granted, free of charge, to any person obtaining
     a copy of this software and associated documentation files (the
@@ -30,9 +29,4 @@ licenses:
     LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
     OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
     WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-- sources: README.md
-  text: |-
-    Copyright (c) 2009-2022 Simone Carletti. This is Free Software distributed under the MIT license.
-
-    The [Public Suffix List source](https://publicsuffix.org/list/) is subject to the terms of the Mozilla Public License, v. 2.0.
 notices: []

--- a/.licenses/bundler/httpclient.dep.yml
+++ b/.licenses/bundler/httpclient.dep.yml
@@ -1,0 +1,20 @@
+---
+name: httpclient
+version: 2.8.3
+type: bundler
+summary: gives something like the functionality of libwww-perl (LWP) in Ruby
+homepage: https://github.com/nahi/httpclient
+license: other
+licenses:
+- sources: README.md
+  text: |-
+    This program is copyrighted free software by NAKAMURA, Hiroshi.  You can
+    redistribute it and/or modify it under the same terms of Ruby's license;
+    either the dual license version in 2003, or any later version.
+
+    httpclient/session.rb is based on http-access.rb in http-access/0.0.4.  Some
+    part of it is copyrighted by Maebashi-san who made and published
+    http-access/0.0.4.  http-access/0.0.4 did not include license notice but when
+    I asked Maebashi-san he agreed that I can redistribute it under the same terms
+    of Ruby.  Many thanks to Maebashi-san.
+notices: []

--- a/.licenses/bundler/i18n.dep.yml
+++ b/.licenses/bundler/i18n.dep.yml
@@ -1,16 +1,14 @@
 ---
-name: public_suffix
-version: 4.0.7
+name: i18n
+version: 1.12.0
 type: bundler
-summary: Domain name parser based on the Public Suffix List.
-homepage: https://simonecarletti.com/code/publicsuffix-ruby
+summary: New wave Internationalization support for Ruby
+homepage: https://github.com/ruby-i18n/i18n
 license: mit
 licenses:
-- sources: LICENSE.txt
-  text: |
-    Copyright (c) 2009-2022 Simone Carletti <weppos@weppos.net>
-
-    MIT License
+- sources: MIT-LICENSE
+  text: |-
+    Copyright (c) 2008 The Ruby I18n team
 
     Permission is hereby granted, free of charge, to any person obtaining
     a copy of this software and associated documentation files (the
@@ -31,8 +29,5 @@ licenses:
     OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
     WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 - sources: README.md
-  text: |-
-    Copyright (c) 2009-2022 Simone Carletti. This is Free Software distributed under the MIT license.
-
-    The [Public Suffix List source](https://publicsuffix.org/list/) is subject to the terms of the Mozilla Public License, v. 2.0.
+  text: MIT License. See the included MIT-LICENSE file.
 notices: []

--- a/.licenses/bundler/minitest.dep.yml
+++ b/.licenses/bundler/minitest.dep.yml
@@ -1,0 +1,34 @@
+---
+name: minitest
+version: 5.16.3
+type: bundler
+summary: minitest provides a complete suite of testing facilities supporting TDD,
+  BDD, mocking, and benchmarking
+homepage: https://github.com/seattlerb/minitest
+license: mit
+licenses:
+- sources: README.rdoc
+  text: |-
+    (The MIT License)
+
+    Copyright (c) Ryan Davis, seattle.rb
+
+    Permission is hereby granted, free of charge, to any person obtaining
+    a copy of this software and associated documentation files (the
+    'Software'), to deal in the Software without restriction, including
+    without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to
+    permit persons to whom the Software is furnished to do so, subject to
+    the following conditions:
+
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+notices: []

--- a/.licenses/bundler/nap.dep.yml
+++ b/.licenses/bundler/nap.dep.yml
@@ -1,0 +1,29 @@
+---
+name: nap
+version: 1.1.0
+type: bundler
+summary: Nap is a really simple REST library.
+homepage: https://github.com/Fingertips/nap
+license: mit
+licenses:
+- sources: LICENSE
+  text: |
+    Copyright (c) 2015 Manfred Stienstra, Fingertips <manfred@fngtps.com>
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of
+    this software and associated documentation files (the "Software"), to deal in
+    the Software without restriction, including without limitation the rights to
+    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+    the Software, and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+notices: []

--- a/.licenses/bundler/netrc.dep.yml
+++ b/.licenses/bundler/netrc.dep.yml
@@ -1,0 +1,31 @@
+---
+name: netrc
+version: 0.11.0
+type: bundler
+summary: Library to read and write netrc files.
+homepage: https://github.com/geemus/netrc
+license: mit
+licenses:
+- sources: LICENSE.md
+  text: |
+    The MIT License (MIT)
+
+    Copyright (c) 2011-2014 [CONTRIBUTORS.md](https://github.com/geemus/netrc/blob/master/CONTRIBUTORS.md)
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of
+    this software and associated documentation files (the "Software"), to deal in
+    the Software without restriction, including without limitation the rights to
+    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+    the Software, and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+notices: []

--- a/.licenses/bundler/typhoeus.dep.yml
+++ b/.licenses/bundler/typhoeus.dep.yml
@@ -1,0 +1,60 @@
+---
+name: typhoeus
+version: 1.4.0
+type: bundler
+summary: Parallel HTTP library on top of libcurl multi.
+homepage: https://github.com/typhoeus/typhoeus
+license: mit
+licenses:
+- sources: LICENSE
+  text: |
+    Copyright (c) 2009-2010 Paul Dix
+    Copyright (c) 2011 David Balatero
+    Copyright (c) 2012-2016 Hans Hasselberg
+
+    Permission is hereby granted, free of charge, to any person obtaining
+    a copy of this software and associated documentation files (the
+    "Software"), to deal in the Software without restriction, including
+    without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to
+    permit persons to whom the Software is furnished to do so, subject to
+    the following conditions:
+
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+    LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+    OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+    WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+- sources: README.md
+  text: |-
+    (The MIT License)
+
+    Copyright © 2009-2010 [Paul Dix](http://www.pauldix.net/)
+
+    Copyright © 2011-2012 [David Balatero](https://github.com/dbalatero/)
+
+    Copyright © 2012-2016 [Hans Hasselberg](http://github.com/i0rek/)
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without
+    limitation the rights to use, copy, modify, merge, publish, distribute,
+    sublicense, and/or sell copies of the Software, and to permit persons
+    to whom the Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+    OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+    ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+    OTHER DEALINGS IN THE SOFTWARE.
+notices: []

--- a/.licenses/bundler/tzinfo.dep.yml
+++ b/.licenses/bundler/tzinfo.dep.yml
@@ -1,0 +1,32 @@
+---
+name: tzinfo
+version: 2.0.5
+type: bundler
+summary: Time Zone Library
+homepage: https://tzinfo.github.io
+license: mit
+licenses:
+- sources: LICENSE
+  text: |
+    Copyright (c) 2005-2022 Philip Ross
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of
+    this software and associated documentation files (the "Software"), to deal in
+    the Software without restriction, including without limitation the rights to
+    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+    of the Software, and to permit persons to whom the Software is furnished to do
+    so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+- sources: README.md
+  text: TZInfo is released under the MIT license, see LICENSE for details.
+notices: []

--- a/.licenses/bundler/zeitwerk.dep.yml
+++ b/.licenses/bundler/zeitwerk.dep.yml
@@ -1,16 +1,14 @@
 ---
-name: public_suffix
-version: 4.0.7
+name: zeitwerk
+version: 2.6.6
 type: bundler
-summary: Domain name parser based on the Public Suffix List.
-homepage: https://simonecarletti.com/code/publicsuffix-ruby
+summary: Efficient and thread-safe constant autoloader
+homepage: https://github.com/fxn/zeitwerk
 license: mit
 licenses:
-- sources: LICENSE.txt
+- sources: MIT-LICENSE
   text: |
-    Copyright (c) 2009-2022 Simone Carletti <weppos@weppos.net>
-
-    MIT License
+    Copyright (c) 2019–ω Xavier Noria
 
     Permission is hereby granted, free of charge, to any person obtaining
     a copy of this software and associated documentation files (the
@@ -31,8 +29,5 @@ licenses:
     OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
     WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 - sources: README.md
-  text: |-
-    Copyright (c) 2009-2022 Simone Carletti. This is Free Software distributed under the MIT license.
-
-    The [Public Suffix List source](https://publicsuffix.org/list/) is subject to the terms of the Mozilla Public License, v. 2.0.
+  text: Released under the MIT License, Copyright (c) 2019–<i>ω</i> Xavier Noria.
 notices: []


### PR DESCRIPTION
This PR was auto generated by the `licensed-ci` GitHub Action.
It contains updates to cached `github/licensed` dependency metadata to be merged into `cleanup-ruby-usage`: ([branch](https://github.com/github/licensed/tree/cleanup-ruby-usage), [PR](https://github.com/github/licensed/pull/590)).

The `licensed-ci` action will add comments to this PR with the status of license checks.  Please make any changes needed to fix any status failures on this branch, then merge license updates into your branch.

If updates are unexpected, please check the `github/licensed` [changelog](https://github.com/github/licensed/tree/master/CHANGELOG.md) for recent updates.