### PR TITLE
Add support for configuring reviewed and ignored dependencies at specific versions

### DIFF
--- a/docs/configuration/ignoring_dependencies.md
+++ b/docs/configuration/ignoring_dependencies.md
@@ -17,3 +17,16 @@ ignored:
   go:
     - github.com/me/my-repo/**/*
 ```
+
+## Ignoring dependencies at specific versions
+
+Ignore a dependency at specific versions by appending `@<version>` to the end of the dependency's name in an `ignore` list.  If a dependency is configured to be ignored at a specific version, licensed will not ignore non-matching versions of the dependency.
+
+The version value can be one of:
+
+1. `"*"` - match any version value
+1. any version string, or version range string, that can be parsed by `Gem::Requirement`
+   - a semantic version - `dependency@1.2.3`
+   - a gem requirement range - `dependency@~> 1.0.0` or `dependency@< 3.0`
+   - see the [Rubygems version guides](https://guides.rubygems.org/patterns/#pessimistic-version-constraint) for more details about specifying gem version requirements
+1. a value that can't be parsed by `Gem::Requirement`, which will only match dependencies with the same version string

--- a/docs/configuration/reviewing_dependencies.md
+++ b/docs/configuration/reviewing_dependencies.md
@@ -16,3 +16,16 @@ reviewed:
   bundler:
     - gem-using-unallowed-license
 ```
