### PR TITLE
fix: broken hyperlink to docs in licensee repo 

### DIFF
--- a/docs/configuration/customizing_licensee.md
+++ b/docs/configuration/customizing_licensee.md
@@ -1,6 +1,6 @@
 # Customize Licensee's behavior
 
-Licensed uses [Licensee](https://github.com/licensee/licensee) to detect and evaluate OSS licenses for project dependencies found during source enumeration.  Licensed can optionally [customize Licensee's behavior](https://github.com/licensee/licensee/blob/jonabc-patch-1/docs/customizing.md#customizing-licensees-behavior) based on options set in the configuration file.
+Licensed uses [Licensee](https://github.com/licensee/licensee) to detect and evaluate OSS licenses for project dependencies found during source enumeration. Licensed can optionally [customize Licensee's behavior](https://github.com/licensee/licensee/blob/main/docs/customizing.md#customizing-licensees-behavior) based on options set in the configuration file.
 
 **NOTE** Matching licenses based on package manager metadata and README references is always enabled and cannot currently be configured.
 
@@ -8,6 +8,6 @@ Licensed uses [Licensee](https://github.com/licensee/licensee) to detect and eva
 licensee:
   # the confidence threshold is an integer between 1 and 100. the value represents
   # the minimum percentage confidence that Licensee must have to report a matched license
-  # https://github.com/licensee/licensee/blob/master/docs/customizing.md#adjusting-the-confidence-threshold
+  # https://github.com/licensee/licensee/blob/main/docs/customizing.md#adjusting-the-confidence-threshold
   confidence_threshold: 90 # default value: 98
 ```

--- a/script/source-setup/bundler
+++ b/script/source-setup/bundler
@@ -2,7 +2,7 @@
 set -e
 
 if [ -z "$(which bundle)" ]; then
-  echo "A local bundler instalation is required for bundler development." >&2
+  echo "A local bundler installation is required for bundler development." >&2
   exit 127
 fi
 


### PR DESCRIPTION
**PR Summary**:
The PR contains the following changes:
- Fix broken hyperlink to docs of the licensee repo. The link is located at `docs/configuration/customizing_licensee.md`. It was missed in the #455 PR. I also used the `main` branch (and not `master`) because it's the default one of the licensee repo.
- Fix typo in bundler script (`instalation` -> `installation`).