### PR TITLE
Add configured license amendment content

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,6 +67,13 @@ reviewed:
   - classlist # public domain
   - octicons
 
+# Specify license amendments that have been obtained from a dependency's owner
+# which alter the terms of the dependency's license 
+amendments:
+  bundler:
+    bcrypt-ruby:
+      - .licenses/amendments/bundler/bcrypt-ruby/amendment.txt
+
 # A single configuration file can be used to enumerate dependencies for multiple
 # projects.  Each configuration is referred to as an "application" and must include
 # a source path, at a minimum

--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -9,3 +9,4 @@
 1. [Allowed licenses](./allowed_licenses.md)
 1. [Ignoring dependencies](./ignoring_dependencies.md)
 1. [Reviewing dependencies](./reviewing_dependencies.md)
+1. [License amendments](./license_amendments.md)

--- a/docs/configuration/license_amendments.md
+++ b/docs/configuration/license_amendments.md
@@ -1,0 +1,39 @@
+# License amendments
+
+The `amendments` configuration file option is used to specify paths to files containing content which amends the license that would normally applies to a library used by an application.  File contents are expected to be plain text
+
+Amendment files can be located anywhere on disk that is accessible to licensed.  File paths can be specified as a string or array and can contain glob values to simplify configuration inputs.  All file paths are evaluated from the [configuration root](./configuration_root.md).
+
+## Examples
+
+### With a string
+
+```yaml
+amendments:
+  # specify the type of dependency
+  bundler:
+    # specify the dependency name and path to an amendment file
+    <gem-name>: .licenses/amendments/bundler/<gem-name>/amendment.txt
+```
+
+### With a glob string
+
+```yaml
+amendments:
+  # specify the type of dependency
+  bundler:
+    # specify the dependency name and one or more amendment files with a glob pattern
+    <gem-name>: .licenses/amendments/bundler/<gem-name>/*.txt
+```
+
+### With an array of strings
+
+```yaml
+amendments:
+  # specify the type of dependency
+  bundler:
+    # specify the dependency name and array of paths to amendment files
+    <gem-name>:
+      - .licenses/amendments/bundler/<gem-name>/amendment-1.txt
+      - .licenses/amendments/bundler/<gem-name>/amendment-2.txt
+```

--- a/lib/licensed/configuration.rb
+++ b/lib/licensed/configuration.rb
@@ -109,6 +109,12 @@ module Licensed
       self["allowed"] << license
     end
 
+    # Returns an array of amendment content file paths
+    def amendments_for_dependency(dependency)
+      amendment_paths = Array(self.dig("amendments", dependency["type"], dependency["name"]))
+      amendment_paths.flat_map { |path| Dir.glob(self.root.join(path)) }
+    end
+
     private
 
     def any_list_pattern_matched?(list, dependency, match_version: false)

--- a/lib/licensed/sources/source.rb
+++ b/lib/licensed/sources/source.rb
@@ -69,7 +69,9 @@ module Licensed
       # Returns all dependencies that should be evaluated.
       # Excludes ignored dependencies.
       def dependencies
-        cached_dependencies.reject { |d| ignored?(d) }
+        cached_dependencies
+          .reject { |d| ignored?(d) }
+          .each { |d| add_amendments_from_configuration(d) }
       end
 
       # Enumerate all source dependencies.  Must be implemented by each source class.
@@ -87,6 +89,11 @@ module Licensed
       # Returns a cached list of dependencies
       def cached_dependencies
         @dependencies ||= enumerate_dependencies.compact
+      end
+
+      # Add any amendments for this dependency that have been added to the configuration
+      def add_amendments_from_configuration(dependency)
+        dependency.amendments.concat config.amendments_for_dependency("type" => self.class.type, "name" => dependency.name)
       end
     end
   end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -604,4 +604,56 @@ describe Licensed::AppConfiguration do
                    config.cache_path
     end
   end
