### PR TITLE
License updates for dependabot/github_actions/actions/setup-go-4

### DIFF
--- a/.licenses/bundler/octokit.dep.yml
+++ b/.licenses/bundler/octokit.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: octokit
-version: 4.25.1
+version: 6.1.0
 type: bundler
 summary: Ruby toolkit for working with the GitHub API
 homepage: https://github.com/octokit/octokit.rb


### PR DESCRIPTION
This PR was auto generated by the `licensed-ci` GitHub Action.
It contains updates to cached `github/licensed` dependency metadata to be merged into `dependabot/github_actions/actions/setup-go-4`: ([branch](https://github.com/github/licensed/tree/dependabot/github_actions/actions/setup-go-4), [PR](https://github.com/github/licensed/pull/641)).

The `licensed-ci` action will add comments to this PR with the status of license checks.  Please make any changes needed to fix any status failures on this branch, then merge license updates into your branch.

If updates are unexpected, please check the `github/licensed` [changelog](https://github.com/github/licensed/tree/master/CHANGELOG.md) for recent updates.