### PR TITLE
License updates for dependabot/bundler/licensee-eq-9.16.0

### DIFF
--- a/.licenses/bundler/licensee.dep.yml
+++ b/.licenses/bundler/licensee.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: licensee
-version: 9.15.3
+version: 9.16.0
 type: bundler
 summary: A Ruby Gem to detect open source project licenses
 homepage: https://github.com/benbalter/licensee


### PR DESCRIPTION
This PR was auto generated by the `licensed-ci` GitHub Action.
It contains updates to cached `github/licensed` dependency metadata to be merged into `dependabot/bundler/licensee-eq-9.16.0`: ([branch](https://github.com/github/licensed/tree/dependabot/bundler/licensee-eq-9.16.0), [PR](https://github.com/github/licensed/pull/599)).

The `licensed-ci` action will add comments to this PR with the status of license checks.  Please make any changes needed to fix any status failures on this branch, then merge license updates into your branch.

If updates are unexpected, please check the `github/licensed` [changelog](https://github.com/github/licensed/tree/master/CHANGELOG.md) for recent updates.