### PR TITLE
Fix gradlew location when trying to location a gradle executable

### DIFF
--- a/lib/licensed/sources/gradle.rb
+++ b/lib/licensed/sources/gradle.rb
@@ -66,7 +66,7 @@ module Licensed
         return @executable if defined?(@executable)
 
         @executable = begin
-          gradlew = File.join(config.pwd, "gradlew")
+          gradlew = File.join(config.root, "gradlew")
           return gradlew if File.executable?(gradlew)
 
           "gradle" if Licensed::Shell.tool_available?("gradle")


### PR DESCRIPTION
The https://github.com/github/licensed/pull/606 fix changed the search location of the `gradlew` executable
According to the [documentation](https://docs.gradle.org/current/userguide/gradle_wrapper.html#sec:adding_wrapper) the `gradlew` should be present at the root of the project  :
> A Gradle project typically provides a settings.gradle file and one build.gradle file for each subproject. The Wrapper files live alongside in the gradle directory and the root directory of the project. 

This PR therefore aims at updating where licensed searches for `gradlew`