### PR TITLE
Release 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## 4.0.0
+
+### Added
+
+- Licensed supports Cocoapods as a dependency source (:tada: @LouisBoudreau https://github.com/github/licensed/pull/584)
+- Licensed supports Gradle multi-project builds (:tada: @LouisBoudreau https://github.com/github/licensed/pull/583)
+
+### Fixed
+
+- Licensed no longer crashes when run with Bundler >= 2.4.0 (:tada: @JoshReedSchramm https://github.com/github/licensed/pull/597)
+
+### Changed
+
+- BREAKING: Licensed no longer ships executables with releases (https://github.com/github/licensed/pull/586)
+- BREAKING: Licensed no longer includes support for Go <= 1.11
+
 ## 3.9.1
 
 ### Fixed
@@ -661,4 +677,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Initial release :tada:
 
-[Unreleased]: https://github.com/github/licensed/compare/3.9.1...HEAD
+[Unreleased]: https://github.com/github/licensed/compare/4.0.0...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - BREAKING: Licensed no longer ships executables with releases (https://github.com/github/licensed/pull/586)
-- BREAKING: Licensed no longer includes support for Go <= 1.11
+- BREAKING: Licensed no longer includes support for Go <= 1.11 (https://github.com/github/licensed/pull/602)
 
 ## 3.9.1
 

--- a/lib/licensed/version.rb
+++ b/lib/licensed/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Licensed
-  VERSION = "3.9.1".freeze
+  VERSION = "4.0.0".freeze
 
   def self.previous_major_versions
     major_version = Gem::Version.new(Licensed::VERSION).segments.first


### PR DESCRIPTION
### Added
- Licensed supports Cocoapods as a dependency source (:tada: @LouisBoudreau https://github.com/github/licensed/pull/584)
- Licensed supports Gradle multi-project builds (:tada: @LouisBoudreau https://github.com/github/licensed/pull/583)

### Fixed
- Licensed no longer crashes when run with Bundler >= 2.4.0 (:tada: @JoshReedSchramm https://github.com/github/licensed/pull/597)

### Changed
- BREAKING: Licensed no longer ships executables with releases (https://github.com/github/licensed/pull/586)
- BREAKING: Licensed no longer includes support for Go <= 1.11