### PR TITLE
License updates for dependabot/bundler/thor-1.2.2

### DIFF
--- a/.licenses/bundler/thor.dep.yml
+++ b/.licenses/bundler/thor.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: thor
-version: 1.2.1
+version: 1.2.2
 type: bundler
 summary: Thor is a toolkit for building powerful command-line interfaces.
 homepage: http://whatisthor.com/


### PR DESCRIPTION
This PR was auto generated by the `licensed-ci` GitHub Action.
It contains updates to cached `github/licensed` dependency metadata to be merged into `dependabot/bundler/thor-1.2.2`: ([branch](https://github.com/github/licensed/tree/dependabot/bundler/thor-1.2.2), [PR](https://github.com/github/licensed/pull/654)).

The `licensed-ci` action will add comments to this PR with the status of license checks.  Please make any changes needed to fix any status failures on this branch, then merge license updates into your branch.

If updates are unexpected, please check the `github/licensed` [changelog](https://github.com/github/licensed/tree/master/CHANGELOG.md) for recent updates.