+
+## Reviewing dependencies at specific versions
+
+Review a dependency at specific versions by appending `@<version>` to the end of the dependency's name in an `reviewed` list.  If a dependency is configured to be reviewed at a specific version, licensed will not recognize non-matching versions of the dependency as being manually reviewed and accepted.
+
+The version value can be one of:
+
+1. `"*"` - match any version value
+1. any version string, or version range string, that can be parsed by `Gem::Requirement`
+   - a semantic version - `dependency@1.2.3`
+   - a gem requirement range - `dependency@~> 1.0.0` or `dependency@< 3.0`
+   - see the [Rubygems version guides](https://guides.rubygems.org/patterns/#pessimistic-version-constraint) for more details about specifying gem version requirements
+1. a value that can't be parsed by `Gem::Requirement`, which will only match dependencies with the same version string

--- a/docs/sources/pnpm.md
+++ b/docs/sources/pnpm.md
@@ -2,6 +2,8 @@
 
 The npm source will detect dependencies when `pnpm-lock.yaml` is found at an apps `source_path`.  It uses `pnpm licenses list` to enumerate dependencies and metadata.
 
+All dependencies enumerated by the pnpm source include the dependency version in the dependency's name identifier.  All [reviewed](../configuration/reviewing_dependencies.md) or [ignored](../configuration/ignoring_dependencies.md) dependencies must include a version signifier in the configured dependency name.
+
 **NOTE** [pnpm licenses list](https://pnpm.io/cli/licenses) is an experimental CLI command and subject to change.  If changes to pnpm result in unexpected or broken behavior in licensed please open an [issue](https://github.com/github/licensed/issues/new).
 
 ## Including development dependencies

--- a/lib/licensed/commands/cache.rb
+++ b/lib/licensed/commands/cache.rb
@@ -130,7 +130,7 @@ module Licensed
         if dependency.record.matches?(cached_record)
           # use the cached license value if the license text wasn't updated
           dependency.record["license"] = cached_record["license"]
-        elsif app.reviewed?(dependency.record)
+        elsif app.reviewed?(dependency.record, require_version: self.class.require_matched_dependency_version)
           # if the license text changed and the dependency is set as reviewed
           # force a re-review of the dependency
           dependency.record["review_changed_license"] = true

--- a/lib/licensed/commands/cache.rb
+++ b/lib/licensed/commands/cache.rb
@@ -83,7 +83,7 @@ module Licensed
         report["version"] = dependency.version
 
         if save_dependency_record?(dependency, cached_record)
-          update_dependency_from_cached_record(app, dependency, cached_record)
+          update_dependency_from_cached_record(app, source, dependency, cached_record)
 
           dependency.record.save(filename)
           report["cached"] = true
@@ -123,14 +123,14 @@ module Licensed
       # Update dependency metadata from the cached record, to support:
       # 1. continuity between cache runs to cut down on churn
       # 2. notifying users when changed content needs to be reviewed
-      def update_dependency_from_cached_record(app, dependency, cached_record)
+      def update_dependency_from_cached_record(app, source, dependency, cached_record)
         return if cached_record.nil?
         return if options[:force]
 
         if dependency.record.matches?(cached_record)
           # use the cached license value if the license text wasn't updated
           dependency.record["license"] = cached_record["license"]
-        elsif app.reviewed?(dependency.record, require_version: self.class.require_matched_dependency_version)
+        elsif app.reviewed?(dependency.record, require_version: source.class.require_matched_dependency_version)
           # if the license text changed and the dependency is set as reviewed
           # force a re-review of the dependency
           dependency.record["review_changed_license"] = true

--- a/lib/licensed/commands/status.rb
+++ b/lib/licensed/commands/status.rb
@@ -60,7 +60,7 @@ module Licensed
           report.errors << "missing license text" if record.licenses.empty?
           if record["review_changed_license"]
             report.errors << "license text has changed and needs re-review. if the new text is ok, remove the `review_changed_license` flag from the cached record"
-          elsif license_needs_review?(app, record)
+          elsif license_needs_review?(app, source, record)
             report.errors << needs_review_error_message(app, record)
           end
         end
@@ -70,9 +70,10 @@ module Licensed
 
       # Returns true if a cached record needs further review based on the
       # record's license(s) and the app's configuration
-      def license_needs_review?(app, record)
+      def license_needs_review?(app, source, record)
         # review is not needed if the record is set as reviewed
-        return false if app.reviewed?(record, require_version: data_source == "configuration")
+        require_version = data_source == "configuration" || source.class.require_matched_dependency_version
+        return false if app.reviewed?(record, require_version: require_version)
 
         # review is not needed if the top level license is allowed
         return false if app.allowed?(record["license"])

--- a/lib/licensed/commands/status.rb
+++ b/lib/licensed/commands/status.rb
@@ -72,7 +72,7 @@ module Licensed
       # record's license(s) and the app's configuration
       def license_needs_review?(app, record)
         # review is not needed if the record is set as reviewed
-        return false if app.reviewed?(record, match_version: data_source == "configuration")
+        return false if app.reviewed?(record, require_version: data_source == "configuration")
 
         # review is not needed if the top level license is allowed
         return false if app.allowed?(record["license"])
@@ -99,7 +99,7 @@ module Licensed
         error = "dependency needs review"
 
         # look for an unversioned reviewed list match
-        if app.reviewed?(record, match_version: false)
+        if app.reviewed?(record, require_version: false)
           error += ", unversioned 'reviewed' match found: #{record["name"]}"
         end
 

--- a/lib/licensed/configuration.rb
+++ b/lib/licensed/configuration.rb
@@ -131,10 +131,13 @@ module Licensed
           # treat the entire pattern as the dependency name with no version.
           name = pattern
           requirement = nil
-        elsif Gem::Requirement::PATTERN.match?(requirement)
+        elsif !requirement.to_s.empty?
           # check if the version requirement is a valid Gem::Requirement
           # for range matching
-          requirement = Gem::Requirement.new(requirement)
+          requirements = requirement.split(",").map(&:strip)
+          if requirements.all? { |r| Gem::Requirement::PATTERN.match?(r) }
+            requirement = Gem::Requirement.new(requirements)
+          end
         end
 
         # the pattern's name must match the dependency's name

--- a/lib/licensed/dependency.rb
+++ b/lib/licensed/dependency.rb
@@ -99,6 +99,17 @@ module Licensed
          .select { |notice| notice["text"].length > 0 } # files with content only
     end
 
+    # Returns a hash of basic metadata about the dependency - name, version, type, etc
+    def metadata
+      {
+        # can be overriden by values in @metadata
+        "name" => name,
+        "version" => version
+      }.merge(
+        @metadata
+      )
+    end
+
     private
 
     def read_file_with_encoding_check(file_path)
@@ -135,14 +146,8 @@ module Licensed
     # Returns the metadata that represents this dependency.  This metadata
     # is written to YAML in the dependencys cached text file
     def license_metadata
-      {
-        # can be overriden by values in @metadata
-        "name" => name,
-        "version" => version
-      }.merge(
-        @metadata
-      ).merge({
-        # overrides all other values
+      metadata.merge({
+        # overrides all metadata values
         "license" => license_key
       })
     end

--- a/lib/licensed/sources/pnpm.rb
+++ b/lib/licensed/sources/pnpm.rb
@@ -4,6 +4,12 @@ require "json"
 module Licensed
   module Sources
     class PNPM < Source
+      # The PNPM source requires matching reviewed or ignored dependencies
+      # on both name and version
+      def self.require_matched_dependency_version
+        true
+      end
+
       # Returns true when pnpm is installed and a pnpm-lock.yaml file is found,
       # otherwise false
       def enabled?

--- a/lib/licensed/sources/source.rb
+++ b/lib/licensed/sources/source.rb
@@ -51,6 +51,12 @@ module Licensed
                    .downcase
                    .split("::")
         end
+
+        # Returns true if the source requires matching reviewed and ignored dependencies'
+        # versions as well as their name
+        def require_matched_dependency_version
+          false
+        end
       end
 
       # all sources have a configuration
@@ -81,7 +87,7 @@ module Licensed
 
       # Returns whether a dependency is ignored in the configuration.
       def ignored?(dependency)
-        config.ignored?({ "type" => self.class.type, "name" => dependency.name })
+        config.ignored?(dependency.metadata, require_version: self.class.require_matched_dependency_version)
       end
 
       private

--- a/lib/licensed/sources/source.rb
+++ b/lib/licensed/sources/source.rb
@@ -81,7 +81,7 @@ module Licensed
 
       # Returns whether a dependency is ignored in the configuration.
       def ignored?(dependency)
-        config.ignored?("type" => self.class.type, "name" => dependency.name)
+        config.ignored?({ "type" => self.class.type, "name" => dependency.name })
       end
 
       private

--- a/test/commands/cache_test.rb
+++ b/test/commands/cache_test.rb
@@ -61,7 +61,7 @@ describe Licensed::Commands::Cache do
     config.apps.each do |app|
       FileUtils.mkdir_p app.cache_path.join("test")
       File.write app.cache_path.join("test/dependency.#{Licensed::DependencyRecord::EXTENSION}"), ""
-      app.ignore "type" => "test", "name" => "dependency"
+      app.ignore({ "type" => "test", "name" => "dependency" })
     end
 
     run_command
@@ -206,7 +206,7 @@ describe Licensed::Commands::Cache do
     config.apps.each do |app|
       FileUtils.mkdir_p app.cache_path.join("test")
       File.write app.cache_path.join("test/dependency.#{Licensed::DependencyRecord::EXTENSION}"), ""
-      app.ignore "type" => "test", "name" => "dependency"
+      app.ignore({ "type" => "test", "name" => "dependency" })
     end
 
     run_command

--- a/test/commands/list_test.rb
+++ b/test/commands/list_test.rb
@@ -44,7 +44,7 @@ describe Licensed::Commands::List do
     count = dependencies.size
 
     config.apps.each do |app|
-      app.ignore("type" => "test", "name" => "dependency")
+      app.ignore({ "type" => "test", "name" => "dependency" })
     end
 
     run_command

--- a/test/commands/status_test.rb
+++ b/test/commands/status_test.rb
@@ -82,7 +82,7 @@ describe Licensed::Commands::Status do
       config.apps.each do |app|
         app.sources.each do |source|
           assert dependency_errors(app, source).any?
-          app.ignore "type" => source.class.type, "name" => "dependency"
+          app.ignore({ "type" => source.class.type, "name" => "dependency" })
         end
       end
 
@@ -100,7 +100,7 @@ describe Licensed::Commands::Status do
       config.apps.each do |app|
         app.sources.each do |source|
           assert dependency_errors(app, source).any?
-          app.ignore "type" => source.class.type, "name" => "dependency"
+          app.ignore({ "type" => source.class.type, "name" => "dependency" })
         end
       end
 
@@ -189,7 +189,7 @@ describe Licensed::Commands::Status do
     it "does not warn if cached license data missing for ignored gem" do
       config.apps.each do |app|
         FileUtils.rm app.cache_path.join("test/dependency.#{Licensed::DependencyRecord::EXTENSION}")
-        app.ignore "type" => "test", "name" => "dependency"
+        app.ignore({ "type" => "test", "name" => "dependency" })
       end
 
       run_command
@@ -214,7 +214,7 @@ describe Licensed::Commands::Status do
       count = reporter.report.all_reports.size
 
       config.apps.each do |app|
-        app.ignore "type" => "test", "name" => "dependency"
+        app.ignore({ "type" => "test", "name" => "dependency" })
       end
 
       run_command
@@ -423,7 +423,7 @@ describe Licensed::Commands::Status do
       config.apps.each do |app|
         app.sources.each do |source|
           assert dependency_errors(app, source).any?
-          app.ignore "type" => source.class.type, "name" => "dependency"
+          app.ignore({ "type" => source.class.type, "name" => "dependency" })
         end
       end
 
@@ -503,7 +503,7 @@ describe Licensed::Commands::Status do
       count = reporter.report.all_reports.size
 
       config.apps.each do |app|
-        app.ignore "type" => "test", "name" => "dependency"
+        app.ignore({ "type" => "test", "name" => "dependency" })
       end
 
       run_command

--- a/test/commands/status_test.rb
+++ b/test/commands/status_test.rb
@@ -580,4 +580,200 @@ describe Licensed::Commands::Status do
       end
     end
   end
+
+  describe "with cached metadata source that requires versions" do
+    let(:config) { Licensed::Configuration.new("apps" => apps, "cache_path" => cache_path, "sources" => { "test_dependency_version_names" => true }, "test_dependency_version_names" => source_config) }
+
+    before do
+      generator_config = Marshal.load(Marshal.dump(config))
+      generator = Licensed::Commands::Cache.new(config: generator_config)
+      generator.run(force: true, reporter: TestReporter.new)
+    end
+
+    after do
+      config.apps.each do |app|
+        FileUtils.rm_rf app.cache_path
+      end
+    end
+
+    it "does not warn if license is allowed" do
+      config.apps.each do |app|
+        app.allow "mit"
+      end
+
+      run_command
+      config.apps.each do |app|
+        app.sources.each do |source|
+          refute_includes dependency_errors(app, source), "dependency needs review"
+        end
+      end
+    end
+
+    it "does not warn if dependency is ignored" do
+      run_command
+      config.apps.each do |app|
+        app.ignore({
+          "type" => TestSourceWithDependencyVersionNames.type,
+          "name" => TestSource::DEFAULT_DEPENDENCY_NAME,
+          "version" => TestSource::DEPENDENCY_VERSION
+        }, at_version: true)
+      end
+
+      run_command
+
+      config.apps.each do |app|
+        app.sources.each do |source|
+          assert dependency_errors(app, source).empty?
+        end
+      end
+    end
+
+    it "does not warn if dependency is reviewed at a specific version" do
+      run_command
+      config.apps.each do |app|
+        app.review({
+          "type" => TestSourceWithDependencyVersionNames.type,
+          "name" => TestSource::DEFAULT_DEPENDENCY_NAME,
+          "version" => TestSource::DEPENDENCY_VERSION
+        }, at_version: true)
+      end
+
+      run_command
+      config.apps.each do |app|
+        app.sources.each do |source|
+          assert dependency_errors(app, source).empty?
+        end
+      end
+    end
+
+    it "warns if dependency is marked reviewed without version" do
+      config.apps.each do |app|
+        app.review({
+          "type" => TestSourceWithDependencyVersionNames.type,
+          "name" => TestSource::DEFAULT_DEPENDENCY_NAME
+        })
+      end
+
+      run_command
+
+      dependency_report = reporter.report.all_reports.find { |report| report.target.is_a?(Licensed::Dependency) }
+      assert dependency_report.errors.any? do |e|
+        e.match?("dependency needs review") &&
+          e.match?("unversioned 'reviewed' match found: #{TestSource::DEFAULT_DEPENDENCY_NAME}")
+      end
+    end
+
+    it "warns if dependency is reviewed at different version" do
+      config.apps.each do |app|
+        app.review({
+          "type" => TestSourceWithDependencyVersionNames.type,
+          "name" => TestSource::DEFAULT_DEPENDENCY_NAME,
+          "version" => "0.0.0",
+        }, at_version: true)
+      end
+
+      run_command
+
+      dependency_report = reporter.report.all_reports.find { |report| report.target.is_a?(Licensed::Dependency) }
+      assert dependency_report.errors.any? do |e|
+        e.match?("dependency needs review") &&
+          e.match?("possible 'reviewed' matches found at other versions: #{TestSource::DEFAULT_DEPENDENCY_NAME}@0.0.0")
+      end
+    end
+
+    it "reports a link to the documentation on any failures" do
+      # this is the same error case as "warns if license is not allowed"
+      run_command
+
+      command_errors = reporter.report.errors
+      refute_empty command_errors
+      assert command_errors.any? { |e| e =~ /Licensed found errors during source enumeration.  Please see/ }
+    end
+
+    it "does not include ignored dependencies in dependency counts" do
+      run_command
+      count = reporter.report.all_reports.size
+
+      config.apps.each do |app|
+        app.ignore({
+          "type" => TestSourceWithDependencyVersionNames.type,
+          "name" => TestSource::DEFAULT_DEPENDENCY_NAME,
+          "version" => TestSource::DEPENDENCY_VERSION,
+        }, at_version: true)
+      end
+
+      run_command
+      ignored_count = reporter.report.all_reports.size
+
+      assert_equal count - config.apps.size, ignored_count
+    end
+
+    it "changes the current directory to app.source_path while running" do
+      config.apps.each do |app|
+        app["source_path"] = fixtures
+      end
+
+      run_command
+
+      reports = reporter.report.all_reports
+      dependency_report = reports.find { |report| report.target.is_a?(Licensed::Dependency) }
+      assert dependency_report
+      assert_equal fixtures, dependency_report.target.path
+    end
+
+    it "reports whether a dependency is allowed" do
+      run_command
+
+      reports = reporter.report.all_reports
+      dependency_report = reports.find { |report| report.target.is_a?(Licensed::Dependency) }
+      refute dependency_report["allowed"]
+
+      config.apps.each do |app|
+        app.review({
+          "type" => TestSourceWithDependencyVersionNames.type,
+          "name" => TestSource::DEFAULT_DEPENDENCY_NAME,
+          "version" => TestSource::DEPENDENCY_VERSION
+        }, at_version: true)
+      end
+
+      reporter.report.all_reports.clear
+
+      run_command
+
+      reports = reporter.report.all_reports
+      dependency_report = reports.find { |report| report.target.is_a?(Licensed::Dependency) }
+      assert dependency_report["allowed"]
+    end
+
+    it "reports a cached record's recorded license" do
+      run_command
+      reports = reporter.report.all_reports
+      dependency_report = reports.find { |report| report.target.is_a?(Licensed::Dependency) }
+      assert_equal "mit", dependency_report["license"]
+    end
+
+    describe "with multiple apps" do
+      let(:apps) do
+        [
+          {
+            "name" => "app1",
+            "cache_path" => "vendor/licenses/app1",
+            "source_path" => Dir.pwd
+          },
+          {
+            "name" => "app2",
+            "cache_path" => "vendor/licenses/app2",
+            "source_path" => Dir.pwd
+          }
+        ]
+      end
+
+      it "verifies dependencies for all apps" do
+        run_command
+        apps.each do |app|
+          assert reporter.report.reports.find { |report| report.name == app["name"] }
+        end
+      end
+    end
+  end
 end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -396,11 +396,11 @@ describe Licensed::AppConfiguration do
 
       it "matches a dependency ignored at *" do
         config.ignore package.merge("version" => "*"), at_version: true
-        assert config.ignored?(package.merge("version" => "1.0.1"))
+        assert config.ignored?(package)
       end
 
       it "matches a dependency ignored at a requirement pattern" do
-        config.ignore package.merge("version" => ">= 1.0.0"), at_version: true
+        config.ignore package.merge("version" => ">= 1.0.0, < 2.0.0"), at_version: true
         assert config.ignored?(package)
       end
 
@@ -501,7 +501,7 @@ describe Licensed::AppConfiguration do
       end
 
       it "matches a dependency reviewed at a requirement pattern" do
-        config.review package.merge("version" => ">= 1.0.0"), at_version: true
+        config.review package.merge("version" => ">= 1.0.0, < 2.0.0"), at_version: true
         assert config.reviewed?(package, require_version: true)
       end
 

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -273,149 +273,301 @@ describe Licensed::AppConfiguration do
   end
 
   describe "ignore" do
-    let(:package) { { "type" => "go", "name" => "github.com/github/licensed/package" } }
+    let(:package) { { "type" => "go", "name" => "github.com/github/licensed/package", "version" => "1.0.0"  } }
 
     it "marks the dependency as ignored" do
+      assert_nil config.dig("ignored", package["type"])
+      config.ignore package
+      assert_equal [package["name"]], config.dig("ignored", package["type"])
+    end
+
+    it "marks the dependency ignored at the specific version" do
+      assert_nil config.dig("ignored", package["type"])
+      config.ignore package, at_version: true
+      assert_equal ["#{package["name"]}@#{package["version"]}"], config.dig("ignored", package["type"])
+    end
+  end
+
+  describe "ignored?" do
+    let(:package) { { "type" => "go", "name" => "github.com/github/licensed/package", "version" => "1.0.0"  } }
+
+    it "matches exact name matches" do
       refute config.ignored?(package)
       config.ignore package
       assert config.ignored?(package)
     end
 
-    describe "with glob patterns" do
-      it "does not match trailing ** to multiple path segments" do
-        refute config.ignored?(package)
-        config.ignore package.merge("name" => "github.com/github/**")
-        refute config.ignored?(package)
+    it "does not match trailing ** to multiple path segments" do
+      refute config.ignored?(package)
+      config.ignore package.merge("name" => "github.com/github/**")
+      refute config.ignored?(package)
+    end
+
+    it "matches internal ** to multiple path segments" do
+      refute config.ignored?(package)
+      config.ignore package.merge("name" => "github.com/**/package")
+      assert config.ignored?(package)
+    end
+
+    it "matches trailing * to single path segment" do
+      refute config.ignored?(package)
+      config.ignore package.merge("name" => "github.com/github/licensed/*")
+      assert config.ignored?(package)
+    end
+
+    it "maches internal * to single path segment" do
+      refute config.ignored?(package)
+      config.ignore package.merge("name" => "github.com/*/licensed/package")
+      assert config.ignored?(package)
+    end
+
+    it "matches multiple globstars in a pattern" do
+      refute config.ignored?(package)
+      config.ignore package.merge("name" => "**/licensed/*")
+      assert config.ignored?(package)
+    end
+
+    it "does not match * to multiple path segments" do
+      refute config.ignored?(package)
+      config.ignore package.merge("name" => "github.com/github/*")
+      refute config.ignored?(package)
+    end
+
+    it "is case insensitive" do
+      refute config.ignored?(package)
+      config.ignore package.merge("name" => "GITHUB.com/github/**")
+      refute config.ignored?(package)
+    end
+
+    describe "with required_version" do
+      it "matches a dependency ignored at the same version" do
+        config.ignore package, at_version: true
+        assert config.ignored?(package, require_version: true)
       end
 
-      it "matches internal ** to multiple path segments" do
-        refute config.ignored?(package)
-        config.ignore package.merge("name" => "github.com/**/package")
+      it "does not match a dependency not ignored at a version" do
+        config.ignore package
+        refute config.ignored?(package, require_version: true)
+      end
+
+      it "does not match a dependency ignored at a different version" do
+        config.ignore package.merge("version" => "1.0.1"), at_version: true
+        refute config.ignored?(package, require_version: true)
+      end
+
+      it "matches a dependency ignored at *" do
+        config.ignore package.merge("version" => "*"), at_version: true
+        assert config.ignored?(package, require_version: true)
+      end
+
+      it "matches a dependency ignored at a requirement pattern" do
+        config.ignore package.merge("version" => ">= 1.0.0"), at_version: true
+        assert config.ignored?(package, require_version: true)
+      end
+
+      it "does not match a dependency without a version" do
+        config.ignore package, at_version: true
+        package.delete("version")
+        refute config.ignored?(package, require_version: true)
+      end
+
+      it "matches a dependency ignored at a matching non-gem requirement value" do
+        package["version"] = "abcdef"
+        config.ignore package, at_version: true
+        assert config.ignored?(package, require_version: true)
+      end
+    end
+
+    describe "without required_version" do
+      it "matches a dependency ignored at the same version" do
+        config.ignore package, at_version: true
         assert config.ignored?(package)
       end
 
-      it "matches trailing * to single path segment" do
-        refute config.ignored?(package)
-        config.ignore package.merge("name" => "github.com/github/licensed/*")
+      it "matches a dependency not ignored at a version" do
+        config.ignore package
         assert config.ignored?(package)
       end
 
-      it "maches internal * to single path segment" do
+      it "does not match a dependency ignored at a different version" do
+        config.ignore package.merge("version" => "1.0.1"), at_version: true
         refute config.ignored?(package)
-        config.ignore package.merge("name" => "github.com/*/licensed/package")
+      end
+
+      it "matches a dependency ignored at *" do
+        config.ignore package.merge("version" => "*"), at_version: true
+        assert config.ignored?(package.merge("version" => "1.0.1"))
+      end
+
+      it "matches a dependency ignored at a requirement pattern" do
+        config.ignore package.merge("version" => ">= 1.0.0"), at_version: true
         assert config.ignored?(package)
       end
 
-      it "matches multiple globstars in a pattern" do
-        refute config.ignored?(package)
-        config.ignore package.merge("name" => "**/licensed/*")
+      it "matches a dependency without a version" do
+        config.ignore package, at_version: true
+        package.delete("version")
         assert config.ignored?(package)
-      end
-
-      it "does not match * to multiple path segments" do
-        refute config.ignored?(package)
-        config.ignore package.merge("name" => "github.com/github/*")
-        refute config.ignored?(package)
-      end
-
-      it "is case insensitive" do
-        refute config.ignored?(package)
-        config.ignore package.merge("name" => "GITHUB.com/github/**")
-        refute config.ignored?(package)
       end
     end
   end
 
   describe "review" do
-    let(:package) { { "type" => "go", "name" => "github.com/github/licensed/package" } }
+    let(:package) { { "type" => "go", "name" => "github.com/github/licensed/package", "version" => "1.0.0" } }
 
     it "marks the dependency as reviewed" do
+      assert_nil config.dig("reviewed", package["type"])
+      config.review package
+      assert_equal [package["name"]], config.dig("reviewed", package["type"])
+    end
+
+    it "marks the dependency reviewed at the specific version" do
+      assert_nil config.dig("reviewed", package["type"])
+      config.review package, at_version: true
+      assert_equal ["#{package["name"]}@#{package["version"]}"], config.dig("reviewed", package["type"])
+    end
+  end
+
+  describe "reviewed?" do
+    let(:package) { { "type" => "go", "name" => "github.com/github/licensed/package", "version" => "1.0.0" } }
+
+    it "matches exact name matches" do
       refute config.reviewed?(package)
       config.review package
       assert config.reviewed?(package)
     end
 
-    describe "with glob patterns" do
-      it "does not match trailing ** to multiple path segments" do
-        refute config.reviewed?(package)
-        config.review package.merge("name" => "github.com/github/**")
-        refute config.reviewed?(package)
+    it "does not match trailing ** to multiple path segments" do
+      refute config.reviewed?(package)
+      config.review package.merge("name" => "github.com/github/**")
+      refute config.reviewed?(package)
+    end
+
+    it "matches internal ** to multiple path segments" do
+      refute config.reviewed?(package)
+      config.review package.merge("name" => "github.com/**/package")
+      assert config.reviewed?(package)
+    end
+
+    it "matches trailing * to single path segment" do
+      refute config.reviewed?(package)
+      config.review package.merge("name" => "github.com/github/licensed/*")
+      assert config.reviewed?(package)
+    end
+
+    it "maches internal * to single path segment" do
+      refute config.reviewed?(package)
+      config.review package.merge("name" => "github.com/*/licensed/package")
+      assert config.reviewed?(package)
+    end
+
+    it "matches multiple globstars in a pattern" do
+      refute config.reviewed?(package)
+      config.review package.merge("name" => "**/licensed/*")
+      assert config.reviewed?(package)
+    end
+
+    it "does not match * to multiple path segments" do
+      refute config.reviewed?(package)
+      config.review package.merge("name" => "github.com/github/*")
+      refute config.reviewed?(package)
+    end
+
+    it "is case insensitive" do
+      refute config.reviewed?(package)
+      config.review package.merge("name" => "GITHUB.com/github/**")
+      refute config.reviewed?(package)
+    end
+
+    describe "with required_version" do
+      it "matches a dependency reviewed at the same version" do
+        config.review package, at_version: true
+        assert config.reviewed?(package, require_version: true)
       end
 
-      it "matches internal ** to multiple path segments" do
-        refute config.reviewed?(package)
-        config.review package.merge("name" => "github.com/**/package")
-        assert config.reviewed?(package)
+      it "does not match a dependency not reviewed at a version" do
+        config.review package
+        refute config.reviewed?(package, require_version: true)
       end
 
-      it "matches trailing * to single path segment" do
-        refute config.reviewed?(package)
-        config.review package.merge("name" => "github.com/github/licensed/*")
-        assert config.reviewed?(package)
+      it "does not match a dependency reviewed at a different version" do
+        config.review package.merge("version" => "1.0.1"), at_version: true
+        refute config.reviewed?(package, require_version: true)
       end
 
-      it "maches internal * to single path segment" do
-        refute config.reviewed?(package)
-        config.review package.merge("name" => "github.com/*/licensed/package")
-        assert config.reviewed?(package)
+      it "matches a dependency reviewed at *" do
+        config.review package.merge("version" => "*"), at_version: true
+        assert config.reviewed?(package, require_version: true)
       end
 
-      it "matches multiple globstars in a pattern" do
-        refute config.reviewed?(package)
-        config.review package.merge("name" => "**/licensed/*")
-        assert config.reviewed?(package)
+      it "matches a dependency reviewed at a requirement pattern" do
+        config.review package.merge("version" => ">= 1.0.0"), at_version: true
+        assert config.reviewed?(package, require_version: true)
       end
 
-      it "does not match * to multiple path segments" do
-        refute config.reviewed?(package)
-        config.review package.merge("name" => "github.com/github/*")
-        refute config.reviewed?(package)
+      it "does not match a dependency without a version" do
+        config.review package, at_version: true
+        package.delete("version")
+        refute config.reviewed?(package, require_version: true)
       end
 
-      it "is case insensitive" do
-        refute config.reviewed?(package)
-        config.review package.merge("name" => "GITHUB.com/github/**")
-        refute config.reviewed?(package)
+      it "matches a dependency reviewed at a matching non-gem requirement value" do
+        package["version"] = "abcdef"
+        config.review package, at_version: true
+        assert config.reviewed?(package, require_version: true)
       end
     end
 
-    describe "with version" do
-      it "sets the dependency reviewed at the specific version" do
+    describe "without required_version" do
+      it "matches a dependency reviewed at the same version" do
+        config.review package, at_version: true
+        assert config.reviewed?(package)
+      end
+
+      it "matches a dependency not reviewed at a version" do
         config.review package
         assert config.reviewed?(package)
+      end
 
-        package["version"] = "1.2.3"
+      it "does not match a dependency reviewed at a different version" do
+        config.review package.merge("version" => "1.0.1"), at_version: true
+        refute config.reviewed?(package)
+      end
+
+      it "matches a dependency reviewed at *" do
+        config.review package.merge("version" => "*"), at_version: true
+        assert config.reviewed?(package.merge("version" => "1.0.1"))
+      end
+
+      it "matches a dependency reviewed at a requirement pattern" do
+        config.review package.merge("version" => ">= 1.0.0"), at_version: true
         assert config.reviewed?(package)
-        refute config.reviewed?(package, match_version: true)
+      end
 
+      it "matches a dependency without a version" do
         config.review package, at_version: true
-        refute config.reviewed?(package.merge("version" => "1.0.0"), match_version: true)
-        assert config.reviewed?(package, match_version: true)
-        assert_equal ["#{package["name"]}@#{package["version"]}"], config.reviewed_versions(package)
+        package.delete("version")
+        assert config.reviewed?(package)
       end
+    end
+  end
 
-      it "reviewing dependencies at version will not match dependencies without version" do
-        package = { "type" => "bundler", "name" => "licensed", "version" => "1.0.0" }
-        config.review(package, at_version: true)
-        refute config.reviewed?(package, match_version: false)
-      end
+  describe "reviewed_versions" do
+    it "returns an array of all matching reviewed dependency names at versions" do
+      packages = [
+        { "type" => "npm", "name" => "@github/package", "version" => "1.0.0" },
+        { "type" => "npm", "name" => "@github/package", "version" => "1.0.1" }
+      ]
 
-      it "matches glob patterns for specified versions" do
-        config.review({ "type" => "go", "name" => "github.com/github/**/*", "version" => "1.2.3" }, at_version: true)
-        assert_equal ["github.com/github/**/*@1.2.3"], config.reviewed_versions(package)
+      packages.each { |p| config.review(p, at_version: true) }
+      assert_equal packages.map { |p| "#{p["name"]}@#{p["version"]}" },
+        config.reviewed_versions({ "type" => "npm", "name" => "@github/package" })
+    end
 
-        refute config.reviewed?(package.merge("version" => "1.0.0"), match_version: true)
-        assert config.reviewed?(package.merge("version" => "1.2.3"), match_version: true)
-      end
-
-      it "does not treat leading @ symbols as version separators when listing versions" do
-        package = { "type" => "npm", "name" => "@github/package" }
-        config.review(package)
-        assert_empty config.reviewed_versions(package)
-
-        config.review(package.merge("version" => "1.2.3"), at_version: true)
-        assert_equal ["@github/package@1.2.3"], config.reviewed_versions(package)
-      end
+    it "does not return reviewed dependencies without version" do
+      package = { "type" => "npm", "name" => "@github/package", "version" => "1.0.0" }
+      config.review(package)
+      assert_empty config.reviewed_versions(package)
     end
   end
 

--- a/test/dependency_test.rb
+++ b/test/dependency_test.rb
@@ -5,10 +5,10 @@ require "tmpdir"
 describe Licensed::Dependency do
   let(:error) { nil }
 
-  def mkproject(&block)
+  def mkproject(metadata: {}, &block)
     Dir.mktmpdir do |dir|
       Dir.chdir dir do
-        yield Licensed::Dependency.new(name: "test", version: "1.0", path: dir, errors: [error])
+        yield Licensed::Dependency.new(name: "test", version: "1.0", path: dir, errors: [error], metadata: metadata)
       end
     end
   end
@@ -335,6 +335,23 @@ describe Licensed::Dependency do
         dependency.additional_terms << "amendment.txt"
         assert_includes dependency.license_contents,
                         { "sources" => "License terms loaded from amendment.txt", "text" => "license amendment" }
+      end
+    end
+  end
+
+  describe "metadata" do
+    it "returns a hash of license metadata including the name and version" do
+      mkproject(metadata: { "type" => "test-type" }) do |dependency|
+        assert_equal(
+          { "type" => "test-type", "name" => dependency.name, "version" => dependency.version },
+          dependency.metadata
+        )
+      end
+    end
+
+    it "overrides the dependency name and version with values set in metadata input" do
+      mkproject(metadata: { "name" => "custom", "version" => "custom" }) do |dependency|
+        assert_equal({ "name" => "custom", "version" => "custom" }, dependency.metadata)
       end
     end
   end

--- a/test/sources/pnpm_test.rb
+++ b/test/sources/pnpm_test.rb
@@ -9,6 +9,10 @@ if Licensed::Shell.tool_available?("pnpm")
     let(:fixtures) { File.expand_path("../../fixtures/pnpm", __FILE__) }
     let(:source) { Licensed::Sources::PNPM.new(config) }
 
+    it "includes dependency versions in the name identifier" do
+      assert Licensed::Sources::PNPM.require_matched_dependency_version
+    end
+
     describe "enabled?" do
       it "is true if pnpm-lock.yaml exists" do
         Dir.mktmpdir do |dir|
@@ -80,7 +84,7 @@ if Licensed::Shell.tool_available?("pnpm")
 
       it "does not include ignored dependencies" do
         Dir.chdir fixtures do
-          config.ignore({ "type" => Licensed::Sources::PNPM.type, "name" => "autoprefixer@5.2.0" })
+          config.ignore({ "type" => Licensed::Sources::PNPM.type, "name" => "autoprefixer", "version" => "5.2.0" }, at_version: true)
           refute source.dependencies.detect { |dep| dep.name == "autoprefixer@5.2.0" }
         end
       end

--- a/test/sources/source_test.rb
+++ b/test/sources/source_test.rb
@@ -7,6 +7,10 @@ describe Licensed::Sources::Source do
   let(:config) { Licensed::AppConfiguration.new({ "source_path" => Dir.pwd }) }
   let(:source) { TestSource.new(config) }
 
+  it "does not include dependency versions in the name identifier by default" do
+    refute Licensed::Sources::Source.require_matched_dependency_version
+  end
+
   describe "dependencies" do
     it "returns dependencies from the source" do
       dep = source.dependencies.first

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,7 +13,7 @@ require "test_helpers/test_source"
 def each_source(&block)
   Licensed::Sources::Source.sources.each do |source_class|
     # don't run tests meant for actual dependency enumerators on the test source
-    next if source_class == TestSource
+    next if source_class <= TestSource
 
     # if a specific source type is set via ENV, skip other source types
     next if ENV["SOURCE"] && source_class.full_type != ENV["SOURCE"].downcase

--- a/test/test_helpers/test_source.rb
+++ b/test/test_helpers/test_source.rb
@@ -24,10 +24,24 @@ class TestSource < Licensed::Sources::Source
       version: DEPENDENCY_VERSION,
       path: Dir.pwd,
       metadata: {
-        "type" => TestSource.type,
+        "type" => self.class.type,
         "dir" => Dir.pwd
       }.merge(@metadata)
     }.merge(config[self.class.type] || {})
     [Licensed::Dependency.new(**dependency_config)]
+  end
+end
+
+class TestSourceWithDependencyVersionNames < TestSource
+  def self.type
+    "test_dependency_version_names"
+  end
+
+  def self.require_matched_dependency_version
+    true
+  end
+
+  def initialize(config, name = DEFAULT_DEPENDENCY_NAME, metadata = {})
+    super(config, "#{name}@#{TestSource::DEPENDENCY_VERSION}", {"name" => name }.merge(metadata))
   end
 end


### PR DESCRIPTION
This builds off of the configuration changes made in https://github.com/github/licensed/pull/560 to bring in full support for configuring reviewed and ignored dependencies that include version identifiers.

Version identifiers are given by adding `@...` to the end of dependency names in the reviewed and ignored configuration lists.  Identifiers can have the following values:
1. `*` - explicitly match all versions
1. a value that can be parsed by `Gem::Requirement` provides support for version ranges - `(=|<|<=|>|>=|~>) 1.2.3`.  For non-Ruby devs, the `~>` is called the twiddle-waka and is a pessimistic matcher similar to node's [tilda range operator](https://github.com/npm/node-semver#tilde-ranges-123-12-1).
   - Multiple ranges can be specified as a single string separated by commas - `dependency@>= 1.0.0, < 2.0.0`
1. a value that can't be parsed by `Gem::Requirement` will be compared with an exact string match to a found dependency's version

This mostly affects the `pnpm` source at the moment, which requires reviewing and ignoring dependencies using `@...`.  For other sources, the change is expected to be backwards compatible and users should only expect changes when configuring dependencies at specific versions or specific version ranges.