### PR TITLE
Forward `__materialize__` kwargs too

### DIFF
--- a/lib/licensed/sources/bundler/missing_specification.rb
+++ b/lib/licensed/sources/bundler/missing_specification.rb
@@ -47,8 +47,8 @@ module Licensed
         Licensed::Bundler::MissingSpecification.new(name: name, version: version, platform: platform, source: source)
       end
 
-      def __materialize__(*args)
-        spec = super(*args)
+      def __materialize__(*args, **kwargs)
+        spec = super(*args, **kwargs)
         return spec if spec
 
         Licensed::Bundler::MissingSpecification.new(name: name, version: version, platform: platform, source: source)


### PR DESCRIPTION
…to fix bundler 2.4.4 incompatiblity

https://github.com/rubygems/rubygems/pull/6261 changed the arity of `__materialize__` method again, which broke `licensed`
See also: #522 😅