### PR TITLE
License updates for dependabot/bundler/minitest-eq-5.17.0

### DIFF
--- a/.licenses/bundler/minitest.dep.yml
+++ b/.licenses/bundler/minitest.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: minitest
-version: 5.16.3
+version: 5.17.0
 type: bundler
 summary: minitest provides a complete suite of testing facilities supporting TDD,
   BDD, mocking, and benchmarking


### PR DESCRIPTION
This PR was auto generated by the `licensed-ci` GitHub Action.
It contains updates to cached `github/licensed` dependency metadata to be merged into `dependabot/bundler/minitest-eq-5.17.0`: ([branch](https://github.com/github/licensed/tree/dependabot/bundler/minitest-eq-5.17.0), [PR](https://github.com/github/licensed/pull/598)).

The `licensed-ci` action will add comments to this PR with the status of license checks.  Please make any changes needed to fix any status failures on this branch, then merge license updates into your branch.

If updates are unexpected, please check the `github/licensed` [changelog](https://github.com/github/licensed/tree/master/CHANGELOG.md) for recent updates.