### PR TITLE
Fix running gradle and gradle source tests when gradle is unavailable

### DIFF
--- a/lib/licensed/sources/gradle.rb
+++ b/lib/licensed/sources/gradle.rb
@@ -129,8 +129,8 @@ module Licensed
       class Runner
         def initialize(root_path, configurations, executable)
           @root_path = root_path
-          @init_script = create_init_script(root_path, configurations)
           @executable = executable
+          @init_script = create_init_script(root_path, configurations)
         end
 
         def run(command, source_path)

--- a/test/sources/gradle_test.rb
+++ b/test/sources/gradle_test.rb
@@ -3,195 +3,197 @@ require "test_helper"
 require "tmpdir"
 require "fileutils"
 
-describe Licensed::Sources::Gradle do
-  describe "Single project" do
+if Licensed::Shell.tool_available?("gradle")
+  describe Licensed::Sources::Gradle do
+    describe "Single project" do
+      let(:fixtures) { File.expand_path("../../fixtures/gradle/single_project", __FILE__) }
+      let(:config) { Licensed::AppConfiguration.new({ "source_path" => Dir.pwd, "root" => fixtures }) }
+      let(:source) { Licensed::Sources::Gradle.new(config) }
+
+      describe "enabled?" do
+        it "is true if build.gradle exists and gradle is available" do
+          Dir.chdir(fixtures) do
+            assert source.enabled?
+          end
+        end
+
+        it "is false if build.gradle does not exist" do
+          Dir.chdir(Dir.tmpdir) do
+            refute source.enabled?
+          end
+        end
+      end
+
+      describe "dependencies" do
+        it "includes declared dependencies" do
+          Dir.chdir fixtures do
+            dep = source.dependencies.detect { |d| d.name == "io.netty:netty-all" }
+            assert dep
+            assert_equal "gradle", dep.record["type"]
+            assert_equal "4.1.33.Final", dep.version
+          end
+        end
+
+        it "does not include test dependencies" do
+          Dir.chdir fixtures do
+            refute source.dependencies.detect { |d| d.name == "org.junit.jupiter:junit-jupiter" }
+          end
+        end
+
+        it "cleans up grade licenses csv content" do
+          Dir.chdir fixtures do
+            dep = source.dependencies.detect { |d| d.name == "io.netty:netty-all" }
+            # load the dependency record which creates temp license-*.gradle files
+            dep.record
+
+            refute Dir.glob(Pathname.pwd.join("license-*.gradle").to_path).any?
+          end
+        end
+      end
+    end
+
+    describe "Multi project" do
+      let(:fixtures) { File.expand_path("../../fixtures/gradle/multi_project", __FILE__) }
+      let(:config) { Licensed::Configuration.new({
+        "apps" => [{ "source_path" => "#{Dir.pwd}/lib" }, { "source_path" => "#{Dir.pwd}/app" }],
+        "gradle" => { "configurations" => "runtimeClasspath" },
+        "root" => fixtures
+      })
+      }
+      let(:appConfig) { config.apps.last }
+      let(:libConfig) { config.apps.last }
+      let(:source) { Licensed::Sources::Gradle.new(appConfig) }
+
+      describe "app subproject" do
+        let(:appConfig) { config.apps.last }
+        let(:source) { Licensed::Sources::Gradle.new(appConfig) }
+
+        describe "enabled?" do
+          it "is true if build.gradle exists and gradle is available" do
+            Dir.chdir(fixtures) do
+              assert source.enabled?
+            end
+          end
+
+          it "is false if build.gradle does not exist" do
+            Dir.chdir(Dir.tmpdir) do
+              refute source.enabled?
+            end
+          end
+        end
+
+        describe "dependencies" do
+          it "includes declared dependencies" do
+            Dir.chdir fixtures do
+              dep = source.dependencies.detect { |d| d.name == "com.google.guava:guava" }
+              assert dep
+              assert_equal "gradle", dep.record["type"]
+              assert_equal "31.1-jre", dep.version
+            end
+          end
+
+          it "does not include test dependencies" do
+            Dir.chdir fixtures do
+              refute source.dependencies.detect { |d| d.name == "org.junit.jupiter:junit-jupiter-engine" }
+            end
+          end
+
+          it "cleans up grade licenses csv content" do
+            Dir.chdir fixtures do
+              dep = source.dependencies.detect { |d| d.name == "com.google.guava:guava" }
+              # load the dependency record which creates temp license-*.gradle files
+              dep.record
+
+              refute Dir.glob(Pathname.pwd.join("license-*.gradle").to_path).any?
+            end
+          end
+        end
+      end
+
+      describe "lib subproject" do
+        let(:appConfig) { config.apps.first }
+        let(:source) { Licensed::Sources::Gradle.new(appConfig) }
+        describe "enabled?" do
+          it "is true if build.gradle exists and gradle is available" do
+            Dir.chdir(fixtures) do
+              assert source.enabled?
+            end
+          end
+
+          it "is false if build.gradle does not exist" do
+            Dir.chdir(Dir.tmpdir) do
+              refute source.enabled?
+            end
+          end
+        end
+
+        describe "dependencies" do
+          it "includes declared dependencies" do
+            Dir.chdir fixtures do
+              dep = source.dependencies.detect { |d| d.name == "com.google.guava:guava" }
+              assert dep
+              assert_equal "gradle", dep.record["type"]
+              assert_equal "31.1-jre", dep.version
+            end
+          end
+
+          it "does not include test dependencies" do
+            Dir.chdir fixtures do
+              refute source.dependencies.detect { |d| d.name == "org.junit.jupiter:junit-jupiter-engine" }
+            end
+          end
+
+          it "cleans up grade licenses csv content" do
+            Dir.chdir fixtures do
+              dep = source.dependencies.detect { |d| d.name == "com.google.guava:guava" }
+              # load the dependency record which creates temp license-*.gradle files
+              dep.record
+
+              refute Dir.glob(Pathname.pwd.join("license-*.gradle").to_path).any?
+            end
+          end
+        end
+      end
+    end
+  end
+
+  describe Licensed::Sources::Gradle::Dependency do
     let(:fixtures) { File.expand_path("../../fixtures/gradle/single_project", __FILE__) }
     let(:config) { Licensed::AppConfiguration.new({ "source_path" => Dir.pwd, "root" => fixtures }) }
     let(:source) { Licensed::Sources::Gradle.new(config) }
 
