### PR TITLE
Release 4.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## 4.4.0
+
+### Added
+
+- Licensed status command will alert on stale cached dependency records (https://github.com/github/licensed/pull/657)
+
 ## 4.3.1
 
 ### Changed
@@ -735,4 +741,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Initial release :tada:
 
-[Unreleased]: https://github.com/github/licensed/compare/4.3.1...HEAD
+[Unreleased]: https://github.com/github/licensed/compare/4.4.0...HEAD

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    licensed (4.3.1)
+    licensed (4.4.0)
       json (~> 2.6)
       licensee (~> 9.16)
       parallel (~> 1.22)

--- a/lib/licensed/version.rb
+++ b/lib/licensed/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Licensed
-  VERSION = "4.3.1".freeze
+  VERSION = "4.4.0".freeze
 
   def self.previous_major_versions
     major_version = Gem::Version.new(Licensed::VERSION).segments.first


### PR DESCRIPTION
### Added

- Licensed status command will alert on stale cached dependency records (https://github.com/github/licensed/pull/657)