### PR TITLE
License updates for release-4.3.1

### DIFF
--- a/.licenses/bundler/nokogiri.dep.yml
+++ b/.licenses/bundler/nokogiri.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: nokogiri
-version: 1.14.3
+version: 1.14.2
 type: bundler
 summary: Nokogiri (鋸) makes it easy and painless to work with XML and HTML from Ruby.
 homepage: https://nokogiri.org


### PR DESCRIPTION
This PR was auto generated by the `licensed-ci` GitHub Action.
It contains updates to cached `github/licensed` dependency metadata to be merged into `release-4.3.1`: ([branch](https://github.com/github/licensed/tree/release-4.3.1), [PR](https://github.com/github/licensed/pull/650)).

The `licensed-ci` action will add comments to this PR with the status of license checks.  Please make any changes needed to fix any status failures on this branch, then merge license updates into your branch.

If updates are unexpected, please check the `github/licensed` [changelog](https://github.com/github/licensed/tree/master/CHANGELOG.md) for recent updates.