### PR TITLE
License updates for pip-builtin-caching

### DIFF
--- a/.licenses/bundler/racc.dep.yml
+++ b/.licenses/bundler/racc.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: racc
-version: 1.6.1
+version: 1.6.2
 type: bundler
 summary: Racc is a LALR(1) parser generator
 homepage: https://github.com/ruby/racc


### PR DESCRIPTION
This PR was auto generated by the `licensed-ci` GitHub Action.
It contains updates to cached `github/licensed` dependency metadata to be merged into `pip-builtin-caching`: ([branch](https://github.com/github/licensed/tree/pip-builtin-caching), [PR](https://github.com/github/licensed/pull/592)).

The `licensed-ci` action will add comments to this PR with the status of license checks.  Please make any changes needed to fix any status failures on this branch, then merge license updates into your branch.

If updates are unexpected, please check the `github/licensed` [changelog](https://github.com/github/licensed/tree/master/CHANGELOG.md) for recent updates.