### PR TITLE
Update default gradle configuration

### DIFF
--- a/lib/licensed/sources/gradle.rb
+++ b/lib/licensed/sources/gradle.rb
@@ -9,7 +9,7 @@ require "fileutils"
 module Licensed
   module Sources
     class Gradle < Source
-      DEFAULT_CONFIGURATIONS   = ["runtime", "runtimeClasspath"].freeze
+      DEFAULT_CONFIGURATIONS   = ["runtimeClasspath"].freeze
       GRADLE_LICENSES_PATH     = ".gradle-licenses".freeze
       GRADLE_LICENSES_CSV_NAME = "licenses.csv".freeze
       class Dependency < Licensed::Dependency


### PR DESCRIPTION
Answer to https://github.com/github/licensed/pull/630#issuecomment-1440243636

I am by no means a Gradle expert. Our use case is an Android application and we use the `releaseRuntimeClasspath` configuration so I have no experience using the default configuration provided by licensed.

 After investigating this I think we should default to only using the `runtimeClasspath` configuration.
 According to the following section of the [documentation](https://docs.gradle.org/current/userguide/declaring_dependencies.html#sec:resolvable-consumable-configs):
> A configuration which has canBeResolved set to false is not meant to be resolved. Such a configuration is there only to declare dependencies. The reason is that depending on the usage (compile classpath, runtime classpath), it can resolve to different graphs. It is an error to try to resolve a configuration which has canBeResolved set to false

Also, looking at [JavaPlugin doc](https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_configurations_graph), we can see that `runtimeClasspath` is resolvable. 

After making tests I also noticed that no dependencies where listed when running the `printDependencies` task with only the `runtimeOnly` configuration making it useless. 

Here are some screenshots:

![CleanShot 2023-02-24 at 11 03 29@2x](https://user-images.githubusercontent.com/39057274/221228053-ca109724-7d9f-4367-a701-7ba5e9c1d2a5.png)

![image](https://user-images.githubusercontent.com/39057274/221228089-d570a220-2314-445f-8103-63ed399dd3ae.png)

I therefore propose to only using `runtimeClasspath` for the default configuration