### PR TITLE
release 4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## 4.0.1
+
+### Fixed
+
+- Running gradle tests will no longer fail when gradle is not available (https://github.com/github/licensed/pull/606)
+
 ## 4.0.0
 
 ### Added
@@ -677,4 +683,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Initial release :tada:
 
-[Unreleased]: https://github.com/github/licensed/compare/4.0.0...HEAD
+[Unreleased]: https://github.com/github/licensed/compare/4.0.1...HEAD

--- a/lib/licensed/version.rb
+++ b/lib/licensed/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Licensed
-  VERSION = "4.0.0".freeze
+  VERSION = "4.0.1".freeze
 
   def self.previous_major_versions
     major_version = Gem::Version.new(Licensed::VERSION).segments.first


### PR DESCRIPTION
## 4.0.1

### Fixed

- Running gradle tests will no longer fail when gradle is not available (https://github.com/github/licensed/pull/606)