### PR TITLE
Ensure that we don't have a vulnerability from cabal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Ensure homepage string is not too long in cabal.rb to avoid DOS attack
+
 ## 4.4.0
 
 ### Added
@@ -132,7 +136,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Comparing dependency license contents now finds matching contents regardless of the order of the licenses (https://github.com/github/licensed/pull/516)
-- Fixed typo in a link in README.md (https://github.com/github/licensed/pull/514) 
+- Fixed typo in a link in README.md (https://github.com/github/licensed/pull/514)
 
 ### Changed
 

--- a/lib/licensed/sources/cabal.rb
+++ b/lib/licensed/sources/cabal.rb
@@ -71,6 +71,12 @@ module Licensed
       # Returns a homepage url that enforces https and removes url fragments
       def safe_homepage(homepage)
         return unless homepage
+        # Ensure there's no denial of service issue with a long homepage
+        # 1000 characters is likely enough for any real project homepage
+        # See https://github.com/github/licensed/security/code-scanning/1
+        if homepage.length > 1000
+          raise ArgumentError, "Input too long"
+        end
         # use https and remove url fragment
         homepage.gsub(/http:/, "https:")
                 .gsub(/#[^?]*\z/, "")


### PR DESCRIPTION
This makes sure we don't get a homepage URL from cabal that's too
long and causes a performance issue leading to a denial of service.

Fixes https://github.com/github/licensed/security/code-scanning/1
