### PR TITLE
Notify on stale cached records

### DIFF
--- a/docs/commands/status.md
+++ b/docs/commands/status.md
@@ -31,6 +31,21 @@ A dependency will fail the status checks if:
    - If `license: other` is specified and all of the `licenses` entries match an `allowed` license a failure will not be logged
    - A `reviewed` entry must reference a specific version of the depdency, e.g. `<name>@<version>`.  The version identifier must specify a specific dependency version, ranges are not allowed.
 
+## Detect and alert on stale cached metadata files
+
+Licensed can alert on any metadata files that don't correlate to a currently used dependency when `licensed status` is run.  To configure this behavior, set a root-level `stale_records_action` value in your [licensed configuration file](./../configuration.md).
+
+Available values are:
+
+1. `'error'`: Treat stale cached records as errors.  Licensed will output errors for any stale metadata files and will cause `licensed status` to fail.
+1. `'warn'`, `''`, or unset (default): Treat stale cached records as warnings.  Licensed will output warnings for any stale metadata files but will not cause `licensed status` to fail.
+1. `'ignore'`, any other value: Ignore stale cached records.  Licensed will not output any notifications about stale metadata files.
+
+```yaml
+# in the licensed configuration file
+stale_records_action: 'warn'
+```
+
 ## Options
 
 - `--config`/`-c`: the path to the licensed configuration file

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,6 +26,15 @@ cache_path: 'relative/path/to/cache'
 # Defaults to current directory when running `licensed`
 source_path: 'relative/path/to/source'
 
+# Whether to take any action when records are detected in the cache paths that don't map to evaluated
+# dependencies.
+# Available values are:
+# - 'error': treat stale cached records as errors.  Notify the user and fail status checks
+# - 'warn', '', unset: treat stale cached records as warnings.  Notify the user but do not fail status checks
+# - 'ignore': Ignore stale cached records.  Do not notify the user and do not fail status checks
+# Optional, when not set this defaults to 'warn' behavior
+stale_records_action: 'warn'
+
 # Sources of metadata
 sources:
   bower: true

--- a/lib/licensed/commands/cache.rb
+++ b/lib/licensed/commands/cache.rb
@@ -23,6 +23,7 @@ module Licensed
       def run_command(report)
         super do |result|
           clear_stale_cached_records if result
+          result
         end
       ensure
         cache_paths.clear

--- a/lib/licensed/commands/command.rb
+++ b/lib/licensed/commands/command.rb
@@ -69,7 +69,7 @@ module Licensed
 
         result = results.all?
 
-        yield(result) if block_given?
+        result = yield(result) if block_given?
 
         result
       ensure
@@ -103,7 +103,7 @@ module Licensed
 
           result = results.all?
 
-          yield(result) if block_given?
+          result = yield(result) if block_given?
 
           result
         end
@@ -142,7 +142,7 @@ module Licensed
 
         result = results.all?
 
-        yield(result) if block_given?
+        result = yield(result) if block_given?
 
         result
       rescue Licensed::Shell::Error => err
@@ -175,7 +175,7 @@ module Licensed
 
         result = evaluate_dependency(app, source, dependency, report)
 
-        yield(result) if block_given?
+        result = yield(result) if block_given?
 
         result
       rescue Licensed::DependencyRecord::Error, Licensed::Shell::Error => err

--- a/lib/licensed/configuration.rb
+++ b/lib/licensed/configuration.rb
@@ -274,6 +274,7 @@ module Licensed
     end
 
     def initialize(options = {})
+      @options = options
       apps = options.delete("apps") || []
       apps << default_options.merge(options) if apps.empty?
 
@@ -283,6 +284,10 @@ module Licensed
 
       apps = apps.flat_map { |app| self.class.expand_app_source_path(app) }
       @apps = apps.map { |app| AppConfiguration.new(app, options) }
+    end
+
+    def [](key)
+      @options&.fetch(key, nil)
     end
 
     private

--- a/lib/licensed/reporters/status_reporter.rb
+++ b/lib/licensed/reporters/status_reporter.rb
@@ -8,6 +8,11 @@ module Licensed
       # command - The command being run
       # report - A report object containing information about the command run
       def end_report_command(command, report)
+        if report.warnings.any?
+          shell.newline
+          report.warnings.each { |e| shell.warn e }
+        end
+
         if report.errors.any?
           shell.newline
           report.errors.each { |e| shell.error e }

--- a/test/reporters/status_reporter_test.rb
+++ b/test/reporters/status_reporter_test.rb
@@ -24,6 +24,18 @@ describe Licensed::Reporters::StatusReporter do
                           style: :error
                       }
     end
+
+    it "reports any warnings specified on the report object" do
+      report.warnings << "command warning"
+      reporter.end_report_command(command, report)
+
+      assert_includes shell.messages,
+                      {
+                          message: "command warning",
+                          newline: true,
+                          style: :warn
+                      }
+    end
   end
 
   describe "#begin_report_app" do


### PR DESCRIPTION
closes https://github.com/github/licensed/issues/656

This change adds a new configuration option `stale_records_action` which is used by `licensed status` to determine if and how to handle stored dependency metadata records that do not match any currently used dependencies.

The configuration option supports the following values:

1. `'error'`: Treat stale cached records as errors.  Licensed will output errors for any stale metadata files and will cause `licensed status` to fail.
1. `'warn'`, `''`, or unset (default): Treat stale cached records as warnings.  Licensed will output warnings for any stale metadata files but will not cause `licensed status` to fail.
1. `'ignore'`, any other value: Ignore stale cached records.  Licensed will not output any notifications about stale metadata files.

The default behavior when the value is unset is `warn` so that this will not cause any unexpected `licensed status` failures on version upgrade.