### PR TITLE
Release 4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## 4.2.0
+
+### Added
+
+- Reviewed and ignored configuration lists support matching on versions and version ranges (https://github.com/github/licensed/pull/629)
+
+### Fixed
+
+- Licensed should more reliably source dependencies from Gradle >= 8.0 (https://github.com/github/licensed/pull/630)
+
 ## 4.1.0
 
 ### Added
@@ -713,4 +723,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Initial release :tada:
 
-[Unreleased]: https://github.com/github/licensed/compare/4.1.0...HEAD
+[Unreleased]: https://github.com/github/licensed/compare/4.2.0...HEAD

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    licensed (4.1.0)
+    licensed (4.2.0)
       json (~> 2.6)
       licensee (~> 9.16)
       parallel (~> 1.22)

--- a/lib/licensed/version.rb
+++ b/lib/licensed/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Licensed
-  VERSION = "4.1.0".freeze
+  VERSION = "4.2.0".freeze
 
   def self.previous_major_versions
     major_version = Gem::Version.new(Licensed::VERSION).segments.first


### PR DESCRIPTION
### Added
- Reviewed and ignored configuration lists support matching on versions and version ranges (https://github.com/github/licensed/pull/629)

### Fixed
- Licensed should more reliably source dependencies from Gradle >= 8.0 (https://github.com/github/licensed/pull/630)