+
+  describe "amendments_for_dependency" do
+    it "returns an empty array if amendments aren't configured for a dependency" do
+      assert_empty config.amendments_for_dependency("type" => "test", "name" => "test")
+    end
+
+    it "returns an array of absolute paths to amendment files for a string configuration" do
+      Dir.mktmpdir do |dir|
+        Dir.chdir dir do
+          options["amendments"] = { "test" => { "test" => "amendment.txt" } }
+          File.write "amendment.txt", "amendment"
+
+          path = File.join(Dir.pwd, "amendment.txt")
+          assert_equal [path], config.amendments_for_dependency("type" => "test", "name" => "test")
+        end
+      end
+    end
+
+    it "returns an array of absolute paths to amendment files for an array configuration" do
+      Dir.mktmpdir do |dir|
+        Dir.chdir dir do
+          options["amendments"] = { "test" => { "test" => ["amendment.txt"] } }
+          File.write "amendment.txt", "amendment"
+
+          path = File.join(Dir.pwd, "amendment.txt")
+          assert_equal [path], config.amendments_for_dependency("type" => "test", "name" => "test")
+        end
+      end
+    end
+
+    it "strips any amendment paths for files that don't exist" do
+      options["amendments"] = { "test" => { "test" => "amendment.txt" } }
+      assert_empty config.amendments_for_dependency("type" => "test", "name" => "test")
+    end
+
+    it "expands glob patterns" do
+      Dir.mktmpdir do |dir|
+        Dir.chdir dir do
+          Dir.mkdir "amendments"
+
+          options["amendments"] = { "test" => { "test" => "amendments/*" } }
+          paths = 2.times.map do |index|
+            path = "amendments/amendment-#{index}.txt"
+            File.write path, "amendment-#{index}"
+            File.join(Dir.pwd, path)
+          end
+
+          assert_equal paths, config.amendments_for_dependency("type" => "test", "name" => "test")
+        end
+      end
+    end
+  end
 end

--- a/test/dependency_test.rb
+++ b/test/dependency_test.rb
@@ -319,4 +319,23 @@ describe Licensed::Dependency do
       refute dep.exist?
     end
   end
+
+  describe "project_files" do
+    it "returns found only project files when the dependency does not contain amendments" do
+      mkproject do |dependency|
+        File.write "LICENSE", Licensee::License.find("mit").text
+        assert_includes dependency.license_contents,
+                        { "sources" => "LICENSE", "text" => Licensee::License.find("mit").text }
+      end
+    end
+
+    it "returns custom license amendment files when the dependency contains amendments" do
+      mkproject do |dependency|
+        File.write "amendment.txt", "license amendment"
+        dependency.amendments << "amendment.txt"
+        assert_includes dependency.license_contents,
+                        { "sources" => "License amendment loaded from amendment.txt", "text" => "license amendment" }
+      end
+    end
+  end
 end

--- a/test/sources/source_test.rb
+++ b/test/sources/source_test.rb
@@ -18,5 +18,20 @@ describe Licensed::Sources::Source do
       config.ignore("type" => "test", "name" => "dependency")
       assert_empty source.dependencies
     end
+
+    it "adds configured dependency amendments to dependencies" do
+      Dir.mktmpdir do |dir|
+        Dir.chdir dir do
+          config["amendments"] = {
+            TestSource.type => {
+              TestSource::DEFAULT_DEPENDENCY_NAME => "amendment.txt"
+            }
+          }
+          File.write "amendment.txt", "amendment"
+          dep = source.dependencies.first
+          assert_equal [Pathname.pwd.join("amendment.txt")], dep.amendments
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This change allows users to specify file paths to custom license amendment content provided by a library owner.  Amendment content files paths are specified per dependency type and name, and the files are treated as additional licenses for the dependency.  See the added [documentation](https://github.com/github/licensed/blob/319b85ec024f8378972ce8ff82667dc2fbaa87b8/docs/configuration/license_amendments.md) for details on how to use the added `amendments` configuration option.

/cc @mlinksva I'm curious for your thoughts here - is this an appropriate change?
1. It seems like there is some amount of risk in allowing users to specify content that would be treated as legally binding
2. Should the amendment content be treated as a legal notice rather than a license?