### PR TITLE
License updates for dependency-version-ranges

### DIFF
--- a/.licenses/bundler/faraday.dep.yml
+++ b/.licenses/bundler/faraday.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: faraday
-version: 2.7.3
+version: 2.7.4
 type: bundler
 summary: HTTP/REST API client library.
 homepage: https://lostisland.github.io/faraday

--- a/.licenses/bundler/rugged.dep.yml
+++ b/.licenses/bundler/rugged.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: rugged
-version: 1.5.0.1
+version: 1.5.1
 type: bundler
 summary: Rugged is a Ruby binding to the libgit2 linkable library
 homepage: https://github.com/libgit2/rugged


### PR DESCRIPTION
This PR was auto generated by the `licensed-ci` GitHub Action.
It contains updates to cached `github/licensed` dependency metadata to be merged into `dependency-version-ranges`: ([branch](https://github.com/github/licensed/tree/dependency-version-ranges), [PR](https://github.com/github/licensed/pull/619)).

The `licensed-ci` action will add comments to this PR with the status of license checks.  Please make any changes needed to fix any status failures on this branch, then merge license updates into your branch.

If updates are unexpected, please check the `github/licensed` [changelog](https://github.com/github/licensed/tree/master/CHANGELOG.md) for recent updates.