### PR TITLE
License updates for dependabot/bundler/parallel-1.23.0

### DIFF
--- a/.licenses/bundler/parallel.dep.yml
+++ b/.licenses/bundler/parallel.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: parallel
-version: 1.22.1
+version: 1.23.0
 type: bundler
 summary: Run any kind of code in parallel processes
 homepage: https://github.com/grosser/parallel


### PR DESCRIPTION
This PR was auto generated by the `licensed-ci` GitHub Action.
It contains updates to cached `github/licensed` dependency metadata to be merged into `dependabot/bundler/parallel-1.23.0`: ([branch](https://github.com/github/licensed/tree/dependabot/bundler/parallel-1.23.0), [PR](https://github.com/github/licensed/pull/652)).

The `licensed-ci` action will add comments to this PR with the status of license checks.  Please make any changes needed to fix any status failures on this branch, then merge license updates into your branch.

If updates are unexpected, please check the `github/licensed` [changelog](https://github.com/github/licensed/tree/master/CHANGELOG.md) for recent updates.