### PR TITLE
Add `csv` as a dependency for Ruby 3.4+

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     licensed (5.0.1)
+      csv (~> 3.3)
       json (~> 2.6)
       licensee (~> 9.16)
       parallel (~> 1.22)
@@ -32,6 +33,7 @@ GEM
     byebug (11.1.3)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
+    csv (3.3.2)
     dotenv (3.1.4)
     drb (2.2.1)
     faraday (2.12.1)

--- a/licensed.gemspec
+++ b/licensed.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 3.0.0"
 
+  spec.add_dependency "csv", "~> 3.3"
   spec.add_dependency "licensee", "~> 9.16"
   spec.add_dependency "thor", "~> 1.2"
   spec.add_dependency "pathname-common_prefix", "~> 0.0.1"


### PR DESCRIPTION
This should close https://github.com/github/licensed/issues/752.

As the issue says, the gem can't be used with Ruby 3.4, because `csv` was taken out of the Ruby standard library. `csv` is being used by [the Gradle source](https://github.com/github/licensed/blob/d9e41a4a6c6091783a1e31167c22e3eb58e91170/lib/licensed/sources/gradle.rb#L3). 