### PR TITLE
replace references to jonabc org with github org

### DIFF
--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -30,7 +30,7 @@ jobs:
           bundler-cache: true
 
       # run licensed
-      - uses: jonabc/licensed-ci@v1
+      - uses: github/licensed-ci@v1
         with:
           # override the command to use licensed built from this repo
           command: bundle exec licensed
@@ -49,5 +49,5 @@ jobs:
           # the "branch" workflow creates a new branch for license file updates.
           # e.g. when the action is run on main, changes are pushed to a new "main-licenses" branch
 
-          # see https://github.com/jonabc/licensed-ci for more details
+          # see https://github.com/github/licensed-ci for more details
           workflow: branch

--- a/docs/migrations/v3.md
+++ b/docs/migrations/v3.md
@@ -14,11 +14,11 @@ When using licensed v3 with bundler dependencies, licensed must be installed fro
 
 Using licensed to enumerate bundler dependencies in a GitHub Actions workflow will require ruby to be available in the actions VM environment.  Ruby can be setup in an actions workflow using [ruby/setup-ruby](https://github.com/ruby/setup-ruby)(preferred) or [actions/setup-ruby](https://github.com/actions/setup-ruby)(deprecated).
 
-If you are using licensed in a GitHub Actions workflow, [jonabc/setup-licensed](https://github.com/jonabc/setup-licensed) has been updated according to this breaking change.  `setup-licensed` will install the licensed gem when ruby is available, or the licensed executable when ruby is not available.  Alternatively, you can `gem install` licensed directly as an actions step.
+If you are using licensed in a GitHub Actions workflow, [github/setup-licensed](https://github.com/github/setup-licensed) has been updated according to this breaking change.  `setup-licensed` will install the licensed gem when ruby is available, or the licensed executable when ruby is not available.  Alternatively, you can `gem install` licensed directly as an actions step.
 
-This is an example workflow definition that runs [jonabc/licensed-ci](https://github.com/jonabc/licensed-ci)'s opinionated license compliance workflow in CI.  It includes jobs that demonstrate installing licensed using 
+This is an example workflow definition that runs [github/licensed-ci](https://github.com/github/licensed-ci)'s opinionated license compliance workflow in CI.  It includes jobs that demonstrate installing licensed using 
 - `gem install`
-- [jonabc/setup-licensed](https://github.com/jonabc/setup-licensed)
+- [github/setup-licensed](https://github.com/github/setup-licensed)
 - installing when included in a bundler gem file
 
 ```yml
@@ -50,7 +50,7 @@ jobs:
           ruby-version: "3.0"
 
       # install licensed gem using setup-licensed
-      - uses: jonabc/setup-licensed@v1
+      - uses: github/setup-licensed@v1
         with:
           version: '3.x'
 
@@ -58,7 +58,7 @@ jobs:
       - run: bundle install
 
       # run licensed-ci to cache any metadata changes and verify compliance
-      - uses: jonabc/licensed-ci@v1
+      - uses: github/licensed-ci@v1
 
   # OR 
   
@@ -82,7 +82,7 @@ jobs:
       - run: bundle install
 
       # run licensed-ci to cache any metadata changes and verify compliance
-      - uses: jonabc/licensed-ci@v1
+      - uses: github/licensed-ci@v1
 
   # OR
 
@@ -103,7 +103,7 @@ jobs:
       - run: bundle install
 
       # run licensed-ci to cache any metadata changes and verify compliance
-      - uses: jonabc/licensed-ci@v1
+      - uses: github/licensed-ci@v1
         with:
           command: 'bundle exec licensed' # run licensed within the bundler context
 ```

--- a/docs/sources/cocoapods.md
+++ b/docs/sources/cocoapods.md
@@ -2,7 +2,7 @@
 
 The cocoapods source will detect dependencies when `Podfile` and `Podfile.lock` are found at an app's `source_path`.  The cocoapods source uses the [cocoapods-dependencies-list](https://github.com/jonabc/cocoapods-dependencies-list) plugin to enumerate dependencies and gather metadata on each package.
 
-**NOTE:  Licensed does not install the [cocoapods-dependencies-list](https://github.com/jonanc/cocoapods-dependencies-list) plugin.  Users must install the gem alongside the cocoapods gem to enumerate cocoapods dependencies.**
+**NOTE:  Licensed does not install the [cocoapods-dependencies-list](https://github.com/jonabc/cocoapods-dependencies-list) plugin.  Users must install the gem alongside the cocoapods gem to enumerate cocoapods dependencies.**
 
 ## Evaluating dependencies from a specific target
 


### PR DESCRIPTION
### Description

GitHub actions jonabc/setup-licensed and jonabc/licensed-ci have moved to the github org.  This PR updates references to jonabc org to github org.
