### PR TITLE
Upgrade nokogiri to 1.16.5 to address CVE-2024-34459

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -138,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.7', '3.0', '3.1', '3.2' ]
+        ruby: [ '3.0', '3.1', '3.2' ]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Ruby

--- a/.licenses/bundler/nokogiri.dep.yml
+++ b/.licenses/bundler/nokogiri.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: nokogiri
-version: 1.15.6
+version: 1.16.5
 type: bundler
 summary: Nokogiri (鋸) makes it easy and painless to work with XML and HTML from Ruby.
 homepage: https://nokogiri.org

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Breaking change
+
+- Only supports Ruby 3.0+ due to nokogiri upgrade
+
 ### Changed
 
 - Ensure homepage string is not too long in cabal.rb to avoid DOS attack

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,7 +54,7 @@ GEM
     mocha (2.4.5)
       ruby2_keywords (>= 0.0.5)
     mutex_m (0.2.0)
-    nokogiri (1.15.6)
+    nokogiri (1.16.5)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     octokit (6.1.0)

--- a/licensed.gemspec
+++ b/licensed.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.7.0"
+  spec.required_ruby_version = ">= 3.0.0"
 
   spec.add_dependency "licensee", "~> 9.16"
   spec.add_dependency "thor", "~> 1.2"


### PR DESCRIPTION
This upgrade is not critical, because it addresses and xmllint issue
and nokogiri doesn't expose xmllint to us.

Fixes https://github.com/github/licensed/security/dependabot/11
