### PR TITLE
Release 4.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## 4.3.1
+
+### Changed
+
+- Bump nokogiri to resolve vulnerabilities (https://github.com/github/licensed/pull/648)
+
 ## 4.3.0
 
 ### Added
@@ -729,4 +735,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Initial release :tada:
 
-[Unreleased]: https://github.com/github/licensed/compare/4.3.0...HEAD
+[Unreleased]: https://github.com/github/licensed/compare/4.3.1...HEAD

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,7 +44,7 @@ GEM
       minitest (> 5.3)
     mocha (2.0.2)
       ruby2_keywords (>= 0.0.5)
-    nokogiri (1.14.2)
+    nokogiri (1.14.3)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     octokit (6.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    licensed (4.3.0)
+    licensed (4.3.1)
       json (~> 2.6)
       licensee (~> 9.16)
       parallel (~> 1.22)
@@ -44,7 +44,7 @@ GEM
       minitest (> 5.3)
     mocha (2.0.2)
       ruby2_keywords (>= 0.0.5)
-    nokogiri (1.14.3)
+    nokogiri (1.14.2)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     octokit (6.1.0)

--- a/lib/licensed/version.rb
+++ b/lib/licensed/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Licensed
-  VERSION = "4.3.0".freeze
+  VERSION = "4.3.1".freeze
 
   def self.previous_major_versions
     major_version = Gem::Version.new(Licensed::VERSION).segments.first


### PR DESCRIPTION
### Changed

- Bump nokogiri to resolve vulnerabilities (https://github.com/github/licensed/pull/648)