### PR TITLE
build: remove GO111MODULE env as it is default on

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -182,8 +182,6 @@ jobs:
       run: script/source-setup/go
     - name: Run tests
       run: script/test go
-      env:
-        GO111MODULE: "on"
 
   gradle:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- dep has been archived in favor of go modules since early 2020, https://github.com/golang/dep/pull/2233
- `go modules` now is the default mode, so no need to set `GO111MODULE`