### PR TITLE
Release 4.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## 4.3.0
+
+### Added
+
+- Cocoapods support has been re-enabled using a cocoapods plugin (https://github.com/github/licensed/pull/644)
+
 ## 4.2.0
 
 ### Added
@@ -723,4 +729,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Initial release :tada:
 
-[Unreleased]: https://github.com/github/licensed/compare/4.2.0...HEAD
+[Unreleased]: https://github.com/github/licensed/compare/4.3.0...HEAD

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    licensed (4.2.0)
+    licensed (4.3.0)
       json (~> 2.6)
       licensee (~> 9.16)
       parallel (~> 1.22)

--- a/lib/licensed/version.rb
+++ b/lib/licensed/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Licensed
-  VERSION = "4.2.0".freeze
+  VERSION = "4.3.0".freeze
 
   def self.previous_major_versions
     major_version = Gem::Version.new(Licensed::VERSION).segments.first


### PR DESCRIPTION
### Added

- Cocoapods support has been re-enabled using a cocoapods plugin (https://github.com/github/licensed/pull/644)