### PR TITLE
Release 4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## 4.1.0
+
+### Added
+
+- Custom license terms can be added to dependencies via new configuration options (https://github.com/github/licensed/pull/624)
+- Licensed is now integrated with pnpm to enumerate dependencies (https://github.com/github/licensed/pull/626)
+
 ## 4.0.4
 
 ### Changed
@@ -706,4 +713,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Initial release :tada:
 
-[Unreleased]: https://github.com/github/licensed/compare/4.0.4...HEAD
+[Unreleased]: https://github.com/github/licensed/compare/4.1.0...HEAD

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    licensed (4.0.4)
+    licensed (4.1.0)
       json (~> 2.6)
       licensee (~> 9.16)
       parallel (~> 1.22)

--- a/lib/licensed/version.rb
+++ b/lib/licensed/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Licensed
-  VERSION = "4.0.4".freeze
+  VERSION = "4.1.0".freeze
 
   def self.previous_major_versions
     major_version = Gem::Version.new(Licensed::VERSION).segments.first


### PR DESCRIPTION
### Added

- Custom license terms can be added to dependencies via new configuration options (https://github.com/github/licensed/pull/624)
- Licensed is now integrated with pnpm to enumerate dependencies (https://github.com/github/licensed/pull/626)