### PR TITLE
Release 4.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## 4.0.2
+
+### Fixed
+
+- The path to a gradlew executable can be configured when enumerating gradle dependencies (:tada: @LouisBoudreau https://github.com/github/licensed/pull/610)
+
 ## 4.0.1
 
 ### Fixed
@@ -683,4 +689,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Initial release :tada:
 
-[Unreleased]: https://github.com/github/licensed/compare/4.0.1...HEAD
+[Unreleased]: https://github.com/github/licensed/compare/4.0.2...HEAD

--- a/docs/sources/gradle.md
+++ b/docs/sources/gradle.md
@@ -14,6 +14,7 @@ gradle:
     - runtime
     - runtimeClassPath
 ```
+
 ### Multi-build projects
 
 To run `licensed` for specific projects in a [multi-build project](https://docs.gradle.org/current/userguide/multi_project_builds.html) you must specify the [apps](../configuration/application_source.md) configuration key.
@@ -23,11 +24,11 @@ apps:
   - source_path: ./path/to/subproject
 ```
 
-### Gradlew 
+### Gradlew
 
 The `gradle.gradlew` property is used to determine where the `gradlew` executable is. The default location the [configuration root](../configuration/configuration_root.md).
 
 ```yml
 gradle:
-  - gradlew: path/from/root/to/gradle/gradlew
+  gradlew: path/from/root/to/gradle/gradlew
 ```

--- a/lib/licensed/version.rb
+++ b/lib/licensed/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Licensed
-  VERSION = "4.0.1".freeze
+  VERSION = "4.0.2".freeze
 
   def self.previous_major_versions
     major_version = Gem::Version.new(Licensed::VERSION).segments.first


### PR DESCRIPTION
## 4.0.2

### Fixed
- The path to a gradlew executable can be configured when enumerating gradle dependencies (:tada: @LouisBoudreau https://github.com/github/licensed/pull/610)