-    describe "enabled?" do
-      it "is true if build.gradle exists and gradle is available" do
-        Dir.chdir(fixtures) do
-          assert source.enabled?
-        end
-      end
+    it "returns the dependency license" do
+      Dir.chdir fixtures do
+        dep = source.dependencies.detect { |d| d.name == "io.netty:netty-all" }
+        assert dep
+        assert_equal "apache-2.0", dep.license.key
 
-      it "is false if build.gradle does not exist" do
-        Dir.chdir(Dir.tmpdir) do
-          refute source.enabled?
-        end
+        license = dep.record.licenses.find { |l| l.text =~ /Apache License/ }
+        assert license
+        assert_equal ["https://www.apache.org/licenses/LICENSE-2.0"], license.sources
       end
     end
 
-    describe "dependencies" do
-      it "includes declared dependencies" do
-        Dir.chdir fixtures do
-          dep = source.dependencies.detect { |d| d.name == "io.netty:netty-all" }
-          assert dep
-          assert_equal "gradle", dep.record["type"]
-          assert_equal "4.1.33.Final", dep.version
-        end
-      end
+    it "cleans up grade licenses csv content" do
+      Dir.chdir fixtures do
+        dep = source.dependencies.detect { |d| d.name == "io.netty:netty-all" }
+        # load the dependency record, pulling license files
+        dep.record
 
-      it "does not include test dependencies" do
-        Dir.chdir fixtures do
-          refute source.dependencies.detect { |d| d.name == "org.junit.jupiter:junit-jupiter" }
-        end
-      end
-
-      it "cleans up grade licenses csv content" do
-        Dir.chdir fixtures do
-          dep = source.dependencies.detect { |d| d.name == "io.netty:netty-all" }
-          # load the dependency record which creates temp license-*.gradle files
-          dep.record
-
-          refute Dir.glob(Pathname.pwd.join("license-*.gradle").to_path).any?
-        end
-      end
-    end
-  end
-
-  describe "Multi project" do
-    let(:fixtures) { File.expand_path("../../fixtures/gradle/multi_project", __FILE__) }
-    let(:config) { Licensed::Configuration.new({
-      "apps" => [{ "source_path" => "#{Dir.pwd}/lib" }, { "source_path" => "#{Dir.pwd}/app" }],
-      "gradle" => { "configurations" => "runtimeClasspath" },
-      "root" => fixtures
-    })
-    }
-    let(:appConfig) { config.apps.last }
-    let(:libConfig) { config.apps.last }
-    let(:source) { Licensed::Sources::Gradle.new(appConfig) }
-
-    describe "app subproject" do
-      let(:appConfig) { config.apps.last }
-      let(:source) { Licensed::Sources::Gradle.new(appConfig) }
-
-      describe "enabled?" do
-        it "is true if build.gradle exists and gradle is available" do
-          Dir.chdir(fixtures) do
-            assert source.enabled?
-          end
-        end
-
-        it "is false if build.gradle does not exist" do
-          Dir.chdir(Dir.tmpdir) do
-            refute source.enabled?
-          end
-        end
-      end
-
-      describe "dependencies" do
-        it "includes declared dependencies" do
-          Dir.chdir fixtures do
-            dep = source.dependencies.detect { |d| d.name == "com.google.guava:guava" }
-            assert dep
-            assert_equal "gradle", dep.record["type"]
-            assert_equal "31.1-jre", dep.version
-          end
-        end
-
-        it "does not include test dependencies" do
-          Dir.chdir fixtures do
-            refute source.dependencies.detect { |d| d.name == "org.junit.jupiter:junit-jupiter-engine" }
-          end
-        end
-
-        it "cleans up grade licenses csv content" do
-          Dir.chdir fixtures do
-            dep = source.dependencies.detect { |d| d.name == "com.google.guava:guava" }
-            # load the dependency record which creates temp license-*.gradle files
-            dep.record
-
-            refute Dir.glob(Pathname.pwd.join("license-*.gradle").to_path).any?
-          end
-        end
+        refute Pathname.pwd.join(Licensed::Sources::Gradle::GRADLE_LICENSES_PATH).exist?
       end
     end
 
