### PR TITLE
Release 4.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## 4.0.3
+
+### Changed
+
+- Cocoapods dependency enumeration has been disabled (https://github.com/github/licensed/pull/616)
+
+### Fixed
+
+- Fixed method signature change in Bundler API with Bundler >= 2.4.4 (:tada: @CvX https://github.com/github/licensed/pull/614)
+- Fixed installation dependency compatibility with Rails >= 7.0 (https://github.com/github/licensed/pull/616)
+
 ## 4.0.2
 
 ### Fixed
@@ -689,4 +700,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Initial release :tada:
 
-[Unreleased]: https://github.com/github/licensed/compare/4.0.2...HEAD
+[Unreleased]: https://github.com/github/licensed/compare/4.0.3...HEAD

--- a/lib/licensed/version.rb
+++ b/lib/licensed/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Licensed
-  VERSION = "4.0.2".freeze
+  VERSION = "4.0.3".freeze
 
   def self.previous_major_versions
     major_version = Gem::Version.new(Licensed::VERSION).segments.first


### PR DESCRIPTION
### Changed

- Cocoapods dependency enumeration has been disabled (https://github.com/github/licensed/pull/616)

### Fixed

- Fixed method signature change in Bundler API with Bundler >= 2.4.4 (:tada: @CvX https://github.com/github/licensed/pull/614)
- Fixed installation dependency compatibility with Rails >= 7.0 (https://github.com/github/licensed/pull/616)