-    describe "lib subproject" do
-      let(:appConfig) { config.apps.first }
-      let(:source) { Licensed::Sources::Gradle.new(appConfig) }
-      describe "enabled?" do
-        it "is true if build.gradle exists and gradle is available" do
-          Dir.chdir(fixtures) do
-            assert source.enabled?
-          end
-        end
+    it "does not make any network requests when accessing non-license data" do
+      Licensed::Sources::Gradle::Dependency.expects(:retrieve_license).never
+      Licensed::Sources::Gradle::Dependency.expects(:load_csv).never
 
-        it "is false if build.gradle does not exist" do
-          Dir.chdir(Dir.tmpdir) do
-            refute source.enabled?
-          end
-        end
+      Dir.chdir fixtures do
+        dep = source.dependencies.detect { |d| d.name == "io.netty:netty-all" }
+        # accessing non-license dependency data does not make network requests
+        dep.name
+        dep.version
       end
-
-      describe "dependencies" do
-        it "includes declared dependencies" do
-          Dir.chdir fixtures do
-            dep = source.dependencies.detect { |d| d.name == "com.google.guava:guava" }
-            assert dep
-            assert_equal "gradle", dep.record["type"]
-            assert_equal "31.1-jre", dep.version
-          end
-        end
-
-        it "does not include test dependencies" do
-          Dir.chdir fixtures do
-            refute source.dependencies.detect { |d| d.name == "org.junit.jupiter:junit-jupiter-engine" }
-          end
-        end
-
-        it "cleans up grade licenses csv content" do
-          Dir.chdir fixtures do
-            dep = source.dependencies.detect { |d| d.name == "com.google.guava:guava" }
-            # load the dependency record which creates temp license-*.gradle files
-            dep.record
-
-            refute Dir.glob(Pathname.pwd.join("license-*.gradle").to_path).any?
-          end
-        end
-      end
-    end
-  end
-end
-
-describe Licensed::Sources::Gradle::Dependency do
-  let(:fixtures) { File.expand_path("../../fixtures/gradle/single_project", __FILE__) }
-  let(:config) { Licensed::AppConfiguration.new({ "source_path" => Dir.pwd, "root" => fixtures }) }
-  let(:source) { Licensed::Sources::Gradle.new(config) }
-
-  it "returns the dependency license" do
-    Dir.chdir fixtures do
-      dep = source.dependencies.detect { |d| d.name == "io.netty:netty-all" }
-      assert dep
-      assert_equal "apache-2.0", dep.license.key
-
-      license = dep.record.licenses.find { |l| l.text =~ /Apache License/ }
-      assert license
-      assert_equal ["https://www.apache.org/licenses/LICENSE-2.0"], license.sources
-    end
-  end
-
-  it "cleans up grade licenses csv content" do
-    Dir.chdir fixtures do
-      dep = source.dependencies.detect { |d| d.name == "io.netty:netty-all" }
-      # load the dependency record, pulling license files
-      dep.record
-
-      refute Pathname.pwd.join(Licensed::Sources::Gradle::GRADLE_LICENSES_PATH).exist?
-    end
-  end
-
-  it "does not make any network requests when accessing non-license data" do
-    Licensed::Sources::Gradle::Dependency.expects(:retrieve_license).never
-    Licensed::Sources::Gradle::Dependency.expects(:load_csv).never
-
-    Dir.chdir fixtures do
-      dep = source.dependencies.detect { |d| d.name == "io.netty:netty-all" }
-      # accessing non-license dependency data does not make network requests
-      dep.name
-      dep.version
     end
   end
 end


### PR DESCRIPTION
closes https://github.com/github/licensed/issues/605

The gradle source's `enabled?` check creates a `Gradle::Runner` object to determine if a gradle executable is available.  This can cause an order of operations where the source tries to use the executable before its existence has been check.

1. `Licensed::Sources::Gradle.enabled?` called `gradle_runner.enabled?` to check whether a gradle executable is available
1. `Licensed::Sources::Gradle.gradle_runner` creates a `Licensed::Sources::Gradle::Runner` object
1. `Licensed::Sources::Gradle::Runner#initialize` calls `Licensed::Sources::Gradle::Runner#create_init_script` which creates an initialization script that is used when calling into licensed
1. creating the initialization script calls `Licensed::Sources::Gradle::Runner.gradle_version`, which tries to use a gradle executable.  this is where the error is thrown, because the gradle executable isn't available

I fixed this by moving the runner's enabled and executable location logic into the source enumerator class so that it could be used without needing to create the init script.  There are other ways to fix this but this was quick and I think it makes sense for the source to be responsible for determining whether a gradle executable exists and providing its path, if it exists, to the runner.

I also wrapped the tests in a check that enforces that `gradle` is available when running the tests because a gradle executable is no longer shipped in licensed's test fixtures.